### PR TITLE
Tao 1773 catch terminate state

### DIFF
--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -231,7 +231,7 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
     protected function notifyError($message, $code = 0) {
         $ctx = array(
             'success' => false,
-            'state' => AssessmentTestSessionState::CLOSED,
+            'state' => $this->getTestSession()->getState(),
             'message' => $message,
             'code' => $code,
         );
@@ -347,8 +347,10 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      * 
      */
 	public function index() {
-	    if ($this->beforeAction()) {
-            $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        $noError = $this->beforeAction();
+
+        if ($noError) {
             $session = $this->getTestSession();
 
             /** @var \oat\taoQtiTest\models\SessionStateService $sessionStateService */
@@ -370,15 +372,17 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
             if (taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
                 taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
             }
+        }
 
-            // loads the specific config
-            $this->setData('review_screen', !empty($config['test-taker-review']));
-            $this->setData('review_region', isset($config['test-taker-review-region']) ? $config['test-taker-review-region'] : '');
+        // loads the specific config
+        $this->setData('review_screen', !empty($config['test-taker-review']));
+        $this->setData('review_region', isset($config['test-taker-review-region']) ? $config['test-taker-review-region'] : '');
 
-            $this->setData('client_config_url', $this->getClientConfigUrl());
-            $this->setData('client_timeout', $this->getClientTimeout());
-            $this->setView('test_runner.tpl');
+        $this->setData('client_config_url', $this->getClientConfigUrl());
+        $this->setData('client_timeout', $this->getClientTimeout());
+        $this->setView('test_runner.tpl');
 
+        if ($noError) {
             $this->afterAction(false);
         }
 	}

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -829,7 +829,7 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	    if ($qtiStorage->exists($sessionId) === false) {
 	        common_Logger::i("Instantiating QTI Assessment Test Session");
             $this->setTestSession($qtiStorage->instantiate($this->getTestDefinition(), $sessionId));
-            $this->setInitialOutcomes();
+            taoQtiTest_helpers_TestRunnerUtils::setInitialOutcomes($this->getTestSession());
 	    }
 	    else {
 	        common_Logger::i("Retrieving QTI Assessment Test Session '${sessionId}'...");
@@ -863,27 +863,6 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	        break;
 	    }
 	}
-    
-    /**
-     * Set the initial outcomes defined in the rdf outcome map configuration file
-     */
-    protected function setInitialOutcomes(){
-        
-        $testSession = $this->getTestSession();
-        
-        $rdfOutcomeMap = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('rdfOutcomeMap');
-        if(is_array($rdfOutcomeMap)){
-            $testTaker = \common_session_SessionManager::getSession()->getUser();
-            foreach($rdfOutcomeMap as $outcomeId => $rdfPropUri){
-                //set outcome value
-                $values = $testTaker->getPropertyValues($rdfPropUri);
-                $outcome = $testSession->getVariable($outcomeId);
-                if(!is_null($outcome) && count($values)){
-                    $outcome->setValue(new String($values[0]));
-                }
-            }
-        }
-    }
 
     /**
      * Preserve the outcomes variables set in the "rdfOutcomeMap" config

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -353,6 +353,7 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
         $noError = $this->beforeAction();
 
+        // this part is only accessible if beforeAction did not return an error
         if ($noError) {
             $session = $this->getTestSession();
 
@@ -378,6 +379,8 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         }
 
         // loads the specific config
+        // this part must be processed no matter if beforeAction returned an error:
+        // the context object is provided through the view
         $this->setData('review_screen', !empty($config['test-taker-review']));
         $this->setData('review_region', isset($config['test-taker-review-region']) ? $config['test-taker-review-region'] : '');
 
@@ -385,6 +388,7 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         $this->setData('client_timeout', $this->getClientTimeout());
         $this->setView('test_runner.tpl');
 
+        // this part is only accessible if beforeAction did not return an error
         if ($noError) {
             $this->afterAction(false);
         }

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -829,14 +829,16 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	    if ($qtiStorage->exists($sessionId) === false) {
 	        common_Logger::i("Instantiating QTI Assessment Test Session");
             $this->setTestSession($qtiStorage->instantiate($this->getTestDefinition(), $sessionId));
-            taoQtiTest_helpers_TestRunnerUtils::setInitialOutcomes($this->getTestSession());
+
+            $testTaker = \common_session_SessionManager::getSession()->getUser();
+            taoQtiTest_helpers_TestRunnerUtils::setInitialOutcomes($this->getTestSession(), $testTaker);
 	    }
 	    else {
 	        common_Logger::i("Retrieving QTI Assessment Test Session '${sessionId}'...");
 	        $this->setTestSession($qtiStorage->retrieve($this->getTestDefinition(), $sessionId));
 	    }
 
-        $this->preserveOutcomes();
+        taoQtiTest_helpers_TestRunnerUtils::preserveOutcomes($this->getTestSession());
     }
     
     /**
@@ -863,17 +865,4 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	        break;
 	    }
 	}
-
-    /**
-     * Preserve the outcomes variables set in the "rdfOutcomeMap" config
-     * This is required to prevent those special outcomes from being reset before every outcome processing
-     */
-    protected function preserveOutcomes(){
-
-        //preserve the special outcomes defined in the rdfOutcomeMap config
-        $rdfOutcomeMap = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('rdfOutcomeMap');
-        if (is_array($rdfOutcomeMap) === true) {
-            $this->getTestSession()->setPreservedOutcomeVariables(array_keys($rdfOutcomeMap));
-        }
-    }
 }

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -221,12 +221,41 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	protected function getTestMeta() {
 	    return $this->testMeta;
 	}
