### PR TITLE
Fix/tao 877 progress bar

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -41,12 +41,12 @@ return array(
     /**
      * When the `progress-indicator` option is set to `position`, define the scope of progress 
      * (i. e.: the number of items on which the ratio is computed). Can be:
-     * - section : The progression within the current section
-     * - part : The progression within the current part
+     * - testSection : The progression within the current section
+     * - testPart : The progression within the current part
      * - test : The progression within the current test
      * @type string
      */
-    'progress-indicator-scope' => 'section',
+    'progress-indicator-scope' => 'testSection',
 
     /**
      * Enables the test taker review screen

--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -39,6 +39,16 @@ return array(
     'progress-indicator' => 'percentage',
 
     /**
+     * When the `progress-indicator` option is set to `position`, define the scope of progress 
+     * (i. e.: the number of items on which the ratio is computed). Can be:
+     * - section : The progression within the current section
+     * - part : The progression within the current part
+     * - test : The progression within the current test
+     * @type string
+     */
+    'progress-indicator-scope' => 'section',
+
+    /**
      * Enables the test taker review screen
      * @type boolean
      */

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.6.3',
+    'version' => '2.6.4',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=2.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -21,7 +21,7 @@ namespace oat\taoQtiTest\scripts\update;
 
 /**
  *
- * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ * @author Jean-Sï¿½bastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
 class Updater extends \common_ext_ExtensionUpdater {
     
@@ -56,6 +56,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.6.2';
         }
+        
         // add testrunner review screen config
         if ($currentVersion == '2.6.2') {
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
@@ -68,6 +69,35 @@ class Updater extends \common_ext_ExtensionUpdater {
             )));
 
             $currentVersion = '2.6.3';
+        }
+        
+        // adjust testrunner config
+        if ($currentVersion == '2.6.3') {
+            $defaultConfig = array(
+                'timerWarning' => array(
+                    'assessmentItemRef' => null,
+                    'assessmentSection' => null,
+                    'testPart'          => null
+                ),
+                'progress-indicator' => 'percentage',
+                'progress-indicator-scope' => 'section',
+                'test-taker-review' => false,
+                'test-taker-review-region' => 'left',
+                'test-taker-review-section-only' => false,
+                'test-taker-review-prevents-unseen' => true,
+                'exitButton' => false
+            );
+
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            foreach($defaultConfig as $key => $value) {
+                if (!isset($config[$key])) {
+                    $config[$key] = $value;
+                }
+            }
+            $extension->setConfig('testRunner', $config);
+
+            $currentVersion = '2.6.4';
         }
         
         return $currentVersion;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -80,7 +80,7 @@ class Updater extends \common_ext_ExtensionUpdater {
                     'testPart'          => null
                 ),
                 'progress-indicator' => 'percentage',
-                'progress-indicator-scope' => 'section',
+                'progress-indicator-scope' => 'testSection',
                 'test-taker-review' => false,
                 'test-taker-review-region' => 'left',
                 'test-taker-review-section-only' => false,

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -738,11 +738,11 @@ define([
 
                 TestRunner.progressUpdater = progressUpdater($controls.$progressBar, $controls.$progressLabel);
 
-                if ($controls.$contentPanel.data('reviewScreen')) {
+                if (testContext.reviewScreen) {
                     TestRunner.testReview = testReview($controls.$contentPanel, {
-                        region: $controls.$contentPanel.data('reviewRegion') || 'left',
-                        sectionOnly: !!$controls.$contentPanel.data('reviewSectionOnly'),
-                        preventsUnseen: !!$controls.$contentPanel.data('reviewPreventsUnseen')
+                        region: testContext.reviewRegion || 'left',
+                        sectionOnly: !!testContext.reviewSectionOnly,
+                        preventsUnseen: !!testContext.reviewPreventsUnseen
                     }).on('jump', function(event, position) {
                         TestRunner.jump(position);
                     }).on('mark', function(event, flag, position) {

--- a/views/js/runner/progressUpdater.js
+++ b/views/js/runner/progressUpdater.js
@@ -97,11 +97,11 @@ define([
                     total : 'numberItems',
                     position : 'itemPosition'
                 },
-                part : {
+                testPart : {
                     total : 'numberItemsPart',
                     position : 'itemPositionPart'
                 },
-                section : {
+                testSection : {
                     total : 'numberItemsSection',
                     position : 'itemPositionSection'
                 }

--- a/views/js/runner/progressUpdater.js
+++ b/views/js/runner/progressUpdater.js
@@ -91,8 +91,24 @@ define([
          * @returns {{ratio: number, label: string}}
          */
         positionProgression: function(testContext) {
-            var total = Math.max(1, testContext.numberItems);
-            var position = testContext.itemPosition + 1;
+            var progressScope = testContext.progressIndicatorScope;
+            var progressScopeCounter = {
+                test : {
+                    total : 'numberItems',
+                    position : 'itemPosition'
+                },
+                part : {
+                    total : 'numberItemsPart',
+                    position : 'itemPositionPart'
+                },
+                section : {
+                    total : 'numberItemsSection',
+                    position : 'itemPositionSection'
+                }
+            };
+            var counter = progressScopeCounter[progressScope] || progressScopeCounter.test;
+            var total = Math.max(1, testContext[counter.total]);
+            var position = testContext[counter.position] + 1;
             return {
                 ratio : Math.floor(position / total * 100),
                 label : __('Item %d of %d', position, total)

--- a/views/templates/test_runner.tpl
+++ b/views/templates/test_runner.tpl
@@ -53,7 +53,7 @@ use oat\tao\helpers\Layout;
         </div>
     </div>
 
-    <div class="content-panel"<?= get_data('review_screen') ? ' data-review-screen="1"' : ''; ?><?= get_data('review_region') ? ' data-review-region="' . get_data('review_region') . '"' : ''; ?>>
+    <div class="content-panel<?= get_data('review_screen') ? ' has-review-screen' : ''; ?><?= get_data('review_region') ? ' review-screen-region-' . get_data('review_region') : ''; ?>">
         <!--div class="test-sidebar test-sidebar-left flex-container-navi">
         </div-->
         <div class="test-item flex-container-remaining">


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-877

An update is needed to be able to use the new options for progress bar.
But, you will need to manually change the options in the file `config/taoQtiTest/testRunner.conf.php`.

There are some interesting options you can change:
- **progress-indicator** : allows to change the behavior of the progress bar (can be `percentage`or `position`
- **progress-indicator-scope** : when the `progress-indicator` option is set to `position`, set the progress bar scope. Can be: `test`, `part`, `section`
