### PR TITLE
Reconnect the item service API after flagging

### DIFF
--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -120,6 +120,11 @@ define([
              */
             markForReview: function(flag, position) {
                 var self = this;
+
+                // Ask the top window to start the loader.
+                iframeNotifier.parent('loading');
+
+                // Disable buttons.
                 this.disableGui();
 
                 this.itemServiceApi.kill(function () {
@@ -136,7 +141,14 @@ define([
                         success: function(testContext) {
                             self.setTestContext(testContext);
                             self.updateTestReview();
+                            self.itemServiceApi.connect($controls.$itemFrame[0]);
+
+                            // Enable buttons.
                             self.enableGui();
+
+                            //ask the top window to stop the loader
+                            iframeNotifier.parent('unloading');
+
                         }
                     });
                 });
@@ -260,7 +272,7 @@ define([
                 iframeResizer.autoHeight($controls.$itemFrame, 'body');
 
                 if (this.testContext.itemSessionState === this.TEST_ITEM_STATE_INTERACTING && self.testContext.isTimeout === false) {
-                    $doc.on('serviceloaded', function () {
+                    $doc.off('.testRunner').on('serviceloaded.testRunner', function () {
                         self.afterTransition();
                         self.adjustFrame();
                         $controls.$itemFrame.css({visibility: 'visible'});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-1212

The issue was only occurring when the item is flagged before an answer is made. When the flagging is made after an answer, the response is kept while navigating. 

Steps to reproduce, without the patch, when running a test with the test taker review screen activated:
- working:
    - set a response
    - mark for review
    - go to the next item
    - go back
    - the response is still there and the flag too

- not working:
    - mark for review
    - set a response
    - go to the next item
    - go back
    - the response has disappeared, but the flag is still there
