### PR TITLE
Restore GUI before displaying the time limit message

### DIFF
--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -242,9 +242,9 @@ define([
 
                 $confirmBox.find('.message').html(message);
                 $confirmBox.modal({ width: 500 });
+                this.enableGui();
 
                 $confirmBox.find('.js-exit-cancel, .modal-close').off('click').on('click', function () {
-                    self.enableGui();
                     $confirmBox.modal('close');
                 });
 

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -347,6 +347,7 @@ define([
                         metaData = {"SECTION" : {"SECTION_EXIT_CODE" : TestRunner.SECTION_EXIT_CODE.TIMEOUT}};
                     }
 
+                    self.enableGui();
                     confirmBox.modal({width: 500});
                     confirmBtn.off('click').on('click', function () {
                         confirmBox.modal('close');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-1418

Fix the issue occurring when the test taker click outside the time limit message.

Need a time limited test. When the time limit is reached, a message is displayed. If you click on the Ok button, you are redirected to the next available item. But if you click outside, the modal will disappear leaving the GUI unusable unless you refresh the page. This patch fix this issue.

After merge into dev-act, you will also need to merge this branch into develop...