### PR TITLE
Fix unit tests of test taker review screen related buttons

### DIFF
--- a/views/js/test/collapseReview/test.js
+++ b/views/js/test/collapseReview/test.js
@@ -56,7 +56,8 @@ define([
 
     QUnit.test('button enabled/disabled', function(assert) {
         var testContextMock = {
-            reviewScreen: true
+            reviewScreen: true,
+            considerProgress: true
         };
 
         assert.ok(collapseReview.isVisible(configMock, testContextMock), 'The collapseReview button is visible when the test taker screen is enabled');
@@ -82,7 +83,8 @@ define([
         };
 
         var testContextMock = {
-            reviewScreen: true
+            reviewScreen: true,
+            considerProgress: true
         };
 
         var $btn = $('#mark-for-review-1');
@@ -113,7 +115,8 @@ define([
         };
 
         var testContextMock = {
-            reviewScreen: true
+            reviewScreen: true,
+            considerProgress: true
         };
 
         var $btn = $('#mark-for-review-2');
@@ -146,7 +149,8 @@ define([
         };
 
         var testContextMock = {
-            reviewScreen: true
+            reviewScreen: true,
+            considerProgress: true
         };
 
         var $btn = $('#mark-for-review-4');

--- a/views/js/test/markForReview/test.js
+++ b/views/js/test/markForReview/test.js
@@ -57,6 +57,7 @@ define([
     QUnit.test('button enabled/disabled', function(assert) {
         var testContextMock = {
             reviewScreen: true,
+            considerProgress: true,
             navigatorMap: []
         };
 
@@ -82,6 +83,7 @@ define([
 
         var testContextMock = {
             reviewScreen: true,
+            considerProgress: true,
             navigatorMap: []
         };
 
@@ -110,6 +112,7 @@ define([
 
         var testContextMock = {
             reviewScreen: true,
+            considerProgress: true,
             navigatorMap: [],
             itemFlagged: true
         };
@@ -143,6 +146,7 @@ define([
 
         var testContextMock = {
             reviewScreen: true,
+            considerProgress: true,
             navigatorMap: [],
             itemFlagged: false,
             itemPosition: 1


### PR DESCRIPTION
Unit tests updated to match the last changes in the test taker review screen.

Fixed unit tests:
- `/taoQtiTest/views/js/test/markForReview/test.html`
- `/taoQtiTest/views/js/test/collapseReview/test.html`

You can also check using the command line:
`grunt connect taoqtitesttest`