### PR TITLE
bug fix for taoQtiTest import

### DIFF
--- a/helpers/class.Utils.php
+++ b/helpers/class.Utils.php
@@ -180,7 +180,7 @@ class taoQtiTest_helpers_Utils {
         $basePath = helpers_File::truePath($basePath);
         $basePath .= DIRECTORY_SEPARATOR;
         
-        $documentURI = preg_replace('/^file:\/{3}/', '', $test->getDomDocument()->documentURI);
+        $documentURI = preg_replace("|^file:/+|", '', $test->getDomDocument()->documentURI);
         $testPathInfo = pathinfo($documentURI);
         $testBasePath = tao_helpers_File::truePath($testPathInfo['dirname']) . DIRECTORY_SEPARATOR;
         

--- a/helpers/class.Utils.php
+++ b/helpers/class.Utils.php
@@ -180,7 +180,7 @@ class taoQtiTest_helpers_Utils {
         $basePath = helpers_File::truePath($basePath);
         $basePath .= DIRECTORY_SEPARATOR;
         
-        $documentURI = preg_replace("|^file:/+|", '', $test->getDomDocument()->documentURI);
+        $documentURI = preg_replace("/^file:\/{1,3}/", '', $test->getDomDocument()->documentURI);
         $testPathInfo = pathinfo($documentURI);
         $testBasePath = tao_helpers_File::truePath($testPathInfo['dirname']) . DIRECTORY_SEPARATOR;
         


### PR DESCRIPTION
Windows 10 Pro x64
```
XmlDocument->getDomDocument()->documentUri
``` 
in path returns "file:/" instead of the expected "file:///" 

Test it doesn't break existing taoQtiTest import (for example QtiPackage.zip)
Test if the related unit tests are still running