### PR TITLE
Test review scope

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -63,10 +63,13 @@ return array(
     'test-taker-review-region' => 'left',
 
     /**
-     * Limits the test taker review screen to the current test section.
-     * @type boolean
+     * Limits the test taker review screen to a particular scope. Can be:
+     * - test : the whole test
+     * - testPart : the current test part
+     * - testSection : the current test section
+     * @type string
      */
-    'test-taker-review-section-only' => false,
+    'test-taker-review-scope' => 'test',
 
     /**
      * Prevents the test taker to access unseen items.

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.7.0',
+    'version' => '2.9.0',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=2.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -103,6 +103,17 @@ class Updater extends \common_ext_ExtensionUpdater {
          if ($currentVersion == '2.6.4') {
             $currentVersion = '2.7.0';
          }
+
+        // adjust testrunner config
+        if ($currentVersion == '2.8.0') {
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $config['test-taker-review-scope'] = 'test';
+            unset($config['test-taker-review-section-only']);
+            $extension->setConfig('testRunner', $config);
+
+            $currentVersion = '2.9.0';
+        }
         
         return $currentVersion;
     }

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -596,7 +596,7 @@ define([
                     message = __(
                         "You have %s unanswered question(s) and have %s item(s) marked for review. Are you sure you want to end the test?",
                         (self.testContext.numberItems - self.testContext.numberCompleted).toString(),
-                        self.testContext.numberFlagged.toString()
+                        (self.testContext.numberFlagged || 0).toString()
                     ),
                     metaData = {
                         "TEST" : {"TEST_EXIT_CODE" : TestRunner.TEST_EXIT_CODE.INCOMPLETE},

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -273,7 +273,7 @@ define([
             },
 
             updateTools: function updateTools(testContext) {
-                
+
 				var $toolsContainer,
                     config = module.config();
 
@@ -291,7 +291,7 @@ define([
                     $controls.$skip.hide();
                     $controls.$skipEnd.hide();
                 }
-                
+
                 if(config && config.qtiTools){
                     $toolsContainer = $('.tools-box-list');
                     _.forIn(config.qtiTools, function(toolconfig, id){
@@ -544,8 +544,8 @@ define([
             /**
              * Call action specified in testContext. A postfix <i>Url</i> will be added to the action name.
              * To specify actions see {@link https://github.com/oat-sa/extension-tao-testqti/blob/master/helpers/class.TestRunnerUtils.php}
-             * @param {Sting} action - Action name
-             * @param {Object} metaData - Metadata to be sent to the server. Will be saved in result storage as a trace variable.
+             * @param {String} action - Action name
+             * @param {Object} [metaData] - Metadata to be sent to the server. Will be saved in result storage as a trace variable.
              * Example:
              * <pre>
              * {
@@ -557,7 +557,7 @@ define([
              *   }
              * }
              * </pre>
-             * @param {Object} extraParams - Additional parameters to be sent to the server
+             * @param {Object} [extraParams] - Additional parameters to be sent to the server
              * @returns {undefined}
              */
             actionCall: function (action, metaData, extraParams) {
@@ -596,7 +596,7 @@ define([
                     message = __(
                         "You have %s unanswered question(s) and have %s item(s) marked for review. Are you sure you want to end the test?",
                         (self.testContext.numberItems - self.testContext.numberCompleted).toString(),
-                        self.testContext.numberReview.toString()
+                        self.testContext.numberFlagged.toString()
                     ),
                     metaData = {
                         "TEST" : {"TEST_EXIT_CODE" : TestRunner.TEST_EXIT_CODE.INCOMPLETE},
@@ -758,7 +758,7 @@ define([
                 if (testContext.reviewScreen) {
                     TestRunner.testReview = testReview($controls.$contentPanel, {
                         region: testContext.reviewRegion || 'left',
-                        sectionOnly: !!testContext.reviewSectionOnly,
+                        reviewScope: !!testContext.reviewScope,
                         preventsUnseen: !!testContext.reviewPreventsUnseen
                     }).on('jump', function(event, position) {
                         TestRunner.jump(position);

--- a/views/js/test/samples/json/testContext.json
+++ b/views/js/test/samples/json/testContext.json
@@ -9,20 +9,28 @@
   "itemSessionState": 1,
   "isLast": false,
   "itemPosition": 0,
-  "timeConstraints": [],
-  "testTitle": "Test 7",
-  "testPartId": "testPart-1",
+  "timeConstraints": [
+    {
+      "label": "QTI Example Test",
+      "source": "Test-1",
+      "seconds": 7810,
+      "allowLateSubmission": false,
+      "qtiClassName": "assessmentTest"
+    }
+  ],
+  "testTitle": "QTI Example Test",
+  "testPartId": "Introduction",
   "sectionTitle": "Section 1",
   "numberItems": 9,
   "numberCompleted": 0,
   "numberPresented": 1,
   "considerProgress": true,
-  "moveForwardUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/moveForward?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
-  "moveBackwardUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/moveBackward?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
-  "skipUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/skip?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
-  "commentUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/comment?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
-  "timeoutUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/timeout?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
-  "endTestSessionUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/endTestSession?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
+  "moveForwardUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/moveForward?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
+  "moveBackwardUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/moveBackward?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
+  "skipUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/skip?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
+  "commentUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/comment?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
+  "timeoutUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/timeout?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
+  "endTestSessionUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/endTestSession?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
   "canMoveBackward": false,
   "jumps": [
     {
@@ -64,7 +72,7 @@
   ],
   "navigatorMap": [
     {
-      "id": "testPart-1",
+      "id": "Introduction",
       "sections": [
         {
           "id": "assessmentSection-1",
@@ -89,7 +97,7 @@
       "label": "Part 1"
     },
     {
-      "id": "testPart-2",
+      "id": "QTIExamples",
       "sections": [
         {
           "id": "assessmentSection-2",
@@ -176,21 +184,33 @@
       "label": "Part 2"
     }
   ],
-  "numberReview": 0,
-  "jumpUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/jumpTo?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
-  "markForReviewUrl": "http:\/\/parcc.dev\/taoQtiTest\/TestRunner\/markForReview?QtiTestDefinition=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358424814618461&QtiTestCompilation=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i1435843802614465-%7Chttp%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438025926466%2B&standalone=true&serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489",
-  "itemServiceApiCall": "new ServiceApi(\"http:\\\/\\\/parcc.dev\\\/taoQtiTest\\\/ItemRunner\\\/index\",{\"itemUri\":\"http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i1435220772806039\",\"itemPath\":\"http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i14358438037787467+\",\"itemDataPath\":\"http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i14358438031158468-\",\"QtiTestParentServiceCallId\":\"http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i14358438344898489\",\"QtiTestDefinition\":\"http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i14358424814618461\",\"QtiTestCompilation\":\"http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i1435843802614465-|http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i14358438025926466+\",\"standalone\":true},\"http:\\\/\\\/parcc.dev\\\/PARCC.rdf#i14358438344898489.item-1.0\",new StateStorage(null, \"http:\\\/\\\/parcc.dev\\\/tao\\\/ServiceModule\\\/submitState?serviceCallId=http%3A%2F%2Fparcc.dev%2FPARCC.rdf%23i14358438344898489.item-1.0\"),new UserInfoService(\"http:\\\/\\\/parcc.dev\\\/tao\\\/ServiceModule\\\/getUserPropertyValues\",{}))",
+  "numberFlagged": 0,
+  "numberItemsPart": 1,
+  "numberItemsSection": 1,
+  "numberCompletedPart": 0,
+  "numberCompletedSection": 0,
+  "numberPresentedPart": 1,
+  "numberPresentedSection": 1,
+  "numberFlaggedPart": 0,
+  "numberFlaggedSection": 0,
+  "itemPositionPart": 0,
+  "itemPositionSection": 0,
+  "jumpUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/jumpTo?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
+  "markForReviewUrl": "http:\/\/tao.dev\/taoQtiTest\/TestRunner\/markForReview?QtiTestDefinition=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i1434615925556637&QtiTestCompilation=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468266248480-%7Chttp%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468264481%2B&standalone=true&serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504",
+  "itemServiceApiCall": "new ServiceApi(\u0022http:\\\/\\\/tao.dev\\\/taoQtiTest\\\/ItemRunner\\\/index\u0022,{\u0022itemUri\u0022:\u0022http:\\\/\\\/tao.dev\\\/TAO.rdf#i1434615927811740\u0022,\u0022itemPath\u0022:\u0022http:\\\/\\\/tao.dev\\\/TAO.rdf#i14369468271277482+\u0022,\u0022itemDataPath\u0022:\u0022http:\\\/\\\/tao.dev\\\/TAO.rdf#i14369468276374483-\u0022,\u0022QtiTestParentServiceCallId\u0022:\u0022http:\\\/\\\/tao.dev\\\/TAO.rdf#i14369468729921504\u0022,\u0022QtiTestDefinition\u0022:\u0022http:\\\/\\\/tao.dev\\\/TAO.rdf#i1434615925556637\u0022,\u0022QtiTestCompilation\u0022:\u0022http:\\\/\\\/tao.dev\\\/TAO.rdf#i14369468266248480-|http:\\\/\\\/tao.dev\\\/TAO.rdf#i14369468264481+\u0022,\u0022standalone\u0022:true},\u0022http:\\\/\\\/tao.dev\\\/TAO.rdf#i14369468729921504.item-1.0\u0022,new StateStorage(null, \u0022http:\\\/\\\/tao.dev\\\/tao\\\/ServiceModule\\\/submitState?serviceCallId=http%3A%2F%2Ftao.dev%2FTAO.rdf%23i14369468729921504.item-1.0\u0022),new UserInfoService(\u0022http:\\\/\\\/tao.dev\\\/tao\\\/ServiceModule\\\/getUserPropertyValues\u0022,{}))",
   "rubrics": [],
-  "allowComment": false,
+  "allowComment": true,
   "allowSkipping": false,
+  "exitButton": true,
   "timerWarning": {
-    "assessmentItemRef": null,
-    "assessmentSection": 300,
-    "testPart": null
+    "assessmentItemRef": 15,
+    "assessmentSection": 15,
+    "testPart": 15
   },
-  "progressIndicator": "percentage",
+  "progressIndicator": "position",
+  "progressIndicatorScope": "test",
   "reviewScreen": true,
   "reviewRegion": "left",
-  "reviewSectionOnly": false,
+  "reviewScope": "test",
   "reviewPreventsUnseen": true
 }

--- a/views/js/testRunner/testReview.js
+++ b/views/js/testRunner/testReview.js
@@ -23,8 +23,9 @@ define([
     'lodash',
     'i18n',
     'tpl!taoQtiTest/testRunner/tpl/navigator',
-    'tpl!taoQtiTest/testRunner/tpl/navigatorTree'
-], function ($, _, __, navigatorTpl, navigatorTreeTpl) {
+    'tpl!taoQtiTest/testRunner/tpl/navigatorTree',
+    'util/capitalize'
+], function ($, _, __, navigatorTpl, navigatorTreeTpl, capitalize) {
     'use strict';
 
     /**
@@ -100,8 +101,19 @@ define([
      * @private
      */
     var _optionsMap = {
-        'reviewSectionOnly' : 'sectionOnly',
+        'reviewScope' : 'reviewScope',
         'reviewPreventsUnseen' : 'preventsUnseen'
+    };
+
+    /**
+     * Maps the handled review scopes
+     * @type {Object}
+     * @private
+     */
+    var _reviewScopes = {
+        test : 'test',
+        testPart : 'testPart',
+        testSection : 'testSection'
     };
 
     /**
@@ -114,7 +126,8 @@ define([
          * @param {String|jQuery|HTMLElement} element The element on which install the component
          * @param {Object} [options] A list of extra options
          * @param {String} [options.region] The region on which put the component: left or right
-         * @param {Boolean} [options.sectionOnly] Limit the review screen to the current test section only
+         * @param {Boolean} [options.reviewScope] Limit the review screen to a particular scope:
+         * the whole test, the current test part or the current test section)
          * @param {Boolean} [options.preventsUnseen] Prevents the test taker to access unseen items
          * @returns {testReview}
          */
@@ -467,17 +480,62 @@ define([
          * @param {Object} testContext The progression context
          */
         _updateInfos: function(testContext) {
-            var total = testContext.numberItems || 0;
-            var answered = testContext.numberCompleted || 0;
-            var viewed = testContext.numberPresented || 0;
-            var flagged = testContext.numberReview || 0;
-            var unanswered = total - answered;
+            var reviewScope = _reviewScopes[this.options.reviewScope] || 'test';
+            var progressInfoMethod = '_getProgressionOf' + capitalize(reviewScope);
+            var getProgression = this[progressInfoMethod] || this._getProgressionOfTest;
+            var progression = getProgression && getProgression(testContext) || {};
+            var unanswered = Number(progression.total) - Number(progression.answered);
 
             // update the info panel
-            this.$infoAnswered.text(answered + '/' + total);
-            this.$infoUnanswered.text(unanswered + '/' + total);
-            this.$infoViewed.text(viewed + '/' + total);
-            this.$infoFlagged.text(flagged + '/' + total);
+            this.$infoAnswered.text(progression.answered + '/' + progression.total);
+            this.$infoUnanswered.text(unanswered + '/' + progression.total);
+            this.$infoViewed.text(progression.viewed + '/' + progression.total);
+            this.$infoFlagged.text(progression.flagged + '/' + progression.total);
+        },
+
+        /**
+         * Gets the progression stats for the whole test
+         * @param {Object} testContext The progression context
+         * @returns {{total: (Number), answered: (Number), viewed: (Number), flagged: (Number)}}
+         * @private
+         */
+        _getProgressionOfTest: function(testContext) {
+            return {
+                total : testContext.numberItems || 0,
+                answered : testContext.numberCompleted || 0,
+                viewed : testContext.numberPresented || 0,
+                flagged : testContext.numberFlagged || 0
+            };
+        },
+
+        /**
+         * Gets the progression stats for the current test part
+         * @param {Object} testContext The progression context
+         * @returns {{total: (Number), answered: (Number), viewed: (Number), flagged: (Number)}}
+         * @private
+         */
+        _getProgressionOfTestPart: function(testContext) {
+            return {
+                total : testContext.numberItemsPart || 0,
+                answered : testContext.numberCompletedPart || 0,
+                viewed : testContext.numberPresentedPart || 0,
+                flagged : testContext.numberFlaggedPart || 0
+            };
+        },
+
+        /**
+         * Gets the progression stats for the current test section
+         * @param {Object} testContext The progression context
+         * @returns {{total: (Number), answered: (Number), viewed: (Number), flagged: (Number)}}
+         * @private
+         */
+        _getProgressionOfTestSection: function(testContext) {
+            return {
+                total : testContext.numberItemsSection || 0,
+                answered : testContext.numberCompletedSection || 0,
+                viewed : testContext.numberPresentedSection || 0,
+                flagged : testContext.numberFlaggedSection || 0
+            };
         },
 
         /**
@@ -486,8 +544,11 @@ define([
          */
         _updateTree: function(testContext) {
             var navigatorMap = testContext.navigatorMap;
+            var reviewScope = this.options.reviewScope;
+            var reviewScopePart = reviewScope === 'testPart';
+            var reviewScopeSection = reviewScope === 'testSection';
             var _partsFilter = function(part) {
-                if (part.sections) {
+                if (reviewScopeSection && part.sections) {
                     part.sections = _.filter(part.sections, _partsFilter);
                 }
                 return part.active;
@@ -495,7 +556,7 @@ define([
 
             // rebuild the tree
             if (navigatorMap) {
-                if (this.options.sectionOnly) {
+                if (reviewScopePart || reviewScopeSection) {
                     // display only the current section
                     navigatorMap = _.filter(navigatorMap, _partsFilter);
                 }
@@ -605,7 +666,8 @@ define([
      * @param {String|jQuery|HTMLElement} element The element on which install the component
      * @param {Object} [options] A list of extra options
      * @param {String} [options.region] The region on which put the component: left or right
-     * @param {Boolean} [options.sectionOnly] Limit the review screen to the current test section only
+     * @param {Boolean} [options.reviewScope] Limit the review screen to a particular scope:
+     * the whole test, the current test part or the current test section)
      * @param {Boolean} [options.preventsUnseen] Prevents the test taker to access unseen items
      * @returns {testReview}
      */


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-1054 

The test taker review screen can be scoped for:
- the whole test
- the current test part
- the current test section

This scope is set up by the `test-taker-review-scope` config entry, which can take one of these values:
- `test`
- `testPart`
- `testSection`

This option entry is stored inside the `testRunner.conf.php` file
