### PR TITLE
Change way to hide item iframe

### DIFF
--- a/views/css/test_runner.css
+++ b/views/css/test_runner.css
@@ -10,7 +10,7 @@ html, body {
 #qti-item {
 	width: 100%;
 	overflow: hidden;
-	display: none;
+        visibility: hidden;
 	margin: 0;
 	padding: 0;
 }

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -129,8 +129,8 @@ define(['jquery', 'lodash', 'spin', 'serviceApi/ServiceApi', 'serviceApi/UserInf
 			if (this.assessmentTestContext.itemSessionState === this.TEST_ITEM_STATE_INTERACTING && self.assessmentTestContext.isTimeout === false) {
 			    $(document).on('serviceloaded', function() {
 			        self.afterTransition();
-                    self.adjustFrame();
-                    $itemFrame.show();
+                                self.adjustFrame();
+                                $itemFrame.css({visibility: 'visible'});
 			    });
 
 			    // Inject API into the frame.


### PR DESCRIPTION
If Iframe has `display: none;` css rule then for the nested elements can't be calculated it dimensions (width, height). But for select2 plugin is necessary to get width of initial `<select>` element to create widget with appropriate width.