### PR TITLE
decoding html entities in 'title' attribute value

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -838,7 +838,7 @@ class taoQtiTest_models_classes_QtiTestService extends taoTests_models_classes_T
             
             // Set the test label as title.
             $emptyTestXml = str_replace('{testId}', str_replace('_', '-', tao_helpers_Display::textCleaner($test->getLabel(), '*', 32)), $emptyTestXml);
-            $emptyTestXml = str_replace('{testTitle}', $test->getLabel(), $emptyTestXml);
+            $emptyTestXml = str_replace('{testTitle}', htmlentities($test->getLabel()), $emptyTestXml);
             $emptyTestXml = str_replace('{taoVersion}', TAO_VERSION, $emptyTestXml);
             
             $filePath = $dirPath . TAOQTITEST_FILENAME;

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -836,13 +836,16 @@ class taoQtiTest_models_classes_QtiTestService extends taoTests_models_classes_T
         if ($createTestFile === true) {
             $emptyTestXml = $this->getQtiTestTemplateFileAsString();
             
+            $doc = new DOMDocument();
+            $doc->loadXML($emptyTestXml);
+            
             // Set the test label as title.
-            $emptyTestXml = str_replace('{testId}', str_replace('_', '-', tao_helpers_Display::textCleaner($test->getLabel(), '*', 32)), $emptyTestXml);
-            $emptyTestXml = str_replace('{testTitle}', htmlentities($test->getLabel()), $emptyTestXml);
-            $emptyTestXml = str_replace('{taoVersion}', TAO_VERSION, $emptyTestXml);
+            $doc->documentElement->setAttribute('title', $test->getLabel());
+            $doc->documentElement->setAttribute('identifier', str_replace('_', '-', tao_helpers_Display::textCleaner($test->getLabel(), '*', 32)));
+            $doc->documentElement->setAttribute('toolVersion', TAO_VERSION);
             
             $filePath = $dirPath . TAOQTITEST_FILENAME;
-            if (file_put_contents($filePath, $emptyTestXml) === false) {
+            if ($doc->save($filePath) === false) {
                 $msg = "Unable to write raw QTI Test template at location '${filePath}'.";
                 throw new taoQtiTest_models_classes_QtiTestServiceException($msg, taoQtiTest_models_classes_QtiTestServiceException::TEST_WRITE_ERROR);
             }

--- a/test/QtiTestServiceTest.php
+++ b/test/QtiTestServiceTest.php
@@ -372,4 +372,26 @@ class QtiTestServiceTest extends TaoPhpUnitTestRunner
         $this->testService->deleteTestClass($subClass);
         $this->assertFalse($subClass->exists());
     }
+    
+    /**
+     * Verify that test attribute value in xml file will be properly encoded
+     * (<b>&amp;</b>, <b>&lt;</b> and <b>&quot;</b> symbols must be encoded)
+     * 
+     * @author Aleh Hutnikau, hutnikau@1pt.com
+     */
+    public function testCreateContent()
+    {
+        $attrValue = '"A & B < C"';
+        
+        $qtiTest = $this->testService->createInstance($this->testService->getRootclass(), 'UnitTestQtiItem');
+        $qtiTest->setLabel($attrValue);
+        $this->testService->createContent($qtiTest);
+        $xmlFilePath = $this->testService->getDocPath($qtiTest);
+        $this->assertTrue(file_exists($xmlFilePath));
+        
+        $doc = new \DOMDocument();
+        
+        $this->assertTrue($doc->load($xmlFilePath));
+        $this->assertEquals($attrValue, $doc->documentElement->getAttribute('title'));
+    }
 }

--- a/test/QtiTestServiceTest.php
+++ b/test/QtiTestServiceTest.php
@@ -393,5 +393,8 @@ class QtiTestServiceTest extends TaoPhpUnitTestRunner
         
         $this->assertTrue($doc->load($xmlFilePath));
         $this->assertEquals($attrValue, $doc->documentElement->getAttribute('title'));
+        
+        $this->testService->deleteTest($qtiTest);
+        $this->assertFalse($qtiTest->exists());
     }
 }


### PR DESCRIPTION
In the value of the attribute (`title` in this case) is not allowed to use ampersand.