-    
-    protected function beforeAction() {
+
+    /**
+     * Print an error report into the response.
+     * After you have called this method, you must prevent other actions to be processed and must close the response.
+     * @param string $message
+     * @param int $code
+     */
+    protected function notifyError($message, $code = 0) {
+        $ctx = array(
+            'success' => false,
+            'state' => AssessmentTestSessionState::CLOSED,
+            'message' => $message,
+            'code' => $code,
+        );
+
+        $this->setData('assessmentTestContext', $ctx);
+
+        if (\tao_helpers_Request::isAjax()) {
+            $this->returnJson($ctx);
+        }
+    }
+
+    /**
+     * Common stuff processessed on almost all actions.
+     * If something goes wrong, print a report and return false, otherwise return true.
+     * @param bool $notifyError Allow to print error message if needed
+     * @return bool Returns a flag telling whether or not the action can be processed
+     * @throws \oat\oatbox\service\ServiceNotFoundException
+     * @throws common_exception_Error
+     */
+    protected function beforeAction($notifyError = true) {
         // Controller initialization.
         $this->retrieveTestDefinition($this->getRequestParameter('QtiTestCompilation'));
         $resultServer = taoResultServer_models_classes_ResultServerStateFull::singleton();
-        
+
         // Initialize storage and test session.
         $testResource = new core_kernel_classes_Resource($this->getRequestParameter('QtiTestDefinition'));
         
@@ -237,8 +266,26 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         $this->setStorage(new taoQtiTest_helpers_TestSessionStorage($sessionManager, $seeker, $userUri));
         $this->retrieveTestSession();
 
+        // @TODO: use some storage to get the potential reason of the state (close/suspended)
+        $session = $this->getTestSession();
+        $state = $session->getState();
+        if ($state == AssessmentTestSessionState::CLOSED) {
+            if ($notifyError) {
+                $this->notifyError(__('The assessment test has been terminated!'), $state);
+            }
+            return false;
+        }
+
+        // @TODO: maybe use an option to enable this behavior
+        if ($state == AssessmentTestSessionState::SUSPENDED) {
+            if ($notifyError) {
+                $this->notifyError(__('The assessment test has been suspended!'), $state);
+            }
+            return false;
+        }
+
         $sessionStateService = $this->getServiceManager()->get('taoQtiTest/SessionStateService');
-        $sessionStateService->resumeSession($this->getTestSession());
+        $sessionStateService->resumeSession($session);
 
         $this->retrieveTestMeta();
         
@@ -250,6 +297,8 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         if (!empty($metaData)) {
             $this->getMetaDataHandler()->save($metaData);
         }
+
+        return true;
     }
 
     /**
@@ -264,7 +313,11 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         }
         return $this->metaDataHandler;
     }
-    
+
+    /**
+     * Does some complementary stuff to finish the action. Builds the test context object and binds it to the response.
+     * @param bool $withContext
+     */
     protected function afterAction($withContext = true) {
         $testSession = $this->getTestSession();
         $sessionId = $testSession->getSessionId();
@@ -294,39 +347,40 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      * 
      */
 	public function index() {
-	    $this->beforeAction();
-        $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
-	    $session = $this->getTestSession();
+	    if ($this->beforeAction()) {
+            $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+            $session = $this->getTestSession();
 
-        /** @var \oat\taoQtiTest\models\SessionStateService $sessionStateService */
-        $sessionStateService = $this->getServiceManager()->get('taoQtiTest/SessionStateService');
-        $resetTimerAfterResume = isset($config['reset-timer-after-resume']) && $config['reset-timer-after-resume'];
-        if ($resetTimerAfterResume) {
-            $sessionStateService->updateTimeReference($session);
+            /** @var \oat\taoQtiTest\models\SessionStateService $sessionStateService */
+            $sessionStateService = $this->getServiceManager()->get('taoQtiTest/SessionStateService');
+            $resetTimerAfterResume = isset($config['reset-timer-after-resume']) && $config['reset-timer-after-resume'];
+            if ($resetTimerAfterResume) {
+                $sessionStateService->updateTimeReference($session);
+            }
+            $this->setData('client_session_state_service',
+                $sessionStateService->getClientImplementation($resetTimerAfterResume));
+
+            if ($session->getState() === AssessmentTestSessionState::INITIAL) {
+                // The test has just been instantiated.
+                $session->beginTestSession();
+                $this->getMetaDataHandler()->registerItemCallbacks();
+                common_Logger::i("Assessment Test Session begun.");
+            }
+
+            if (taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
+                taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+            }
+
+            // loads the specific config
+            $this->setData('review_screen', !empty($config['test-taker-review']));
+            $this->setData('review_region', isset($config['test-taker-review-region']) ? $config['test-taker-review-region'] : '');
+
+            $this->setData('client_config_url', $this->getClientConfigUrl());
+            $this->setData('client_timeout', $this->getClientTimeout());
+            $this->setView('test_runner.tpl');
+
+            $this->afterAction(false);
         }
-        $this->setData('client_session_state_service',
-            $sessionStateService->getClientImplementation($resetTimerAfterResume));
-
-	    if ($session->getState() === AssessmentTestSessionState::INITIAL) {
-            // The test has just been instantiated.
-            $session->beginTestSession();
-            $this->getMetaDataHandler()->registerItemCallbacks();
-            common_Logger::i("Assessment Test Session begun.");
-        }
-
-        if (taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
-            taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
-        }
-
-        // loads the specific config
-        $this->setData('review_screen', !empty($config['test-taker-review']));
-        $this->setData('review_region', isset($config['test-taker-review-region']) ? $config['test-taker-review-region'] : '');
-        
-        $this->setData('client_config_url', $this->getClientConfigUrl());
-        $this->setData('client_timeout', $this->getClientTimeout());
-        $this->setView('test_runner.tpl');
-        
-        $this->afterAction(false);
 	}
 
     /**
@@ -336,25 +390,25 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      * @throws common_ext_ExtensionException
      */
     public function keepItemTimed(){
-        $this->beforeAction();
+        if ($this->beforeAction()) {
+            $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
 
-        $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+            if (isset( $config['reset-timer-after-resume'] ) && $config['reset-timer-after-resume'] && $this->hasRequestParameter('duration')) {
 
-        if (isset( $config['reset-timer-after-resume'] ) && $config['reset-timer-after-resume'] && $this->hasRequestParameter('duration')) {
+                $session = $this->getTestSession();
 
-            $session = $this->getTestSession();
+                // originally in milliseconds, but we have to convert to seconds now
+                $durationInSeconds = (int) ($this->getRequestParameter('duration') / 1000);
 
-            // originally in milliseconds, but we have to convert to seconds now
-            $durationInSeconds = (int) ($this->getRequestParameter('duration') / 1000);
+                $time = new \DateTime('now', new \DateTimeZone('UTC'));
+                $duration = new DateInterval('PT' . $durationInSeconds . 'S');
+                $time->sub($duration);
 
-            $time = new \DateTime('now', new \DateTimeZone('UTC'));
-            $duration = new DateInterval('PT' . $durationInSeconds . 'S');
-            $time->sub($duration);
-
-            /** @var \oat\taoQtiTest\models\SessionStateService $sessionStateService */
-            $sessionStateService = $this->getServiceManager()->get('taoQtiTest/SessionStateService');
-            $sessionStateService->updateTimeReference($session, $time);
-            $this->afterAction();
+                /** @var \oat\taoQtiTest\models\SessionStateService $sessionStateService */
+                $sessionStateService = $this->getServiceManager()->get('taoQtiTest/SessionStateService');
+                $sessionStateService->updateTimeReference($session, $time);
+                $this->afterAction();
+            }
         }
     }
     
@@ -363,40 +417,40 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      *
      */
     public function markForReview() {
-        $this->beforeAction();
-        $testSession = $this->getTestSession();
-        $sessionId = $testSession->getSessionId();
+        if ($this->beforeAction()) {
+            $testSession = $this->getTestSession();
+            $sessionId = $testSession->getSessionId();
 
-        try {
-            if ($this->hasRequestParameter('position')) {
-                $itemPosition = intval($this->getRequestParameter('position'));
-            } else {
-                $itemPosition = $testSession->getRoute()->getPosition();
-            }
-            if ($this->hasRequestParameter('flag')) {
-                $flag = $this->getRequestParameter('flag');
-                if (is_numeric($flag)) {
-                    $flag = !!(intval($flag));
+            try {
+                if ($this->hasRequestParameter('position')) {
+                    $itemPosition = intval($this->getRequestParameter('position'));
                 } else {
-                    $flag = 'false' != strtolower($flag);
+                    $itemPosition = $testSession->getRoute()->getPosition();
                 }
-            } else {
-                $flag = true;
+                if ($this->hasRequestParameter('flag')) {
+                    $flag = $this->getRequestParameter('flag');
+                    if (is_numeric($flag)) {
+                        $flag = !!(intval($flag));
+                    } else {
+                        $flag = 'false' != strtolower($flag);
+                    }
+                } else {
+                    $flag = true;
+                }
+                taoQtiTest_helpers_TestRunnerUtils::setItemFlag($testSession, $itemPosition, $flag);
+
+                $this->returnJson(array(
+                    'success' => true,
+                    'position' => $itemPosition,
+                    'flag' => $flag
+                ));
+            } catch (AssessmentTestSessionException $e) {
+                $this->handleAssessmentTestSessionException($e);
             }
-            taoQtiTest_helpers_TestRunnerUtils::setItemFlag($testSession, $itemPosition, $flag);
 
-            $this->returnJson(array(
-                'success' => true,
-                'position' => $itemPosition,
-                'flag' => $flag
-            ));
+            common_Logger::i("Persisting QTI Assessment Test Session '${sessionId}'...");
+            $this->getStorage()->persist($testSession);
         }
-        catch (AssessmentTestSessionException $e) {
-            $this->handleAssessmentTestSessionException($e);
-        }
-
-        common_Logger::i("Persisting QTI Assessment Test Session '${sessionId}'...");
-        $this->getStorage()->persist($testSession);
     }
 
     /**
@@ -404,24 +458,24 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      *
      */
     public function jumpTo() {
-        $this->beforeAction();
-        $session = $this->getTestSession();
-        $nextPosition = intval($this->getRequestParameter('position'));
+        if ($this->beforeAction()) {
+            $session = $this->getTestSession();
+            $nextPosition = intval($this->getRequestParameter('position'));
 
-        try {
-            $this->endTimedSection($nextPosition);
+            try {
+                $this->endTimedSection($nextPosition);
 
-            $session->jumpTo($nextPosition);
+                $session->jumpTo($nextPosition);
 
-            if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
-                taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
+                    taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                }
+            } catch (AssessmentTestSessionException $e) {
+                $this->handleAssessmentTestSessionException($e);
             }
-        }
-        catch (AssessmentTestSessionException $e) {
-            $this->handleAssessmentTestSessionException($e);
-        }
 
-        $this->afterAction();
+            $this->afterAction();
+        }
     }
 
     protected function endTimedSection($nextPosition)
@@ -463,24 +517,24 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	 *
 	 */
 	public function moveForward() {
-        $this->beforeAction();
-        $session = $this->getTestSession();
-        $nextPosition = $session->getRoute()->getPosition() + 1;
+        if ($this->beforeAction()) {
+            $session = $this->getTestSession();
+            $nextPosition = $session->getRoute()->getPosition() + 1;
 
-        try {
-            $this->endTimedSection($nextPosition);
+            try {
+                $this->endTimedSection($nextPosition);
 
-            $session->moveNext();
+                $session->moveNext();
 
-            if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
-                taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
+                    taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                }
+            } catch (AssessmentTestSessionException $e) {
+                $this->handleAssessmentTestSessionException($e);
             }
-        }
-        catch (AssessmentTestSessionException $e) {
-            $this->handleAssessmentTestSessionException($e);
-        }
 
-        $this->afterAction();
+            $this->afterAction();
+        }
 	}
 	    
 	/**
@@ -488,24 +542,24 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	 *
 	 */
 	public function moveBackward() {
-	    $this->beforeAction();
-	    $session = $this->getTestSession();
-        $nextPosition = $session->getRoute()->getPosition() - 1;
-	    
-	    try {
-            $this->endTimedSection($nextPosition);
+        if ($this->beforeAction()) {
+            $session = $this->getTestSession();
+            $nextPosition = $session->getRoute()->getPosition() - 1;
 
-	        $session->moveBack();
-	        
-	        if (taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
-	            taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
-	        }
-	    }
-	    catch (AssessmentTestSessionException $e) {
-	        $this->handleAssessmentTestSessionException($e);
-	    }
+            try {
+                $this->endTimedSection($nextPosition);
 
-	    $this->afterAction();
+                $session->moveBack();
+
+                if (taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
+                    taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                }
+            } catch (AssessmentTestSessionException $e) {
+                $this->handleAssessmentTestSessionException($e);
+            }
+
+            $this->afterAction();
+        }
 	}
 
     /**
@@ -513,21 +567,21 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      *
      */
     public function nextSection() {
-        $this->beforeAction();
-        $session = $this->getTestSession();
+        if ($this->beforeAction()) {
+            $session = $this->getTestSession();
 
-        try {
-            $session->moveNextAssessmentSection();
+            try {
+                $session->moveNextAssessmentSection();
 
-            if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
-                taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
+                    taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                }
+            } catch (AssessmentTestSessionException $e) {
+                $this->handleAssessmentTestSessionException($e);
             }
-        }
-        catch (AssessmentTestSessionException $e) {
-            $this->handleAssessmentTestSessionException($e);
-        }
 
-        $this->afterAction();
+            $this->afterAction();
+        }
     }
 	
 	/**
@@ -535,22 +589,22 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	 *
 	 */
 	public function skip() {
-	    $this->beforeAction();
-	    $session = $this->getTestSession();
-	    
-	    try {
-	        $session->skip();
-	        $session->moveNext();
-	        
-	        if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
-	            taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
-	        }
-	    }
-	    catch (AssessmentTestSessionException $e) {
-	        $this->handleAssessmentTestSessionException($e);
-	    }
-	    
-	    $this->afterAction();
+        if ($this->beforeAction()) {
+            $session = $this->getTestSession();
+
+            try {
+                $session->skip();
+                $session->moveNext();
+
+                if ($session->isRunning() === true && taoQtiTest_helpers_TestRunnerUtils::isTimeout($session) === false) {
+                    taoQtiTest_helpers_TestRunnerUtils::beginCandidateInteraction($session);
+                }
+            } catch (AssessmentTestSessionException $e) {
+                $this->handleAssessmentTestSessionException($e);
+            }
+
+            $this->afterAction();
+        }
 	}
 	
 	/**
@@ -558,33 +612,35 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	 *
 	 */
 	public function timeout() {
-	    $this->beforeAction();
-	    $session = $this->getTestSession();
-	    
-	    try {
-            $session->checkTimeLimits(false, true, false);
-        } catch (AssessmentTestSessionException $e) {
-            $this->onTimeout($e);
+        if ($this->beforeAction()) {
+            $session = $this->getTestSession();
+
+            try {
+                $session->checkTimeLimits(false, true, false);
+            } catch (AssessmentTestSessionException $e) {
+                $this->onTimeout($e);
+            }
+
+            // If we are here, without executing onTimeout() there is an inconsistency. Simply respond
+            // to the client with the actual assessment test context. Maybe the client will be able to
+            // continue...
+            $this->afterAction();
         }
-        
-        // If we are here, without executing onTimeout() there is an inconsistency. Simply respond
-        // to the client with the actual assessment test context. Maybe the client will be able to
-        // continue...
-        $this->afterAction();
 	}
     
 	/**
 	 * Action to end test session
 	 */
 	public function endTestSession() {
-	    $this->beforeAction();
-        $session = $this->getTestSession();
-        $sessionId = $session->getSessionId();
-        
-        common_Logger::i("The user has requested termination of the test session '{$sessionId}'");
-	    $session->endTestSession();
-        
-        $this->afterAction();
+        if ($this->beforeAction()) {
+            $session = $this->getTestSession();
+            $sessionId = $session->getSessionId();
+
+            common_Logger::i("The user has requested termination of the test session '{$sessionId}'");
+            $session->endTestSession();
+
+            $this->afterAction();
+        }
 	}
 
 	/**
@@ -631,76 +687,74 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	 */
 	public function storeItemVariableSet()
 	{
-	    $this->beforeAction();
-	    
-	    // --- Deal with provided responses.
-	    $jsonPayload = taoQtiCommon_helpers_Utils::readJsonPayload();
+        if ($this->beforeAction()) {
 
-	    $responses = new State();
-	    $currentItem = $this->getTestSession()->getCurrentAssessmentItemRef();
-	    $currentOccurence = $this->getTestSession()->getCurrentAssessmentItemRefOccurence();
-	    
-	    if ($currentItem === false) {
-	        $msg = "Trying to store item variables but the state of the test session is INITIAL or CLOSED.\n";
-	        $msg .= "Session state value: " . $this->getTestSession()->getState() . "\n";
-	        $msg .= "Session ID: " . $this->getTestSession()->getSessionId() . "\n";
-	        $msg .= "JSON Payload: " . mb_substr(json_encode($jsonPayload), 0, 1000);
-	        common_Logger::e($msg);
-	    }
-	    
-	    $filler = new taoQtiCommon_helpers_PciVariableFiller($currentItem);
-	    
-        if (is_array($jsonPayload)) {
-    	    foreach ($jsonPayload as $id => $response) {
-    	        try {
-    	            $var = $filler->fill($id, $response);
-    	            // Do not take into account QTI File placeholders.
-    	            if (taoQtiCommon_helpers_Utils::isQtiFilePlaceHolder($var) === false) {
-    	                $responses->setVariable($var);
-    	            }
-    	        }
-    	        catch (OutOfRangeException $e) {
-    	            common_Logger::d("Could not convert client-side value for variable '${id}'.");
-    	        }
-    	        catch (OutOfBoundsException $e) {
-    	            common_Logger::d("Could not find variable with identifier '${id}' in current item.");
-    	        }
-    	    }
-        } else {
-            common_Logger::e('Invalid json payload');
+            // --- Deal with provided responses.
+            $jsonPayload = taoQtiCommon_helpers_Utils::readJsonPayload();
+
+            $responses = new State();
+            $currentItem = $this->getTestSession()->getCurrentAssessmentItemRef();
+            $currentOccurence = $this->getTestSession()->getCurrentAssessmentItemRefOccurence();
+
+            if ($currentItem === false) {
+                $msg = "Trying to store item variables but the state of the test session is INITIAL or CLOSED.\n";
+                $msg .= "Session state value: " . $this->getTestSession()->getState() . "\n";
+                $msg .= "Session ID: " . $this->getTestSession()->getSessionId() . "\n";
+                $msg .= "JSON Payload: " . mb_substr(json_encode($jsonPayload), 0, 1000);
+                common_Logger::e($msg);
+            }
+
+            $filler = new taoQtiCommon_helpers_PciVariableFiller($currentItem);
+
+            if (is_array($jsonPayload)) {
+                foreach ($jsonPayload as $id => $response) {
+                    try {
+                        $var = $filler->fill($id, $response);
+                        // Do not take into account QTI File placeholders.
+                        if (taoQtiCommon_helpers_Utils::isQtiFilePlaceHolder($var) === false) {
+                            $responses->setVariable($var);
+                        }
+                    } catch (OutOfRangeException $e) {
+                        common_Logger::d("Could not convert client-side value for variable '${id}'.");
+                    } catch (OutOfBoundsException $e) {
+                        common_Logger::d("Could not find variable with identifier '${id}' in current item.");
+                    }
+                }
+            } else {
+                common_Logger::e('Invalid json payload');
+            }
+
+            $displayFeedback = $this->getTestSession()->getCurrentSubmissionMode() !== SubmissionMode::SIMULTANEOUS;
+            $stateOutput = new taoQtiCommon_helpers_PciStateOutput();
+
+            try {
+                common_Logger::i('Responses sent from the client-side. The Response Processing will take place.');
+                $this->getTestSession()->endAttempt($responses, true);
+
+                // Return the item session state to the client side.
+                $itemSession = $this->getTestSession()->getAssessmentItemSessionStore()->getAssessmentItemSession($currentItem, $currentOccurence);
+
+                foreach ($itemSession->getAllVariables() as $var) {
+                    $stateOutput->addVariable($var);
+                }
+
+                $itemCompilationDirectory = $this->getDirectory($this->getRequestParameter('itemDataPath'));
+                $jsonReturn = array('success' => true,
+                    'displayFeedback' => $displayFeedback,
+                    'itemSession' => $stateOutput->getOutput(),
+                    'feedbacks' => array());
+
+                if ($displayFeedback === true) {
+                    $jsonReturn['feedbacks'] = QtiRunner::getFeedbacks($itemCompilationDirectory, $itemSession);
+                }
+
+                echo json_encode($jsonReturn);
+            } catch (AssessmentTestSessionException $e) {
+                $this->handleAssessmentTestSessionException($e);
+            }
+
+            $this->afterAction(false);
         }
-	    
-	    $displayFeedback = $this->getTestSession()->getCurrentSubmissionMode() !== SubmissionMode::SIMULTANEOUS;
-	    $stateOutput = new taoQtiCommon_helpers_PciStateOutput();
-	    
-	    try {
-	        common_Logger::i('Responses sent from the client-side. The Response Processing will take place.');
-	        $this->getTestSession()->endAttempt($responses, true);
-	         
-	        // Return the item session state to the client side.
-	        $itemSession = $this->getTestSession()->getAssessmentItemSessionStore()->getAssessmentItemSession($currentItem, $currentOccurence);
-	         
-	        foreach ($itemSession->getAllVariables() as $var) {
-	            $stateOutput->addVariable($var);
-	        }
-	        
-	        $itemCompilationDirectory = $this->getDirectory($this->getRequestParameter('itemDataPath'));
-	        $jsonReturn = array('success' => true,
-	                            'displayFeedback' => $displayFeedback,
-	                            'itemSession' => $stateOutput->getOutput(),
-	                            'feedbacks' => array());
-	        
-	        if ($displayFeedback === true) {
-	            $jsonReturn['feedbacks'] = QtiRunner::getFeedbacks($itemCompilationDirectory, $itemSession);
-	        }
-	         
-	        echo json_encode($jsonReturn);
-	    }
-	    catch (AssessmentTestSessionException $e) {
-	        $this->handleAssessmentTestSessionException($e);
-	    }
-	    
-	    $this->afterAction(false);
     }
     
     /**
@@ -708,26 +762,27 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      * 
      */
 	public function comment() {
-	    $this->beforeAction();
-	    $testSession = $this->getTestSession();
-	    
-	    $resultServer = taoResultServer_models_classes_ResultServerStateFull::singleton();
-	    $transmitter = new taoQtiCommon_helpers_ResultTransmitter($resultServer);
-	    
-	    // prepare transmission Id for result server.
-	    $item = $testSession->getCurrentAssessmentItemRef()->getIdentifier();
-	    $occurence = $testSession->getCurrentAssessmentItemRefOccurence();
-	    $sessionId = $testSession->getSessionId();
-	    $transmissionId = "${sessionId}.${item}.${occurence}";
-	    
-	    // retrieve comment's intrinsic value.
-	    $comment = $this->getRequestParameter('comment');
-	    
-	    // build variable and send it.
-	    $itemUri = taoQtiTest_helpers_TestRunnerUtils::getCurrentItemUri($testSession);
-	    $testUri = $testSession->getTest()->getUri();
-	    $variable = new ResponseVariable('comment', Cardinality::SINGLE, BaseType::STRING, new String($comment));
-	    $transmitter->transmitItemVariable($variable, $transmissionId, $itemUri, $testUri);
+        if ($this->beforeAction()) {
+            $testSession = $this->getTestSession();
+
+            $resultServer = taoResultServer_models_classes_ResultServerStateFull::singleton();
+            $transmitter = new taoQtiCommon_helpers_ResultTransmitter($resultServer);
+
+            // prepare transmission Id for result server.
+            $item = $testSession->getCurrentAssessmentItemRef()->getIdentifier();
+            $occurence = $testSession->getCurrentAssessmentItemRefOccurence();
+            $sessionId = $testSession->getSessionId();
+            $transmissionId = "${sessionId}.${item}.${occurence}";
+
+            // retrieve comment's intrinsic value.
+            $comment = $this->getRequestParameter('comment');
+
+            // build variable and send it.
+            $itemUri = taoQtiTest_helpers_TestRunnerUtils::getCurrentItemUri($testSession);
+            $testUri = $testSession->getTest()->getUri();
+            $variable = new ResponseVariable('comment', Cardinality::SINGLE, BaseType::STRING, new String($comment));
+            $transmitter->transmitItemVariable($variable, $transmissionId, $itemUri, $testUri);
+        }
 	}
 	
 	/**

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -329,6 +329,9 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 	                                                                          $this->getRequestParameter('QtiTestCompilation'),
 	                                                                          $this->getRequestParameter('standalone'),
 	                                                                          $this->getCompilationDirectory());
+
+        // add a flag to allow distinction with error responses
+        $ctx['success'] = true;
 	    
         // Put the assessment test context in request data.
 	    $this->setData('assessmentTestContext', $ctx);

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -120,13 +120,14 @@ class taoQtiTest_helpers_TestRunnerUtils {
      * Set the initial outcomes defined in the rdf outcome map configuration file
      *
      * @param AssessmentTestSession $session
+     * @param \oat\oatbox\user\User $testTaker
      * @throws common_exception_Error
      * @throws common_ext_ExtensionException
      */
-    public static function setInitialOutcomes(AssessmentTestSession $session){
+    public static function setInitialOutcomes(AssessmentTestSession $session, \oat\oatbox\user\User $testTaker)
+    {
         $rdfOutcomeMap = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('rdfOutcomeMap');
         if(is_array($rdfOutcomeMap)){
-            $testTaker = \common_session_SessionManager::getSession()->getUser();
             foreach($rdfOutcomeMap as $outcomeId => $rdfPropUri){
                 //set outcome value
                 $values = $testTaker->getPropertyValues($rdfPropUri);
@@ -135,6 +136,22 @@ class taoQtiTest_helpers_TestRunnerUtils {
                     $outcome->setValue(new String($values[0]));
                 }
             }
+        }
+    }
+
+    /**
+     * Preserve the outcomes variables set in the "rdfOutcomeMap" config
+     * This is required to prevent those special outcomes from being reset before every outcome processing
+     *
+     * @param AssessmentTestSession $session
+     * @throws common_ext_ExtensionException
+     */
+    public static function preserveOutcomes(AssessmentTestSession $session)
+    {
+        //preserve the special outcomes defined in the rdfOutcomeMap config
+        $rdfOutcomeMap = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('rdfOutcomeMap');
+        if (is_array($rdfOutcomeMap) === true) {
+            $session->setPreservedOutcomeVariables(array_keys($rdfOutcomeMap));
         }
     }
     

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -524,6 +524,9 @@ class taoQtiTest_helpers_TestRunnerUtils {
                 }
             }
         }
+
+        // add a flag to allow distinction with error responses
+        $context['success'] = true;
         
         return $context;
     }

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -525,9 +525,6 @@ class taoQtiTest_helpers_TestRunnerUtils {
             }
         }
 
-        // add a flag to allow distinction with error responses
-        $context['success'] = true;
-        
         return $context;
     }
         

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -115,6 +115,28 @@ class taoQtiTest_helpers_TestRunnerUtils {
 	    $occurence = $session->getCurrentAssessmentItemRefOccurence();
 	    return "${sessionId}.${itemId}.${occurence}";
     }
+
+    /**
+     * Set the initial outcomes defined in the rdf outcome map configuration file
+     *
+     * @param AssessmentTestSession $session
+     * @throws common_exception_Error
+     * @throws common_ext_ExtensionException
+     */
+    public static function setInitialOutcomes(AssessmentTestSession $session){
+        $rdfOutcomeMap = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('rdfOutcomeMap');
+        if(is_array($rdfOutcomeMap)){
+            $testTaker = \common_session_SessionManager::getSession()->getUser();
+            foreach($rdfOutcomeMap as $outcomeId => $rdfPropUri){
+                //set outcome value
+                $values = $testTaker->getPropertyValues($rdfPropUri);
+                $outcome = $session->getVariable($outcomeId);
+                if(!is_null($outcome) && count($values)){
+                    $outcome->setValue(new String($values[0]));
+                }
+            }
+        }
+    }
     
     /**
      * Whether or not the current Assessment Item to be presented to the candidate is timed-out. By timed-out

--- a/views/js/ResultServerApi.js
+++ b/views/js/ResultServerApi.js
@@ -37,7 +37,7 @@ define(['jquery', 'i18n', 'iframeNotifier'], function($, __, iframeNotifier) {
             //there is no error management, so doing an alert (an eval and I'll burn in hell...)
             //TODO manage errors during the delivery
             if (response && response.message) {
-                if (response.code === TEST_STATE_CLOSED && response.code === TEST_STATE_SUSPENDED) {
+                if (response.code === TEST_STATE_CLOSED || response.code === TEST_STATE_SUSPENDED) {
                     message = false;
                 } else {
                     message = response.message;

--- a/views/js/ResultServerApi.js
+++ b/views/js/ResultServerApi.js
@@ -1,4 +1,8 @@
-define(['jquery', 'iframeNotifier'], function($, iframeNotifier) {
+define(['jquery', 'i18n', 'iframeNotifier'], function($, __, iframeNotifier) {
+
+    // Constants
+    var TEST_STATE_SUSPENDED = 3,
+        TEST_STATE_CLOSED = 4;
 
     function ResultServerApi(endpoint, params) {
 
@@ -22,11 +26,26 @@ define(['jquery', 'iframeNotifier'], function($, iframeNotifier) {
     ResultServerApi.prototype.submitItemVariables = function(itemId, serviceCallId, responses, scores, events, params, callback) {
 
         var that = this;
-        var error = function error(){
+        var error = function error(xhr){
+            var response;
+            var message = __('An error occurs, please contact your administrator');
+
+            if (xhr) {
+                try { response = JSON.parse(xhr.responseText); } catch (e) {}
+            }
+
             //there is no error management, so doing an alert (an eval and I'll burn in hell...)
             //TODO manage errors during the delivery
-            alert('An error occurs, please contact your administrator');
-
+            if (response && response.message) {
+                if (response.code === TEST_STATE_CLOSED && response.code === TEST_STATE_SUSPENDED) {
+                    message = false;
+                } else {
+                    message = response.message;
+                }
+            }
+            if (message) {
+                alert(message);
+            }
             iframeNotifier.parent('unloading');
             callback(0);
         };
@@ -50,7 +69,7 @@ define(['jquery', 'iframeNotifier'], function($, iframeNotifier) {
             type : 'post',
             contentType : 'application/json',
             dataType : 'json',
-            success : function(reply){
+            success : function(reply, status, xhr){
 
                 var qtiRunner,
                     fbCount = 0;
@@ -70,7 +89,7 @@ define(['jquery', 'iframeNotifier'], function($, iframeNotifier) {
                     }
 
                 }else{
-                    error();
+                    error(xhr);
                 }
             },
             error : error

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -1003,12 +1003,11 @@ function (
                                 self.afterTransition();
                                 dialog({
                                     message: testContext.message,
-                                    buttons: 'ok'
-                                })
-                                    .on('okbtn', function () {
+                                    buttons: 'ok',
+                                    onokbtn: function () {
                                         self.serviceApi.finish();
-                                    })
-                                    .show();
+                                    }
+                                }).show();
                             }
                             else if (testContext.state === self.TEST_STATE_CLOSED) {
                                 self.serviceApi.finish();

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -1005,7 +1005,7 @@ function (
                 this.beforeTransition();
 
                 // ask the parent to display a message
-                iframeNotifier.parent('alertMessage', {
+                iframeNotifier.parent('messagealert', {
                     message : error.message,
                     action : function() {
                         if (testMetaData) {

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -20,6 +20,7 @@
 define([
     'jquery',
     'lodash',
+    'i18n',
     'module',
     'taoQtiTest/testRunner/actionBarTools',
     'taoQtiTest/testRunner/testReview',
@@ -29,17 +30,36 @@ define([
     'serviceApi/UserInfoService',
     'serviceApi/StateStorage',
     'iframeNotifier',
-    'i18n',
     'mathJax',
     'ui/feedback',
     'ui/deleter',
     'moment',
     'ui/modal',
+    'ui/dialog',
     'ui/progressbar'
 ],
-    function ($, _, module, actionBarTools, testReview, progressUpdater, testMetaDataFactory, ServiceApi, UserInfoService, StateStorage, iframeNotifier, __, MathJax, feedback, deleter, moment, modal) {
+function (
+    $,
+    _,
+    __,
+    module,
+    actionBarTools,
+    testReview,
+    progressUpdater,
+    testMetaDataFactory,
+    ServiceApi,
+    UserInfoService,
+    StateStorage,
+    iframeNotifier,
+    MathJax,
+    feedback,
+    deleter,
+    moment,
+    modal,
+    dialog
+) {
 
-        'use strict';
+    'use strict';
 
     var timerIds = [],
         currentTimes = [],
@@ -978,7 +998,19 @@ define([
                         dataType: 'json',
                         success: function (testContext) {
                             testMetaData.clearData();
-                            if (testContext.state === self.TEST_STATE_CLOSED) {
+
+                            if (!testContext.success) {
+                                self.afterTransition();
+                                dialog({
+                                    message: testContext.message,
+                                    buttons: 'ok'
+                                })
+                                    .on('okbtn', function () {
+                                        self.serviceApi.finish();
+                                    })
+                                    .show();
+                            }
+                            else if (testContext.state === self.TEST_STATE_CLOSED) {
                                 self.serviceApi.finish();
                             }
                             else {

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -1005,7 +1005,7 @@ function (
                 this.beforeTransition();
 
                 // ask the parent to display a message
-                iframeNotifier.parent('message', {
+                iframeNotifier.parent('alertMessage', {
                     message : error.message,
                     action : function() {
                         if (testMetaData) {

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -1004,10 +1004,12 @@ function (
                                 dialog({
                                     message: testContext.message,
                                     buttons: 'ok',
-                                    onokbtn: function () {
+                                    autoRender: true,
+                                    autoDestroy: true,
+                                    onOkBtn: function () {
                                         self.serviceApi.finish();
                                     }
-                                }).show();
+                                });
                             }
                             else if (testContext.state === self.TEST_STATE_CLOSED) {
                                 self.serviceApi.finish();

--- a/views/js/testRunner/resumingStrategy/keepAfterResume.js
+++ b/views/js/testRunner/resumingStrategy/keepAfterResume.js
@@ -33,12 +33,12 @@ define([], function () {
         var sessionState = {
 
             reset: function reset() {
-                reset();
+                _reset();
             },
 
             restart: function restart() {
-                reset();
-                start();
+                _reset();
+                _start();
             },
 
             getDuration: function getDuration() {
@@ -46,7 +46,7 @@ define([], function () {
             }
         };
 
-        function start() {
+        function _start() {
             if (null !== _interval) {
                 throw new TypeError('Tracking is already started');
             }
@@ -55,21 +55,21 @@ define([], function () {
             }, _accuracy);
         }
 
-        function stop() {
+        function _stop() {
             clearInterval(_interval);
             _interval = null;
         }
 
-        function reset() {
-            stop();
+        function _reset() {
+            _stop();
             clearLocalStorage();
         }
 
-        function init() {
-            _accuracy = options.accuracy || 1000;
+        function _init() {
+            _accuracy = options && options.accuracy || 1000;
         }
 
-        init();
+        _init();
 
         /**
          * Store duration in ms to local storage

--- a/views/js/testRunner/resumingStrategy/resetAfterResume.js
+++ b/views/js/testRunner/resumingStrategy/resetAfterResume.js
@@ -33,7 +33,7 @@ define(['taoQtiTest/testRunner/resumingStrategy/keepAfterResume'], function (kee
 
             reset: function reset() {
                 //cleanup data if other strategy was in use before
-                keepAfterResume.reset();
+                keepAfterResume().reset();
             },
 
             restart: function restart() {


### PR DESCRIPTION
Related to:
- https://oat-sa.atlassian.net/browse/TAO-1775
- https://oat-sa.atlassian.net/browse/TAO-1773

Requires: https://github.com/oat-sa/extension-tao-delivery/pull/133

Catch error messages and display them.