### PR TITLE
Fix/flagged items

### DIFF
--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -151,6 +151,7 @@ define([
                                 self.testContext.itemFlagged = flag;
                             }
                             self.updateTools(self.testContext);
+                            self.updateFlaggedNumbers(position, flag);
                         }
 
                         // Enable buttons.
@@ -158,6 +159,72 @@ define([
 
                         //ask the top window to stop the loader
                         iframeNotifier.parent('unloading');
+                    }
+                });
+            },
+
+            /**
+             * Update the number of flagged items in the context
+             * @param {Number} position
+             * @param {Boolean} flag
+             */
+            updateFlaggedNumbers: function(position, flag) {
+                var fields = ['numberFlagged'];
+                var testContext = this.testContext;
+                var currentPosition = testContext.itemPosition;
+                var currentFound = false, currentSection = null, currentPart = null;
+                var itemFound = false, itemSection = null, itemPart = null;
+
+                if (this.testContext.navigatorMap) {
+                    // find the current item and the marked item inside the navigator map
+                    // check if the marked item is in the current section
+                    _.forEach(this.testContext.navigatorMap, function(part) {
+                        _.forEach(part && part.sections, function(section) {
+                            _.forEach(section && section.items, function(item) {
+                                if (item) {
+                                    if (item.position === position) {
+                                        itemPart = part;
+                                        itemSection = section;
+                                        itemFound = true;
+                                    }
+                                    if (item.position === currentPosition) {
+                                        currentPart = part;
+                                        currentSection = section;
+                                        currentFound = true;
+
+                                    }
+                                    if (itemFound && currentFound) {
+                                        return false;
+                                    }
+                                }
+                            });
+
+                            if (itemFound && currentFound) {
+                                return false;
+                            }
+                        });
+
+                        if (itemFound && currentFound) {
+                            return false;
+                        }
+                    });
+
+                    // select the context to update
+                    if (itemFound && currentPart === itemPart) {
+                        fields.push('numberFlaggedPart');
+                    }
+                    if (itemFound && currentSection === itemSection) {
+                        fields.push('numberFlaggedSection');
+                    }
+                } else {
+                    // no navigator map, the current the marked item is in the current section
+                    fields.push('numberFlaggedPart');
+                    fields.push('numberFlaggedSection');
+                }
+
+                _.forEach(fields, function(field) {
+                    if (field in testContext) {
+                        testContext[field] += flag ? 1 : -1;
                     }
                 });
             },

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -147,11 +147,11 @@ define([
                         // update the item flagged state
                         if (self.testReview) {
                             self.testReview.setItemFlag(position, flag);
+                            self.testReview.updateNumberFlagged(self.testContext, position, flag);
                             if (self.testContext.itemPosition === position) {
                                 self.testContext.itemFlagged = flag;
                             }
                             self.updateTools(self.testContext);
-                            self.updateFlaggedNumbers(position, flag);
                         }
 
                         // Enable buttons.
@@ -159,72 +159,6 @@ define([
 
                         //ask the top window to stop the loader
                         iframeNotifier.parent('unloading');
-                    }
-                });
-            },
-
-            /**
-             * Update the number of flagged items in the context
-             * @param {Number} position
-             * @param {Boolean} flag
-             */
-            updateFlaggedNumbers: function(position, flag) {
-                var fields = ['numberFlagged'];
-                var testContext = this.testContext;
-                var currentPosition = testContext.itemPosition;
-                var currentFound = false, currentSection = null, currentPart = null;
-                var itemFound = false, itemSection = null, itemPart = null;
-
-                if (this.testContext.navigatorMap) {
-                    // find the current item and the marked item inside the navigator map
-                    // check if the marked item is in the current section
-                    _.forEach(this.testContext.navigatorMap, function(part) {
-                        _.forEach(part && part.sections, function(section) {
-                            _.forEach(section && section.items, function(item) {
-                                if (item) {
-                                    if (item.position === position) {
-                                        itemPart = part;
-                                        itemSection = section;
-                                        itemFound = true;
-                                    }
-                                    if (item.position === currentPosition) {
-                                        currentPart = part;
-                                        currentSection = section;
-                                        currentFound = true;
-
-                                    }
-                                    if (itemFound && currentFound) {
-                                        return false;
-                                    }
-                                }
-                            });
-
-                            if (itemFound && currentFound) {
-                                return false;
-                            }
-                        });
-
-                        if (itemFound && currentFound) {
-                            return false;
-                        }
-                    });
-
-                    // select the context to update
-                    if (itemFound && currentPart === itemPart) {
-                        fields.push('numberFlaggedPart');
-                    }
-                    if (itemFound && currentSection === itemSection) {
-                        fields.push('numberFlaggedSection');
-                    }
-                } else {
-                    // no navigator map, the current the marked item is in the current section
-                    fields.push('numberFlaggedPart');
-                    fields.push('numberFlaggedSection');
-                }
-
-                _.forEach(fields, function(field) {
-                    if (field in testContext) {
-                        testContext[field] += flag ? 1 : -1;
                     }
                 });
             },

