### PR TITLE
Verify access to qtiRunner before using it

### DIFF
--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -233,13 +233,16 @@ define([
                     message,
                     messageFlagged = '',
                     unansweredCount=(this.testContext.numberItemsSection - this.testContext.numberCompletedSection),
-                    flaggedCount=this.testContext.numberFlaggedSection;
+                    flaggedCount=this.testContext.numberFlaggedSection,
+                    qtiRunner = this.getQtiRunner();
 
                 if( this.isCurrentItemAnswered() ){
                     unansweredCount--;
                 }
 
-                this.getQtiRunner().updateItemApi();
+                if (qtiRunner) {
+                    qtiRunner.updateItemApi();
+                }
 
                 if( flaggedCount !== undefined ){
                     messageFlagged = " and have %s item(s) marked for review";
@@ -289,12 +292,11 @@ define([
             },
 
             getQtiRunner: function(){
-                var itemWindow, itemContainerWindow;
-
-                itemWindow = $('#qti-item')[0].contentWindow;
-                itemContainerWindow = $(itemWindow.document).find('#item-container')[0].contentWindow;
-
-                return itemContainerWindow.qtiRunner;
+                var itemFrame = document.getElementById('qti-item');
+                var itemWindow = itemFrame && itemFrame.contentWindow;
+                var itemContainerFrame = itemWindow && itemWindow.document.getElementById('item-container');
+                var itemContainerWindow = itemContainerFrame && itemContainerFrame.contentWindow;
+                return itemContainerWindow && itemContainerWindow.qtiRunner;
             },
 
             isTimedSection: function(){


### PR DESCRIPTION
Fix issue occurring when the last item of a timed section has reached the time limit, and the page is refreshed or the session just opened.

To reproduce the issue, use a test with timed section and:
- move to the last item of the timed section
- wait for the time limit
- when the limit reached message appears, refresh the page or logout and reconnect
- when you try to go to the next item, the page is stuck on a javascript error: `TypeError: $(...).find(...)[0] is undefined`