### PR TITLE
Add option to force the display of the progress bar

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -24,7 +24,7 @@ return array(
 
 
     //Show warning message if time remaining less than defined (in seconds)
-   'timerWarning' => array(
+    'timerWarning' => array(
         'assessmentItemRef' => null,
         'assessmentSection' => null,
         'testPart'          => null
@@ -47,6 +47,12 @@ return array(
      * @type string
      */
     'progress-indicator-scope' => 'testSection',
+
+    /**
+     * Force the progress indicator to be always displayed
+     * @type string
+     */
+    'progress-indicator-forced' => false,
 
     /**
      * Enables the test taker review screen

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.11.0',
+    'version' => '2.12.0',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=2.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -104,7 +104,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $currentVersion = '2.6.4';
         }
 
-         if ($currentVersion == '2.6.4') {
+        if ($currentVersion == '2.6.4') {
             $currentVersion = '2.7.0';
         }
 
@@ -163,11 +163,21 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.11.0';
         }
-        
-        if ($currentVersion == '2.7.0') {
+
+        if ($currentVersion == '2.11.0') {
             // correct access roles
             AclProxy::applyRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole', array('act'=>'taoQtiTest', 'mod' => 'TestCommand')));
-            $currentVersion = '2.7.1';
+            $currentVersion = '2.11.1';
+        }
+
+        // adjust testrunner config: set the force progress indicator display
+        if ($currentVersion == '2.11.1') {
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $config['progress-indicator-forced'] = false;
+            $extension->setConfig('testRunner', $config);
+
+            $currentVersion = '2.12.0';
         }
         
         return $currentVersion;

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -491,7 +491,10 @@ define([
              * Updates the test taker review screen
              */
             updateTestReview: function() {
+                var considerProgress = this.testContext.considerProgress === true;
+
                 if (this.testReview) {
+                    this.testReview.toggle(considerProgress);
                     this.testReview.update(this.testContext);
                 }
             },
@@ -500,11 +503,11 @@ define([
              * Updates the progress bar
              */
             updateProgress: function () {
-                var considerProgress = this.testContext.considerProgress;
+                var considerProgress = this.testContext.considerProgress === true;
 
-                $controls.$progressBox.css('visibility', (considerProgress === true) ? 'visible' : 'hidden');
+                $controls.$progressBox.css('visibility', considerProgress ? 'visible' : 'hidden');
 
-                if (considerProgress === true) {
+                if (considerProgress) {
                     this.progressUpdater.update(this.testContext);
                 }
             },

--- a/views/js/testRunner/actionBar/collapseReview.js
+++ b/views/js/testRunner/actionBar/collapseReview.js
@@ -85,7 +85,7 @@ define([
      * @returns {Boolean}
      */
     var isVisibleCollapseButton = function isVisibleCollapseButton(config, testContext) {
-        return !!testContext.reviewScreen;
+        return !!testContext.reviewScreen && !!testContext.considerProgress;
     };
 
     return {

--- a/views/js/testRunner/actionBar/markForReview.js
+++ b/views/js/testRunner/actionBar/markForReview.js
@@ -83,7 +83,7 @@ define([
      * @returns {Boolean}
      */
     var isVisibleFlagButton = function isVisibleFlagButton(config, testContext) {
-        return !!testContext.reviewScreen && !!testContext.navigatorMap;
+        return !!testContext.reviewScreen && !!testContext.navigatorMap && !!testContext.considerProgress;
     };
 
     return {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-877

Required by: https://github.com/oat-sa/extension-tao-act/pull/26

Add an option to force the display of the progress bar, even if the test has branching rules. In this case, the progress bar is not displayed for the parts having branching rules, but as soon as a part does not have branching rules the progress bar is shown.

The option `progress-indicator-forced` is set to `false`by default, and can be enabled inside the `testRunner.conf.php` file.

