### PR TITLE
Tao 1053 item sequence number

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -63,6 +63,20 @@ return array(
     'test-taker-review-region' => 'left',
 
     /**
+     * Forces a unique title for all test items.
+     * @type string
+     */
+    'test-taker-review-force-title' => false,
+    
+    /**
+     * A unique title for all test items, when the option `test-taker-review-force-title` is enabled.
+     * This title will be processed through a sprintf() call, with the item sequence number as argument, 
+     * so you can easily insert the sequence number inside the title. 
+     * @type string
+     */
+    'test-taker-review-item-title' => 'Item %d',
+
+    /**
      * Limits the test taker review screen to a particular scope. Can be:
      * - test : the whole test
      * - testPart : the current test part
@@ -81,5 +95,5 @@ return array(
      * Replace logout to exit button...
      * @type boolean
      */
-    'exitButton' => false
+    'exitButton' => false,
 );

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -731,7 +731,7 @@ class taoQtiTest_helpers_TestRunnerUtils {
         // get config for the sequence number option
         $config = common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
         $forceTitles = !empty($config['test-taker-review-force-title']);
-        $uniqueTitle = isset($config['test-taker-review-config-title']) ? $config['test-taker-review-config-title'] : '%d';
+        $uniqueTitle = isset($config['test-taker-review-item-title']) ? $config['test-taker-review-item-title'] : '%d';
 
         $returnValue = array();
         $testParts   = array();

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -728,6 +728,11 @@ class taoQtiTest_helpers_TestRunnerUtils {
 
         $route->setPosition($oldPosition);
 
+        // get config for the sequence number option
+        $config = common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        $forceTitles = !empty($config['test-taker-review-force-title']);
+        $uniqueTitle = isset($config['test-taker-review-config-title']) ? $config['test-taker-review-config-title'] : 'Item %d';
+
         $returnValue = array();
         $testParts   = array();
         $testPartIdx = 0;
@@ -762,6 +767,7 @@ class taoQtiTest_helpers_TestRunnerUtils {
                     $flagged = 0;
                     $items = array();
                     $firstPositionSection = PHP_INT_MAX;
+                    $positionInSection = 0;
 
                     foreach($section->getSectionParts() as $itemId => $item) {
 
@@ -777,10 +783,15 @@ class taoQtiTest_helpers_TestRunnerUtils {
                             if ($jumpInfo['flagged']) {
                                 ++$flagged;
                             }
+                            if ($forceTitles) {
+                                $label = sprintf($uniqueTitle, ++$positionInSection);
+                            } else {
+                                $label = $resItem->getLabel();
+                            }
                             $items[]  = array_merge(
                                 array(
                                     'id' => $itemId,
-                                    'label' => $resItem->getLabel()
+                                    'label' => $label,
                                 ),
                                 $jumpInfo
                             );

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -731,7 +731,7 @@ class taoQtiTest_helpers_TestRunnerUtils {
         // get config for the sequence number option
         $config = common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
         $forceTitles = !empty($config['test-taker-review-force-title']);
-        $uniqueTitle = isset($config['test-taker-review-config-title']) ? $config['test-taker-review-config-title'] : 'Item %d';
+        $uniqueTitle = isset($config['test-taker-review-config-title']) ? $config['test-taker-review-config-title'] : '%d';
 
         $returnValue = array();
         $testParts   = array();

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.9.0',
+    'version' => '2.11.0',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=2.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -129,6 +129,17 @@ class Updater extends \common_ext_ExtensionUpdater {
             $currentVersion = '2.9.0';
         }
         
+        // adjust testrunner config: set the item sequence number options
+        if ($currentVersion == '2.10.0') {
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $config['test-taker-review-force-title'] = false;
+            $config['test-taker-review-item-title'] = 'Item %d';
+            $extension->setConfig('testRunner', $config);
+
+            $currentVersion = '2.11.0';
+        }
+        
         return $currentVersion;
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-1053

Add an option to replace item titles by item sequence numbers in the test taker review screen.

Two options are involved:
- `test-taker-review-force-title`: Enables/disables the option (`true`/`false`)
- `test-taker-review-item-title`: Set the forced titles. Will be processed through sprintf(), with the sequence number as argument, so you can insert the sequence number wherever your want (`"Item %d"`)

These options are located inside the `testRunner.conf.php` file.
