### PR TITLE
Tao 871 section category

### DIFF
--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -23,31 +23,51 @@ define([
     'use strict';
 
     var _ns = '.sectionCategory';
-
+    
+    /**
+     * Check if the given object is a valid assessmentSection model object
+     * 
+     * @param {object} model
+     * @returns {boolean}
+     */
     function isValidSectionModel(model){
         return (_.isObject(model) && model['qti-type'] === 'assessmentSection' && _.isArray(model.sectionParts));
     }
-
+    
+    /**
+     * Set an array of categories to the section model (affect the childen itemRef)
+     * 
+     * @param {object} model
+     * @param {array} categories
+     * @returns {undefined}
+     */
     function setCategories(model, categories){
 
         var oldCategories = getCategories(model);
         
         //the categories that are no longer in the new list of categories should be removed
         var removed = _.difference(oldCategories.all, categories);
-        //the categories that are not in the old categories collection should be propagated
+        
+        //the categories that are not in the old categories collection should be added to the children
         var propagated = _.difference(categories, oldCategories.all);
         
         //process the modification
         addCategories(model, propagated);
         removeCategories(model, removed);
     }
-
+    
+    /**
+     * Get the categories assign to the section model, infered by its interal itemRefs
+     * 
+     * @param {object} model
+     * @returns {object}
+     */
     function getCategories(model){
 
         if(isValidSectionModel(model)){
             var categories = _.map(model.sectionParts, function (itemRef){
                 if(itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)){
-                    return itemRef.categories;
+                    return _.compact(itemRef.categories);
                 }
             });
             //array of categories
@@ -69,7 +89,14 @@ define([
             errorHandler.throw(_ns, 'invalid tool config format');
         }
     }
-
+    
+    /**
+     * Add an array of categories to a section model (affect the childen itemRef)
+     * 
+     * @param {object} model
+     * @param {array} categories
+     * @returns {undefined}
+     */
     function addCategories(model, categories){
         if(isValidSectionModel(model)){
             _.each(model.sectionParts, function (itemRef){
@@ -86,9 +113,11 @@ define([
     }
     
     /**
+     * Remove an array of categories from a section model (affect the childen itemRef)
      * 
      * @param {object} model
      * @param {array} categories
+     * @returns {undefined}
      */
     function removeCategories(model, categories){
         if(isValidSectionModel(model)){

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -85,12 +85,23 @@ define([
             errorHandler.throw(_ns, 'invalid tool config format');
         }
     }
-
+    
+    /**
+     * 
+     * @param {object} model
+     * @param {array} categories
+     */
     function removeCategories(model, categories){
         if(isValidSectionModel(model)){
             _.each(model.sectionParts, function (itemRef){
                 if(itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)){
-                    _.pull(itemRef.categories, [categories]);
+                    
+                    console.log(_(itemRef.categories));
+                    console.log(_.pull.apply(itemRef.categories, categories));
+                    
+                    var pullArgs = _.clone(categories);
+                    pullArgs.unshift(itemRef.categories);
+                    _.pull.apply(null, pullArgs);
                 }
             });
         }else{

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -32,9 +32,9 @@ define([
 
         var oldCategories = getCategories(model);
         //the categories that are no longer in the new list of categories should be removed
-        var removed = _.without(oldCategories.all, categories);
+        var removed = _.without(oldCategories.all, categories);//@TODO
         //the categories that are not in the old categories collection should be propagated
-        var propagated = _.without(categories, oldCategories.all);
+        var propagated = _.without(categories, oldCategories.all);//@TODO
 
         //process the modification
         addCategories(model, propagated);

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -31,11 +31,12 @@ define([
     function setCategories(model, categories){
 
         var oldCategories = getCategories(model);
+        
         //the categories that are no longer in the new list of categories should be removed
-        var removed = _.without(oldCategories.all, categories);//@TODO
+        var removed = _.difference(oldCategories.all, categories);
         //the categories that are not in the old categories collection should be propagated
-        var propagated = _.without(categories, oldCategories.all);//@TODO
-
+        var propagated = _.difference(categories, oldCategories.all);
+        
         //process the modification
         addCategories(model, propagated);
         removeCategories(model, removed);
@@ -57,9 +58,7 @@ define([
             var propagated = _.intersection.apply(null, arrays);
             
             //the categories that are only partially covered on the section level : complementary of "propagated"
-            var _argsWithout = _.clone(propagated);
-            _argsWithout.unshift(union);
-            var partial = _.without.apply(null, _argsWithout);
+            var partial = _.difference(union, propagated);
             
             return {
                 all : union.sort(),
@@ -95,13 +94,7 @@ define([
         if(isValidSectionModel(model)){
             _.each(model.sectionParts, function (itemRef){
                 if(itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)){
-                    
-                    console.log(_(itemRef.categories));
-                    console.log(_.pull.apply(itemRef.categories, categories));
-                    
-                    var pullArgs = _.clone(categories);
-                    pullArgs.unshift(itemRef.categories);
-                    _.pull.apply(null, pullArgs);
+                    itemRef.categories = _.difference(itemRef.categories, categories);
                 }
             });
         }else{

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -62,9 +62,9 @@ define([
             var partial = _.without.apply(null, _argsWithout);
             
             return {
-                all : union,
-                propagated : propagated,
-                partial : partial
+                all : union.sort(),
+                propagated : propagated.sort(),
+                partial : partial.sort()
             };
         }else{
             errorHandler.throw(_ns, 'invalid tool config format');
@@ -102,7 +102,7 @@ define([
         isValidSectionModel : isValidSectionModel,
         setCategories : setCategories,
         getCategories : getCategories,
-        propagateCategories : addCategories,
+        addCategories : addCategories,
         removeCategories : removeCategories
     };
 });

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -1,0 +1,96 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ */
+define([
+    'lodash',
+    'core/errorHandler'
+], function (_, errorHandler){
+
+    'use strict';
+    
+    var _ns = '.sectionCategory';
+
+    function isValidSectionModel(model){
+        return (_.isObject(model) && model['qti-type'] === 'assessmentSection' && _.isArray(model.sectionParts));
+    }
+
+    function setCategories(model, categories){
+
+        var oldCategories = getCategories(model);
+        //the categories that are no longer in the new list of categories should be removed
+        var removed = _.without(oldCategories.all, categories);
+        //the categories that are not in the old categories collection should be propagated
+        var propagated = _.without(categories, oldCategories.all);
+
+        //process the modification
+        addCategories(model, propagated);
+        removeCategories(model, removed);
+    }
+
+    function getCategories(model){
+
+        if(isValidSectionModel(model)){
+
+            var categories = _.map(model.sectionParts, function (itemRef){
+                if(itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)){
+                    return itemRef.categories;
+                }
+            });
+            //array of categories
+            var arrays = _.values(categories);
+            var union = _.union(arrays);
+            var propagated = _.intersection(arrays);//categories that are common to all itemRef
+            var partial = _.without(union, propagated);//complementary of "propagated"
+
+            return {
+                all : union,
+                propagated : propagated,
+                partial : partial
+            };
+
+        }else{
+            errorHandler.throw(_ns, 'invalid tool config format');
+        }
+    }
+
+    function addCategories(model, categories){
+        _.each(model.sectionParts, function (itemRef){
+            if(itemRef['qti-type'] === 'assessmentItemRef'){
+                if(!_.isArray(itemRef.categories)){
+                    itemRef.categories = [];
+                }
+                itemRef.categories = _.union(itemRef.categories, categories);
+            }
+        });
+    }
+
+    function removeCategories(model, categories){
+        _.each(model.sectionParts, function (itemRef){
+            if(itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)){
+                _.pull(itemRef.categories, [categories]);
+            }
+        });
+    }
+
+    return {
+        isValidSectionModel : isValidSectionModel,
+        setCategories : setCategories,
+        getCategories : getCategories,
+        propagateCategories : addCategories,
+        removeCategories : removeCategories
+    };
+});

--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -113,7 +113,23 @@
             </div>
         </div>
     </div>
-
+    
+    <!-- assessmentTest/testPart/assessmentSection/sectionPart/category -->
+    <div class="grid-row">
+        <div class="col-5">
+            <label for="section-category">{{__ 'Categories'}}</label>
+        </div>
+        <div class="col-6">
+            <input type="text" name="section-category" />
+        </div>
+        <div class="col-1 help">
+            <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span> 
+            <div class="tooltip-content">
+            {{__ 'Items can optionally be assigned to one or more categories.'}}
+            </div>
+        </div>
+    </div>
+    
     <h4 class="toggler closed" data-toggle="~ .section-selection">{{__ 'Selection'}}</h4>
 
 <!-- assessmentTest/testPart/assessmentSection/selection -->
@@ -334,7 +350,7 @@
         </div>
 --}}
     </div>
-
+    
     <h4 class="toggler closed" data-toggle="~ .section-time-limits">{{__ 'Time Limits'}}</h4>
 
 <!-- assessmentTest/timeLimits -->

--- a/views/js/controller/creator/views/itemref.js
+++ b/views/js/controller/creator/views/itemref.js
@@ -86,6 +86,10 @@ function($, _, __, actions){
                 initCategories();
             });
             
+            /**
+             * save the categories into the model
+             * @private
+             */
             function initCategories(){
                 $select.select2('val', model.categories);
             }

--- a/views/js/controller/creator/views/itemref.js
+++ b/views/js/controller/creator/views/itemref.js
@@ -49,7 +49,7 @@ function($, _, __, actions){
          */
         function propHandler (propView) {
 
-            categoriesProperty(propView.getView().find('[name=itemref-category]'));
+            categoriesProperty(propView.getView());
             
             $itemRef.parents('.testpart').on('delete', removePropHandler);
             $itemRef.parents('.section').on('delete', removePropHandler);
@@ -65,9 +65,11 @@ function($, _, __, actions){
         /**
          * Set up the category property
          * @private
-         * @param {jQueryElement} $select - the select box to set up
+         * @param {jQueryElement} $view - the $view object containing the $select
          */
-        function categoriesProperty($select){
+        function categoriesProperty($view){
+            
+            var $select = $view.find('[name=itemref-category]');
             $select.select2({
                 width: '100%',
                 tags : [],
@@ -78,6 +80,15 @@ function($, _, __, actions){
                 },
                 maximumInputLength : 32
             });
+            
+            initCategories();
+            $view.on('propopen.propview', function(){
+                initCategories();
+            });
+            
+            function initCategories(){
+                $select.select2('val', model.categories);
+            }
         }
    };
 

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -105,7 +105,6 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
             categoriesProperty($category);
             
             $category.on('change', function(e){
-                console.log('cat change', e.val);
                 setCategories(e.val);
             });
             
@@ -120,13 +119,11 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
                 
                 //set categories found in the model in the select2 input
                 $category.select2('val', categories.all);
-                console.log(categories);
                 
                 //color partial categories
                 $category.siblings('.select2-container').find('.select2-search-choice').each(function(){
                    var $li = $(this);
                    var content = $li.find('div').text();
-                   console.log(content);
                    if(_.indexOf(categories.partial, content) >= 0){
                        $li.addClass('partial');
                    }

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -28,9 +28,10 @@ define([
     'taoQtiTest/controller/creator/views/itemref',
     'taoQtiTest/controller/creator/views/rubricblock',
     'taoQtiTest/controller/creator/templates/index',
-    'taoQtiTest/controller/creator/helpers/qtiTest'
+    'taoQtiTest/controller/creator/helpers/qtiTest',
+    'taoQtiTest/controller/creator/helpers/sectionCategory'
 ],
-function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTestHelper){
+function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTestHelper, sectionCategory){
     'use strict';
 
    /**
@@ -45,7 +46,6 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
 
         var $actionContainer = $('h2', $section);
 
-        console.log('setup section', model);
         actions.properties($actionContainer, 'section', model, propHandler);
         actions.move($actionContainer, 'sections', 'section');
         itemRefs();
@@ -64,7 +64,6 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
 
             var $view = propView.getView();
             var $category = $('[name=section-category]', $view);
-            var _categories = {};
             
             //enable/disable selection
             var $selectionSwitcher = $('[name=section-enable-selection]', $view);
@@ -103,33 +102,39 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
             $section.on('deleted.deleter', removePropHandler);
             
             //section level category configuration
-            $category.val('AAA,BBB,CDFRE');
             categoriesProperty($category);
+            
             $category.on('change', function(e){
-                console.log('cat change', arguments);
-                var values = e.val;
-                
-                //set categories to items
-                _.each(values, function(value){
-                    //only new category need to be assigned to itemrefs
-                    if(true){
-                        console.log('assign to ', value, model);
-                    }
-                });
+                console.log('cat change', e.val);
+                setCategories(e.val);
             });
-            _.delay(function(){
-                $category.select2('val', ['EE', 'RR']);
-            },1000);
+            
+            initCategories();
             $view.on('propopen.propview', function(){
-                console.log('prop')
+                initCategories();
             });
             
             function initCategories(){
-                _categories = getCategories();
+                
+                var categories = sectionCategory.getCategories(model);
+                
+                //set categories found in the model in the select2 input
+                $category.select2('val', categories.all);
+                console.log(categories);
+                
+                //color partial categories
+                $category.siblings('.select2-container').find('.select2-search-choice').each(function(){
+                   var $li = $(this);
+                   var content = $li.find('div').text();
+                   console.log(content);
+                   if(_.indexOf(categories.partial, content) >= 0){
+                       $li.addClass('partial');
+                   }
+                });
             }
             
             function setCategories(categories){
-                _categories
+                sectionCategory.setCategories(model, categories);
             }
             
             function removePropHandler(){

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -63,7 +63,6 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
         function propHandler (propView) {
 
             var $view = propView.getView();
-            var $category = $('[name=section-category]', $view);
             
             //enable/disable selection
             var $selectionSwitcher = $('[name=section-enable-selection]', $view);
@@ -102,37 +101,7 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
             $section.on('deleted.deleter', removePropHandler);
             
             //section level category configuration
-            categoriesProperty($category);
-            
-            $category.on('change', function(e){
-                setCategories(e.val);
-            });
-            
-            initCategories();
-            $view.on('propopen.propview', function(){
-                initCategories();
-            });
-            
-            function initCategories(){
-                
-                var categories = sectionCategory.getCategories(model);
-                
-                //set categories found in the model in the select2 input
-                $category.select2('val', categories.all);
-                
-                //color partial categories
-                $category.siblings('.select2-container').find('.select2-search-choice').each(function(){
-                   var $li = $(this);
-                   var content = $li.find('div').text();
-                   if(_.indexOf(categories.partial, content) >= 0){
-                       $li.addClass('partial');
-                   }
-                });
-            }
-            
-            function setCategories(categories){
-                sectionCategory.setCategories(model, categories);
-            }
+            categoriesProperty($view);
             
             function removePropHandler(){
                 if(propView !== null){
@@ -310,9 +279,11 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
         /**
          * Set up the category property
          * @private
-         * @param {jQueryElement} $select - the select box to set up
+         * @param {jQueryElement} $view - the $view object containing the $select
          */
-        function categoriesProperty($select){
+        function categoriesProperty($view){
+            
+            var $select = $('[name=section-category]', $view);
             $select.select2({
                 width: '100%',
                 tags : [],
@@ -322,7 +293,36 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
                     return __('Enter a category');
                 },
                 maximumInputLength : 32
+            }).on('change', function(e){
+                setCategories(e.val);
             });
+            
+            initCategories();
+            $view.on('propopen.propview', function(){
+                initCategories();
+            });
+            
+            function initCategories(){
+                
+                var categories = sectionCategory.getCategories(model);
+                
+                //set categories found in the model in the select2 input
+                $select.select2('val', categories.all);
+                
+                //color partial categories
+                $select.siblings('.select2-container').find('.select2-search-choice').each(function(){
+                   var $li = $(this);
+                   var content = $li.find('div').text();
+                   if(_.indexOf(categories.partial, content) >= 0){
+                       $li.addClass('partial');
+                   }
+                });
+            }
+            
+            function setCategories(categories){
+                sectionCategory.setCategories(model, categories);
+            }
+            
         }
    };
 

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -302,6 +302,10 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
                 initCategories();
             });
             
+            /**
+             * Start the categories editing
+             * @private
+             */
             function initCategories(){
                 
                 var categories = sectionCategory.getCategories(model);
@@ -319,6 +323,10 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
                 });
             }
             
+            /**
+             * save the categories into the model
+             * @private
+             */
             function setCategories(categories){
                 sectionCategory.setCategories(model, categories);
             }

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -151,16 +151,19 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
                     $placeholder.show().off('click').on('click', function(e){
                         
                         //prepare the item data 
-                        var defaultItemData = {};
+                        var categories, 
+                            defaultItemData = {};
+                            
                         if(model.itemSessionControl && !_.isUndefined(model.itemSessionControl.maxAttempts)){
                             
                             //for a matter of consistency, the itemRef will "inherit" the itemSessionControl configuration from its parent section
                             defaultItemData.itemSessionControl = _.clone(model.itemSessionControl);
-                            
-                            //the itemRef should also "inherit" the categories set at the item level
-                            
                         }
                         
+                        //the itemRef should also "inherit" the categories set at the item level
+                        var categories = sectionCategory.getCategories(model);
+                        defaultItemData.categories = categories.propagated;
+                            
                         _.forEach(selection, function(item){
                             var $item = $(item);
 

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -161,7 +161,7 @@ function($, _, uri, __, actions, itemRefView, rubricBlockView, templates, qtiTes
                         }
                         
                         //the itemRef should also "inherit" the categories set at the item level
-                        var categories = sectionCategory.getCategories(model);
+                        categories = sectionCategory.getCategories(model);
                         defaultItemData.categories = categories.propagated;
                             
                         _.forEach(selection, function(item){

--- a/views/js/test/sectionCategory/test.html
+++ b/views/js/test/sectionCategory/test.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Section Category Helper test</title>
+        <base href="../../../../../../tao/views/" />
+
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking"  data-cover-only="sectionCategory.js"></script>
+
+        <script  type="text/javascript">
+
+            QUnit.config.autostart = false;
+            require(['/tao/ClientConfig/config'], function(){
+                require(['taoQtiTest/test/sectionCategory/test'], function(){
+                    QUnit.config.reorder = false;
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="tools-container"></div>
+        </div>
+    </body>
+</html>

--- a/views/js/test/sectionCategory/test.js
+++ b/views/js/test/sectionCategory/test.js
@@ -50,7 +50,7 @@ define([
     });
     
     QUnit.test('getCategories', function(assert){
-       var sectionModel = _.clone(_sectionModel);
+       var sectionModel = _.cloneDeep(_sectionModel);
        var categories = sectionCategory.getCategories(sectionModel);
        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
@@ -59,7 +59,7 @@ define([
     
     QUnit.test('addCategories', function(assert){
        
-       var sectionModel = _.clone(_sectionModel);
+       var sectionModel = _.cloneDeep(_sectionModel);
        var categories = sectionCategory.getCategories(sectionModel);
        
        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
@@ -80,19 +80,39 @@ define([
        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
     });
     
-//    QUnit.test('removeCategories', function(assert){
-//       
-//       var sectionModel = _.clone(_sectionModel);
-//       var categories = sectionCategory.getCategories(sectionModel);
-//       
-//       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
-//       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
-//       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-//       
-//       sectionCategory.addCategories(sectionModel, ['G']);
-//       categories = sectionCategory.getCategories(sectionModel);
-//       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
-//       assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
-//       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-//    });
+    QUnit.test('removeCategories', function(assert){
+       
+       var sectionModel = _.cloneDeep(_sectionModel);
+       var categories = sectionCategory.getCategories(sectionModel);
+       
+       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+       
+       //remove one element from the propagated categories
+       sectionCategory.removeCategories(sectionModel, ['A']);
+       categories = sectionCategory.getCategories(sectionModel);
+       assert.deepEqual(categories.all, ['B', 'C', 'D', 'E', 'F'], 'all categories found');
+       assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+       
+       //remove one element from the partial categories
+       sectionCategory.removeCategories(sectionModel, ['F']);
+       categories = sectionCategory.getCategories(sectionModel);
+       assert.deepEqual(categories.all, ['B', 'C', 'D', 'E'], 'all categories found');
+       assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'D', 'E'], 'partial categories found');
+       
+       //remove one element on each group of categories (propagated+partial)
+       sectionCategory.removeCategories(sectionModel, ['B', 'D']);
+       categories = sectionCategory.getCategories(sectionModel);
+       assert.deepEqual(categories.all, ['C', 'E'], 'all categories found');
+       assert.deepEqual(categories.propagated, [], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'E'], 'partial categories found');
+    });
+    
+    
+    QUnit.test('setCategories', function(){
+        
+    });
 });

--- a/views/js/test/sectionCategory/test.js
+++ b/views/js/test/sectionCategory/test.js
@@ -1,0 +1,52 @@
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/sectionCategory',
+    'core/errorHandler'
+], function (_, sectionCategory, errorHandler){
+
+    'use strict';
+
+    var _sectionModel = {
+        'qti-type' : 'assessmentSection',
+        sectionParts : [
+            {
+                'qti-type' : 'assessmentItemRef',
+                categories : ['A', 'B']
+            },
+            {
+                'qti-type' : 'assessmentItemRef',
+                categories : ['A', 'B']
+            },
+            {
+                'qti-type' : 'assessmentItemRef',
+                categories : ['A', 'B', 'C', 'D']
+            },
+            {
+                'qti-type' : 'assessmentItemRef',
+                categories : ['A', 'B', 'D', 'E', 'F']
+            }
+        ]
+    };
+
+    QUnit.test('isValidSectionModel', function (assert){
+
+        assert.ok(sectionCategory.isValidSectionModel({
+            'qti-type' : 'assessmentSection',
+            sectionParts : []
+        }));
+
+        assert.ok(sectionCategory.isValidSectionModel(_sectionModel));
+        
+        assert.ok(!sectionCategory.isValidSectionModel({
+            'qti-type' : 'assessmentItemRef',
+            categories : ['A', 'B', 'C', 'D']
+        }));
+        
+        assert.ok(!sectionCategory.isValidSectionModel({
+            'qti-type' : 'assessmentSection',
+            noSectionParts : null
+        }));
+        
+    });
+
+});

--- a/views/js/test/sectionCategory/test.js
+++ b/views/js/test/sectionCategory/test.js
@@ -50,10 +50,26 @@ define([
     });
     
     QUnit.test('getCategories', function(assert){
-       
-       var categories = sectionCategory.getCategories(_sectionModel);
+       var sectionModel = _.clone(_sectionModel);
+       var categories = sectionCategory.getCategories(sectionModel);
        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+    });
+    
+    QUnit.test('addCategories', function(assert){
+       
+       var sectionModel = _.clone(_sectionModel);
+       var categories = sectionCategory.getCategories(sectionModel);
+       
+       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+       
+       sectionCategory.addCategories(sectionModel, ['G']);
+       categories = sectionCategory.getCategories(sectionModel);
+       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
+       assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
     });
 });

--- a/views/js/test/sectionCategory/test.js
+++ b/views/js/test/sectionCategory/test.js
@@ -66,10 +66,33 @@ define([
        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
        
+       //add a new category
        sectionCategory.addCategories(sectionModel, ['G']);
        categories = sectionCategory.getCategories(sectionModel);
        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
        assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+       
+       //try adding an exiting one
+       sectionCategory.addCategories(sectionModel, ['A', 'C']);
+       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
+       assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
     });
+    
+//    QUnit.test('removeCategories', function(assert){
+//       
+//       var sectionModel = _.clone(_sectionModel);
+//       var categories = sectionCategory.getCategories(sectionModel);
+//       
+//       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+//       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+//       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+//       
+//       sectionCategory.addCategories(sectionModel, ['G']);
+//       categories = sectionCategory.getCategories(sectionModel);
+//       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
+//       assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
+//       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+//    });
 });

--- a/views/js/test/sectionCategory/test.js
+++ b/views/js/test/sectionCategory/test.js
@@ -36,83 +36,98 @@ define([
         }));
 
         assert.ok(sectionCategory.isValidSectionModel(_sectionModel));
-        
+
         assert.ok(!sectionCategory.isValidSectionModel({
             'qti-type' : 'assessmentItemRef',
             categories : ['A', 'B', 'C', 'D']
         }));
-        
+
         assert.ok(!sectionCategory.isValidSectionModel({
             'qti-type' : 'assessmentSection',
             noSectionParts : null
         }));
+
+    });
+
+    QUnit.test('getCategories', function (assert){
+        var sectionModel = _.cloneDeep(_sectionModel);
+        var categories = sectionCategory.getCategories(sectionModel);
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+    });
+
+    QUnit.test('addCategories', function (assert){
+
+        var sectionModel = _.cloneDeep(_sectionModel);
+        var categories = sectionCategory.getCategories(sectionModel);
+
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //add a new category
+        sectionCategory.addCategories(sectionModel, ['G']);
+        categories = sectionCategory.getCategories(sectionModel);
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //try adding an exiting one
+        sectionCategory.addCategories(sectionModel, ['A', 'C']);
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+    });
+
+    QUnit.test('removeCategories', function (assert){
+
+        var sectionModel = _.cloneDeep(_sectionModel);
+        var categories = sectionCategory.getCategories(sectionModel);
+
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //remove one element from the propagated categories
+        sectionCategory.removeCategories(sectionModel, ['A']);
+        categories = sectionCategory.getCategories(sectionModel);
+        assert.deepEqual(categories.all, ['B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //remove one element from the partial categories
+        sectionCategory.removeCategories(sectionModel, ['F']);
+        categories = sectionCategory.getCategories(sectionModel);
+        assert.deepEqual(categories.all, ['B', 'C', 'D', 'E'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E'], 'partial categories found');
+
+        //remove one element on each group of categories (propagated+partial)
+        sectionCategory.removeCategories(sectionModel, ['B', 'D']);
+        categories = sectionCategory.getCategories(sectionModel);
+        assert.deepEqual(categories.all, ['C', 'E'], 'all categories found');
+        assert.deepEqual(categories.propagated, [], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'E'], 'partial categories found');
+    });
+
+
+    QUnit.test('setCategories', function (assert){
+
+        var sectionModel = _.cloneDeep(_sectionModel);
+        var categories = sectionCategory.getCategories(sectionModel);
+
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
         
-    });
-    
-    QUnit.test('getCategories', function(assert){
-       var sectionModel = _.cloneDeep(_sectionModel);
-       var categories = sectionCategory.getCategories(sectionModel);
-       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
-       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-    });
-    
-    QUnit.test('addCategories', function(assert){
-       
-       var sectionModel = _.cloneDeep(_sectionModel);
-       var categories = sectionCategory.getCategories(sectionModel);
-       
-       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
-       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-       
-       //add a new category
-       sectionCategory.addCategories(sectionModel, ['G']);
-       categories = sectionCategory.getCategories(sectionModel);
-       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
-       assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-       
-       //try adding an exiting one
-       sectionCategory.addCategories(sectionModel, ['A', 'C']);
-       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
-       assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-    });
-    
-    QUnit.test('removeCategories', function(assert){
-       
-       var sectionModel = _.cloneDeep(_sectionModel);
-       var categories = sectionCategory.getCategories(sectionModel);
-       
-       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
-       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-       
-       //remove one element from the propagated categories
-       sectionCategory.removeCategories(sectionModel, ['A']);
-       categories = sectionCategory.getCategories(sectionModel);
-       assert.deepEqual(categories.all, ['B', 'C', 'D', 'E', 'F'], 'all categories found');
-       assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
-       
-       //remove one element from the partial categories
-       sectionCategory.removeCategories(sectionModel, ['F']);
-       categories = sectionCategory.getCategories(sectionModel);
-       assert.deepEqual(categories.all, ['B', 'C', 'D', 'E'], 'all categories found');
-       assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'D', 'E'], 'partial categories found');
-       
-       //remove one element on each group of categories (propagated+partial)
-       sectionCategory.removeCategories(sectionModel, ['B', 'D']);
-       categories = sectionCategory.getCategories(sectionModel);
-       assert.deepEqual(categories.all, ['C', 'E'], 'all categories found');
-       assert.deepEqual(categories.propagated, [], 'propagated categories found');
-       assert.deepEqual(categories.partial, ['C', 'E'], 'partial categories found');
-    });
-    
-    
-    QUnit.test('setCategories', function(){
+        //remove B, E and F and add G
+        sectionCategory.setCategories(sectionModel, ['A', 'C', 'D', 'G']);
         
+        //check result
+        categories = sectionCategory.getCategories(sectionModel);
+        assert.deepEqual(categories.all, ['A', 'C', 'D', 'G'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'G' ], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D'], 'partial categories found');
     });
 });

--- a/views/js/test/sectionCategory/test.js
+++ b/views/js/test/sectionCategory/test.js
@@ -48,5 +48,12 @@ define([
         }));
         
     });
-
+    
+    QUnit.test('getCategories', function(assert){
+       
+       var categories = sectionCategory.getCategories(_sectionModel);
+       assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+       assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+       assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+    });
 });


### PR DESCRIPTION
requires https://github.com/oat-sa/tao-core/pull/543

This PR enable adding a category on the qti test section from the test authoring tool. The categories are propagated and saved to child itemRefs.

To validate the AC on the parent user story https://oat-sa.atlassian.net/browse/TAO-871
1.  set exitButton = true in testRunner.conf.php
2.  create a test and add the special category "x-tao-option-exit"
3. compile and execute the delivery -> the section having that exit code should have the exit button displayed, the section that does not have it should have no button "up there"