### PR TITLE
Tao 877 student progress indicator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
   "autoload": {
     "psr-4": {
       "oat\\taoQtiTest\\models\\": "models/classes/",
-      "oat\\taoQtiTest\\test\\": "test"
+      "oat\\taoQtiTest\\test\\": "test",
+      "oat\\taoQtiTest\\scripts\\update\\": "scripts/update/"
     }
   }
 }

--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -1,0 +1,31 @@
+<?php
+/**  
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * 
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ */    
+
+/**
+ * Default log config, does not lock resources
+ */
+return array(
+    /**
+     * Tells what type of progress bar to use? Can be:
+     * - percentage : Classic progress bar displaying the percentage of answered items
+     * - position : Progress bar displaying the position of the current item within the test session
+     * @type string
+     */
+    'progress-indicator' => 'percentage'
+);

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -431,6 +431,10 @@ class taoQtiTest_helpers_TestRunnerUtils {
             // Comment allowed? Skipping allowed?
             $context['allowComment'] = self::doesAllowComment($session);
             $context['allowSkipping'] = self::doesAllowSkipping($session);
+            
+            // the type of progress bar to display
+            $config = common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+            $context['progressIndicator'] = $config['progress-indicator'];
         }
         
         return $context;

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -361,6 +361,9 @@ class taoQtiTest_helpers_TestRunnerUtils {
             // Whether the current item is the very last one of the test.
             $context['isLast'] = $session->getRoute()->isLast();
              
+            // The current position in the route.
+            $context['itemPosition'] = $session->getRoute()->getPosition();
+             
             // Time constraints.
             $context['timeConstraints'] = self::buildTimeConstraints($session);
              
@@ -378,6 +381,9 @@ class taoQtiTest_helpers_TestRunnerUtils {
              
             // Number of items completed during the test session.
             $context['numberCompleted'] = self::testCompletion($session);
+            
+            // Number of items presented during the test session.
+            $context['numberPresented'] = $session->numberPresented();
             
             // Whether or not the progress of the test can be infered.
             $context['considerProgress'] = self::considerProgress($testMeta);

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.6',
+    'version' => '2.6.1',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '2.6',
@@ -52,6 +52,7 @@ return array(
 		    dirname(__FILE__) . '/scripts/install/addQtiTestAcceptableLatency.php'
 		)
 	),
+    'update' => 'oat\\taoQtiTest\\scripts\\update\\Updater',
     'local'	=> array(
         'php'	=> array(
             dirname(__FILE__).'/install/local/addQTIExamples.php'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -31,6 +31,8 @@ class Updater extends \common_ext_ExtensionUpdater {
      * @return string $versionUpdatedTo
      */
     public function update($initialVersion) {
+
+        $currentVersion = $initialVersion;
         
         // add testrunner config
         if ($currentVersion == '2.6') {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoQtiTest\scripts\update;
+
+/**
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+class Updater extends \common_ext_ExtensionUpdater {
+    
+    /**
+     * 
+     * @param string $initialVersion
+     * @return string $versionUpdatedTo
+     */
+    public function update($initialVersion) {
+        
+        // add testrunner config
+        if ($currentVersion == '2.6') {
+
+            common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->setConfig('testRunner', array(
+                'progress-indicator' => 'percentage'
+            ));
+
+            $currentVersion = '2.6.1';
+        }
+   
+        return $currentVersion;
+    }
+}

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -20,7 +20,7 @@ define(['jquery', 'lodash', 'spin', 'serviceApi/ServiceApi', 'serviceApi/UserInf
                 var progressIndicator = assessmentTestContext.progressIndicator || 'percentage';
                 var progressIndicatorMethod = progressIndicator + 'Progression';
                 var getProgression = this[progressIndicatorMethod] || this.percentageProgression;
-                var progression = getProgression(assessmentTestContext);
+                var progression = getProgression && getProgression(assessmentTestContext) || {};
 
                 $('#qti-progress-label').text(progression.label);
                 $('#qti-progressbar').progressbar('value', progression.ratio);
@@ -31,7 +31,8 @@ define(['jquery', 'lodash', 'spin', 'serviceApi/ServiceApi', 'serviceApi/UserInf
              * @param {Object} assessmentTestContext The progression context
              */
             percentageProgression: function(assessmentTestContext) {
-                var ratio = Math.floor(assessmentTestContext.numberCompleted / assessmentTestContext.numberItems * 100);
+                var total = Math.max(1, assessmentTestContext.numberItems);
+                var ratio = Math.floor(assessmentTestContext.numberCompleted / total * 100);
                 return {
                     ratio : ratio,
                     label : __('Test completed at %d%%').replace('%d', ratio).replace('%%', '%')
@@ -43,11 +44,11 @@ define(['jquery', 'lodash', 'spin', 'serviceApi/ServiceApi', 'serviceApi/UserInf
              * @param {Object} assessmentTestContext The progression context
              */
             positionProgression: function(assessmentTestContext) {
-                var total = assessmentTestContext.numberItems;
+                var total = Math.max(1, assessmentTestContext.numberItems);
                 var position = assessmentTestContext.itemPosition + 1;
                 return {
                     ratio : Math.floor(position / total * 100),
-                    label : __('Item %X on %Y').replace('%X', position).replace('%Y', total)
+                    label : __('Item %d on %d', position, total)
                 };
             }
         };

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -48,7 +48,7 @@ define(['jquery', 'lodash', 'spin', 'serviceApi/ServiceApi', 'serviceApi/UserInf
                 var position = assessmentTestContext.itemPosition + 1;
                 return {
                     ratio : Math.floor(position / total * 100),
-                    label : __('Item %d on %d', position, total)
+                    label : __('Item %d of %d', position, total)
                 };
             }
         };


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-877

The progress bar can be displayed using two modes:
- percentage, the classic way with percentage of completed items
- position, which display the position of the currently viewed item within the entire test

The mode is set up from a config entry inside the taoQtiTest extension: `progress-indicator`

As this extension did not have a config previously set, such a config has been added. And this new config need to be handled by updater on already installed systems. Unfortunately the extension mainly uses the old class path system, and the added Updater relies on namespace. To be able to properly update the extension a `composer update` needs to be executed, and this can be done only from the `develop` branch...

So to test the feature without running an update, a change inside the code is needed. By example by forcing directly the mode in the code. To do so just set this code into the `views/js/controller/runtime/testRunner.js` file at line 20:

```javascript
var progressIndicator = 'position'; // or 'percentage'
```