--- a/views/js/testRunner/testReview.js
+++ b/views/js/testRunner/testReview.js
@@ -148,6 +148,7 @@ define([
             this.options = initOptions;
             this.disabled = false;
             this.hidden = false;
+            this.currentFilter = 'all';
 
             // clean the DOM if the init method is called after initialisation
             if (this.$component) {
@@ -320,6 +321,7 @@ define([
                 $items.filter(filter).addClass(_cssCls.masked);
             }
             this._updateSectionCounters(!!filter);
+            this.currentFilter = criteria;
         },
 
         /**
@@ -656,6 +658,7 @@ define([
             // update the info panel
             progression.flagged = this.$tree.find(_selectors.flagged).length;
             this._writeCount(this.$infoFlagged, progression.flagged, progression.total);
+            this._filter(this.currentFilter);
         },
 
         /**

--- a/views/js/testRunner/testReview.js
+++ b/views/js/testRunner/testReview.js
@@ -662,6 +662,72 @@ define([
         },
 
         /**
+         * Update the number of flagged items in the test context
+         * @param {Object} testContext The test context
+         * @param {Number} position The position of the flagged item
+         * @param {Boolean} flag The flag state
+         */
+        updateNumberFlagged: function(testContext, position, flag) {
+            var fields = ['numberFlagged'];
+            var currentPosition = testContext.itemPosition;
+            var currentFound = false, currentSection = null, currentPart = null;
+            var itemFound = false, itemSection = null, itemPart = null;
+
+            if (testContext.navigatorMap) {
+                // find the current item and the marked item inside the navigator map
+                // check if the marked item is in the current section
+                _.forEach(testContext.navigatorMap, function(part) {
+                    _.forEach(part && part.sections, function(section) {
+                        _.forEach(section && section.items, function(item) {
+                            if (item) {
+                                if (item.position === position) {
+                                    itemPart = part;
+                                    itemSection = section;
+                                    itemFound = true;
+                                }
+                                if (item.position === currentPosition) {
+                                    currentPart = part;
+                                    currentSection = section;
+                                    currentFound = true;
+
+                                }
+                                if (itemFound && currentFound) {
+                                    return false;
+                                }
+                            }
+                        });
+
+                        if (itemFound && currentFound) {
+                            return false;
+                        }
+                    });
+
+                    if (itemFound && currentFound) {
+                        return false;
+                    }
+                });
+
+                // select the context to update
+                if (itemFound && currentPart === itemPart) {
+                    fields.push('numberFlaggedPart');
+                }
+                if (itemFound && currentSection === itemSection) {
+                    fields.push('numberFlaggedSection');
+                }
+            } else {
+                // no navigator map, the current the marked item is in the current section
+                fields.push('numberFlaggedPart');
+                fields.push('numberFlaggedSection');
+            }
+
+            _.forEach(fields, function(field) {
+                if (field in testContext) {
+                    testContext[field] += flag ? 1 : -1;
+                }
+            });
+        },
+
+        /**
          * Get progression
          * @param {Object} testContext The progression context
          * @returns {object} progression


### PR DESCRIPTION
When the test taker flag/unflag an item, the current number of flagged items is not updated unless another item is reached. So if the test taker want to exit the test or the section, the confirm message displays a wrong number of flagged items.
