### PR TITLE
Fix: Forward Slashes Not Being Removed Causing Test Import to Fail

### DIFF
--- a/helpers/class.Utils.php
+++ b/helpers/class.Utils.php
@@ -180,7 +180,7 @@ class taoQtiTest_helpers_Utils {
         $basePath = helpers_File::truePath($basePath);
         $basePath .= DIRECTORY_SEPARATOR;
         
-        $documentURI = preg_replace('/^file:\//', '', $test->getDomDocument()->documentURI);
+        $documentURI = preg_replace('/^file:\/{3}/', '', $test->getDomDocument()->documentURI);
         $testPathInfo = pathinfo($documentURI);
         $testBasePath = tao_helpers_File::truePath($testPathInfo['dirname']) . DIRECTORY_SEPARATOR;
         


### PR DESCRIPTION
Fixed Windows issue with some forward slashes not being stripped by regex.
TESTED IN WINDOWS ONLY.