### PR TITLE
Tao 1906 runner proxy

### DIFF
--- a/views/js/runner/config/qtiServiceConfig.js
+++ b/views/js/runner/config/qtiServiceConfig.js
@@ -1,0 +1,155 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'helpers'
+], function(_, helpers) {
+    'use strict';
+
+    /**
+     * Some default config values
+     * @type {Object}
+     * @private
+     */
+    var _defaults = {
+        serviceController : 'Runner',
+        serviceExtension : 'taoQtiTest'
+    };
+
+    /**
+     * The list of handled config entries. Each required entry is set to true, while optional entries are set to false.
+     * @type {Object}
+     * @private
+     */
+    var _entries = {
+        testDefinition : true,
+        testCompilation : true,
+        serviceCallId : true,
+        serviceController : false,
+        serviceExtension : false
+    };
+
+    /**
+     * Extract the handled config entries.
+     * @param {Object} config
+     * @returns {Object}
+     * @throws Error if a required entry is missing
+     */
+    function getConfig(config) {
+        var storage = {};
+        _.forEach(_entries, function(value, name) {
+           if ('undefined' !== typeof config[name]) {
+               storage[name] = config[name];
+           } else if (value) {
+               throw new Error('The config entry "' + name + '" is required!');
+           }
+        });
+        return _.defaults(storage, _defaults);
+    }
+
+    /**
+     * Creates a config object for the proxy implementation
+     * @param {Object} config - Some required and optional config
+     * @param {String} config.testDefinition - The URI of the test
+     * @param {String} config.testCompilation - The URI of the compiled delivery
+     * @param {String} config.serviceCallId - The URI of the service call
+     * @param {String} [config.serviceController] - The name of the service controller
+     * @param {String} [config.serviceExtension] - The name of the extension containing the service controller
+     * @returns {Object}
+     */
+    function configFactory(config) {
+        // protected storage
+        var storage = getConfig(config);
+
+        // returns only a proxy storage object : no direct access to data is provided
+        return {
+            /**
+             * Gets the URI of the test
+             * @returns {String}
+             */
+            getTestDefinition : function getTestDefinition() {
+                return storage.testDefinition;
+            },
+
+            /**
+             * Gets the URI of the compiled delivery
+             * @returns {String}
+             */
+            getTestCompilation : function getTestCompilation() {
+                return storage.testCompilation;
+            },
+
+            /**
+             * Gets the URI of the service call
+             * @returns {String}
+             */
+            getServiceCallId : function getServiceCallId() {
+                return storage.serviceCallId;
+            },
+
+            /**
+             * Gets the name of the service controller
+             * @returns {String}
+             */
+            getServiceController : function getServiceController() {
+                return storage.serviceController;
+            },
+
+            /**
+             * Gets the name of the extension containing the service controller
+             * @returns {String}
+             */
+            getServiceExtension : function getServiceExtension() {
+                return storage.serviceExtension;
+            },
+
+            /**
+             * Gets an URL of a service action related to the test
+             * @param {String} action - the name of the action to request
+             * @returns {String} - Returns the URL
+             */
+            getTestActionUrl : function getTestActionUrl(action) {
+                return helpers._url(action, this.getServiceController(), this.getServiceExtension(), {
+                    testDefinition : this.getTestDefinition(),
+                    testCompilation : this.getTestCompilation(),
+                    serviceCallId : this.getServiceCallId()
+                });
+            },
+
+            /**
+             * Gets an URL of a service action related to a particular item
+             * @param {String} uri - The URI of the item
+             * @param {String} action - the name of the action to request
+             * @returns {String} - Returns the URL
+             */
+            getItemActionUrl : function getItemActionUrl(uri, action) {
+                return helpers._url(action, this.getServiceController(), this.getServiceExtension(), {
+                    testDefinition : this.getTestDefinition(),
+                    testCompilation : this.getTestCompilation(),
+                    testServiceCallId : this.getServiceCallId(),
+                    itemDefinition : uri
+                });
+            }
+        }
+    }
+
+    return configFactory;
+});

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -43,21 +43,17 @@ define([
                 data: params,
                 async: true,
                 dataType: 'json'
-            }).then(
-                // success
-                function(data) {
-                    if (data && data.success) {
-                        resolve(data);
-                    } else {
-                        reject(false);
-                    }
-                },
-
-                // error
-                function(jqXHR) {
-                    reject(jqXHR);
+            })
+            .done(function(data) {
+                if (data && data.success) {
+                    resolve(data);
+                } else {
+                    reject(false);
                 }
-            );
+            })
+            .fail(function(jqXHR) {
+                reject(jqXHR);
+            });
         });
     }
 

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -1,0 +1,266 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'core/promise',
+    'helpers'
+], function($, _, Promise, helpers) {
+    'use strict';
+
+    /**
+     * Proxy request function. Returns a promise
+     * Applied options: asynchronous call, JSON data, no cache
+     * @param {String} url
+     * @param {Object} [params]
+     * @returns {Promise}
+     */
+    function request(url, params) {
+        return new Promise(function(resolve, reject) {
+            $.ajax({
+                url: url,
+                type: params ? 'POST' : 'GET',
+                cache: false,
+                data: params,
+                async: true,
+                dataType: 'json'
+            }).then(
+                // success
+                function(data) {
+                    if (data && data.success) {
+                        resolve(data);
+                    } else {
+                        reject(false);
+                    }
+                },
+
+                // error
+                function(jqXHR) {
+                    reject(jqXHR);
+                }
+            );
+        });
+    }
+
+
+    /**
+     * Extract and validate a required config property. If the property is not set, throws an error.
+     * @param {Object} config
+     * @param {String} property
+     * @returns {*}
+     * @throws Error
+     */
+    function getRequired(config, property) {
+        var value = config[property];
+        if (!value) {
+            throw new Error('The config entry "' + property + '" is required!');
+        }
+        return value;
+    }
+
+    /**
+     * Creates a storage object for test
+     * @param {Object} config - Some required and optional config
+     * @param {String} config.testDefinition - The URI of the test
+     * @param {String} config.testCompilation - The URI of the compiled delivery
+     * @param {String} config.serviceCallId - The URI of the service call
+     * @param {String} [config.serviceController] - The name of the service controller
+     * @param {String} [config.serviceExtension] - The name of the service extension
+     * @returns {Object}
+     */
+    function storageFactory(config) {
+        // protected storage
+        var storage = {
+            testDefinition : getRequired(config, 'testDefinition'),
+            testCompilation : getRequired(config, 'testCompilation'),
+            serviceCallId : getRequired(config, 'serviceCallId'),
+            serviceController : config.serviceController || 'Runner',
+            serviceExtension : config.serviceExtension || null
+        };
+
+        // returns only a proxy storage object : no direct access to data is provided
+        return {
+            getTestDefinition : function getTestDefinition() {
+                return storage.testDefinition;
+            },
+
+            getTestCompilation : function getTestCompilation() {
+                return storage.testCompilation;
+            },
+
+            getServiceCallId : function getServiceCallId() {
+                return storage.serviceCallId;
+            },
+
+            getServiceController : function getServiceController() {
+                return storage.serviceController;
+            },
+
+            getServiceExtension : function getServiceExtension() {
+                return storage.serviceExtension;
+            },
+
+            getTestActionUrl : function getTestActionUrl(action) {
+                return helpers._url(action, this.getServiceController(), this.getServiceExtension(), {
+                    testDefinition : this.getTestDefinition(),
+                    testCompilation : this.getTestCompilation(),
+                    serviceCallId : this.getServiceCallId()
+                });
+            },
+
+            getItemActionUrl : function getTestActionUrl(uri, action) {
+                return helpers._url(action, this.getServiceController(), this.getServiceExtension(), {
+                    testDefinition : this.getTestDefinition(),
+                    testCompilation : this.getTestCompilation(),
+                    testServiceCallId : this.getServiceCallId(),
+                    itemDefinition : uri
+                });
+            }
+        }
+    }
+
+    /**
+     * QTI proxy definition
+     * Related to remote services calls
+     * @type {Object}
+     */
+    var qtiServiceProxy = {
+        /**
+         * Initializes the proxy
+         * @param {Object} config - The config provided to the proxy factory
+         * @param {String} config.testDefinition - The URI of the test
+         * @param {String} config.testCompilation - The URI of the compiled delivery
+         * @param {String} config.serviceCallId - The URI of the service call
+         * @returns {Promise} - Returns a promise. The proxy will be fully initialized on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        init: function init(config) {
+            var initConfig = config || {};
+
+            // store config in a dedicated storage
+            this.storage = storageFactory(initConfig);
+
+            // request for initialization
+            return request(this.storage.getTestActionUrl('init'));
+        },
+
+        /**
+         * Uninstalls the proxy
+         * @returns {Promise} - Returns a promise. The proxy will be fully uninstalled on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        destroy: function destroy() {
+            var self = this;
+            // the method must return a promise
+            return new Promise(function(resolve) {
+                // no request, just a resources cleaning
+                self.storage = null;
+                resolve();
+            });
+        },
+
+        /**
+         * Gets the test definition data
+         * @returns {Promise} - Returns a promise. The test definition data will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        getTestData: function getTestData() {
+            return request(this.storage.getTestActionUrl('getTestData'));
+        },
+
+        /**
+         * Gets the test context
+         * @returns {Promise} - Returns a promise. The context object will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        getTestContext: function getTestContext() {
+            return request(this.storage.getTestActionUrl('getTestContext'));
+        },
+
+        /**
+         * Calls an action related to the test
+         * @param {String} action - The name of the action to call
+         * @param {Object} [params] - Some optional parameters to join to the call
+         * @returns {Promise} - Returns a promise. The result of the request will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        callTestAction: function callTestAction(action, params) {
+            return request(this.storage.getTestActionUrl(action), params);
+        },
+
+        /**
+         * Gets an item definition by its URI
+         * @param string uri - The URI of the item to get
+         * @returns {Promise} - Returns a promise. The item definition data will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         * @fires getItemData
+         */
+        getItemData: function getItemData(uri) {
+            return request(this.storage.getItemActionUrl(uri, 'getItemData'));
+        },
+
+        /**
+         * Gets an item state by the item URI
+         * @param string uri - The URI of the item for which get the state
+         * @returns {Promise} - Returns a promise. The item state object will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        getItemState: function getItemState(uri) {
+            return request(this.storage.getItemActionUrl(uri, 'getItemState'));
+        },
+
+        /**
+         * Submits the state of a particular item
+         * @param {String} uri - The URI of the item to update
+         * @param {Object} state - The state to submit
+         * @returns {Promise} - Returns a promise. The result of the request will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        submitItemState: function submitItemState(uri, state) {
+            return request(this.storage.getItemActionUrl(uri, 'submitItemState'), state);
+        },
+
+        /**
+         * Stores the response for a particular item
+         * @param {String} uri - The URI of the item to update
+         * @param {Object} response - The response object to submit
+         * @returns {Promise} - Returns a promise. The result of the request will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        storeItemResponse: function storeItemResponse(uri, response) {
+            return request(this.storage.getItemActionUrl(uri, 'storeItemResponse'), response);
+        },
+
+        /**
+         * Calls an action related to a particular item
+         * @param {String} uri - The URI of the item for which call the action
+         * @param {String} action - The name of the action to call
+         * @param {Object} [params] - Some optional parameters to join to the call
+         * @returns {Promise} - Returns a promise. The result of the request will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        callItemAction: function callItemAction(uri, action, params) {
+            return request(this.storage.getItemActionUrl(uri, action), params);
+        }
+    };
+
+    return qtiServiceProxy;
+});

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -132,7 +132,7 @@ define([
 
         /**
          * Gets an item definition by its URI
-         * @param string uri - The URI of the item to get
+         * @param {String} uri - The URI of the item to get
          * @returns {Promise} - Returns a promise. The item definition data will be provided on resolve.
          *                      Any error will be provided if rejected.
          * @fires getItemData
@@ -143,7 +143,7 @@ define([
 
         /**
          * Gets an item state by the item URI
-         * @param string uri - The URI of the item for which get the state
+         * @param {String} uri - The URI of the item for which get the state
          * @returns {Promise} - Returns a promise. The item state object will be provided on resolve.
          *                      Any error will be provided if rejected.
          */

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -22,8 +22,9 @@ define([
     'jquery',
     'lodash',
     'core/promise',
-    'helpers'
-], function($, _, Promise, helpers) {
+    'helpers',
+    'taoQtiTest/runner/config/qtiServiceConfig'
+], function($, _, Promise, helpers, configFactory) {
     'use strict';
 
     /**
@@ -60,83 +61,6 @@ define([
         });
     }
 
-
-    /**
-     * Extract and validate a required config property. If the property is not set, throws an error.
-     * @param {Object} config
-     * @param {String} property
-     * @returns {*}
-     * @throws Error
-     */
-    function getRequired(config, property) {
-        var value = config[property];
-        if (!value) {
-            throw new Error('The config entry "' + property + '" is required!');
-        }
-        return value;
-    }
-
-    /**
-     * Creates a storage object for test
-     * @param {Object} config - Some required and optional config
-     * @param {String} config.testDefinition - The URI of the test
-     * @param {String} config.testCompilation - The URI of the compiled delivery
-     * @param {String} config.serviceCallId - The URI of the service call
-     * @param {String} [config.serviceController] - The name of the service controller
-     * @param {String} [config.serviceExtension] - The name of the service extension
-     * @returns {Object}
-     */
-    function storageFactory(config) {
-        // protected storage
-        var storage = {
-            testDefinition : getRequired(config, 'testDefinition'),
-            testCompilation : getRequired(config, 'testCompilation'),
-            serviceCallId : getRequired(config, 'serviceCallId'),
-            serviceController : config.serviceController || 'Runner',
-            serviceExtension : config.serviceExtension || null
-        };
-
-        // returns only a proxy storage object : no direct access to data is provided
-        return {
-            getTestDefinition : function getTestDefinition() {
-                return storage.testDefinition;
-            },
-
-            getTestCompilation : function getTestCompilation() {
-                return storage.testCompilation;
-            },
-
-            getServiceCallId : function getServiceCallId() {
-                return storage.serviceCallId;
-            },
-
-            getServiceController : function getServiceController() {
-                return storage.serviceController;
-            },
-
-            getServiceExtension : function getServiceExtension() {
-                return storage.serviceExtension;
-            },
-
-            getTestActionUrl : function getTestActionUrl(action) {
-                return helpers._url(action, this.getServiceController(), this.getServiceExtension(), {
-                    testDefinition : this.getTestDefinition(),
-                    testCompilation : this.getTestCompilation(),
-                    serviceCallId : this.getServiceCallId()
-                });
-            },
-
-            getItemActionUrl : function getTestActionUrl(uri, action) {
-                return helpers._url(action, this.getServiceController(), this.getServiceExtension(), {
-                    testDefinition : this.getTestDefinition(),
-                    testCompilation : this.getTestCompilation(),
-                    testServiceCallId : this.getServiceCallId(),
-                    itemDefinition : uri
-                });
-            }
-        }
-    }
-
     /**
      * QTI proxy definition
      * Related to remote services calls
@@ -156,7 +80,7 @@ define([
             var initConfig = config || {};
 
             // store config in a dedicated storage
-            this.storage = storageFactory(initConfig);
+            this.storage = configFactory(initConfig);
 
             // request for initialization
             return request(this.storage.getTestActionUrl('init'));

--- a/views/js/test/runner/config/qtiServiceConfig/test.html
+++ b/views/js/test/runner/config/qtiServiceConfig/test.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>Test Runner - qtiServiceProxy</title>
+        <title>Test Runner - qtiServiceConfig</title>
         <base href="../../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="runner/proxy/qtiServiceProxy.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="runner/config/qtiServiceConfig.js"></script>
 
         <script  type="text/javascript">
 
@@ -19,7 +19,7 @@
             require(['/tao/ClientConfig/config'], function(){
 
                 //load the test
-                require(['taoQtiTest/test/runner/proxy/qtiServiceProxy/test'], function(){
+                require(['taoQtiTest/test/runner/config/qtiServiceConfig/test'], function(){
 
                     //Tests loaded, run tests
                     QUnit.start();

--- a/views/js/test/runner/config/qtiServiceConfig/test.js
+++ b/views/js/test/runner/config/qtiServiceConfig/test.js
@@ -1,0 +1,230 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'helpers',
+    'taoQtiTest/runner/config/qtiServiceConfig'
+], function(_, helpers, qtiServiceConfig) {
+    'use strict';
+
+    QUnit.module('qtiServiceConfig');
+
+
+    QUnit.test('module', 3, function(assert) {
+        var config = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+        };
+        assert.equal(typeof qtiServiceConfig, 'function', "The qtiServiceConfig module exposes a function");
+        assert.equal(typeof qtiServiceConfig(config), 'object', "The qtiServiceConfig factory produces an instance");
+        assert.notStrictEqual(qtiServiceConfig(config), qtiServiceConfig(config), "The qtiServiceConfig factory provides a different instance on each call");
+    });
+
+
+    // small coverage check to facilitate dev of unit tests
+    var coverage = {};
+    QUnit.moduleDone(function() {
+        _.forEach(proxyApi, function(api) {
+            if (!coverage[api.name]) {
+                console.log('Missing unit test for method qtiServiceConfig.' + api.name);
+            }
+        });
+    });
+
+
+    var proxyApi = [
+        { name : 'getTestDefinition', title : 'getTestDefinition' },
+        { name : 'getTestCompilation', title : 'getTestCompilation' },
+        { name : 'getServiceCallId', title : 'getServiceCallId' },
+        { name : 'getServiceController', title : 'getServiceController' },
+        { name : 'getServiceExtension', title : 'getServiceExtension' },
+        { name : 'getTestActionUrl', title : 'getTestActionUrl' },
+        { name : 'getItemActionUrl', title : 'getItemActionUrl' }
+    ];
+
+    QUnit
+        .cases(proxyApi)
+        .test('proxy API ', 1, function(data, assert) {
+            var config = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+            };
+            var instance = qtiServiceConfig(config);
+            assert.equal(typeof instance[data.name], 'function', 'The qtiServiceConfig instances expose a "' + data.title + '" function');
+        });
+
+
+    QUnit.test('qtiServiceConfig factory', 4, function(assert) {
+        qtiServiceConfig({
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+        });
+        assert.ok(true, 'The qtiServiceConfig() factory must not throw an exception when all the required config entries are provided');
+
+        assert.throws(function() {
+            qtiServiceConfig({
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+            });
+        }, 'The qtiServiceConfig() factory must throw an exception is the required config entry testDefinition is missing');
+
+        assert.throws(function() {
+            qtiServiceConfig({
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+            });
+        }, 'The qtiServiceConfig() factory must throw an exception is the required config entry testCompilation is missing');
+
+        assert.throws(function() {
+            qtiServiceConfig({
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123'
+            });
+        }, 'The qtiServiceConfig() factory must throw an exception is the required config entry serviceCallId is missing');
+    });
+
+
+    QUnit.test('qtiServiceConfig.getTestDefinition', 1, function(assert) {
+        var expectedTestDefinition = 'http://tao.dev/mockTestDefinition#123';
+        var config = {
+            testDefinition: expectedTestDefinition,
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+        };
+        var instance = qtiServiceConfig(config);
+        coverage.getTestDefinition = true;
+
+        assert.equal(instance.getTestDefinition(), expectedTestDefinition, 'The qtiServiceConfig.getTestDefinition() method has returned the expected value');
+    });
+
+
+    QUnit.test('qtiServiceConfig.getTestCompilation', 1, function(assert) {
+        var expectedTestCompilation = 'http://tao.dev/mockTestCompilation#123';
+        var config = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: expectedTestCompilation,
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+        };
+        var instance = qtiServiceConfig(config);
+        coverage.getTestCompilation = true;
+
+        assert.equal(instance.getTestCompilation(), expectedTestCompilation, 'The qtiServiceConfig.getTestCompilation() method has returned the expected value');
+    });
+
+
+    QUnit.test('qtiServiceConfig.getServiceCallId', 1, function(assert) {
+        var expectedServiceCallId = 'http://tao.dev/mockServiceCallId#123';
+        var config = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: expectedServiceCallId
+        };
+        var instance = qtiServiceConfig(config);
+        coverage.getServiceCallId = true;
+
+        assert.equal(instance.getServiceCallId(), expectedServiceCallId, 'The qtiServiceConfig.getServiceCallId() method has returned the expected value');
+    });
+
+
+    QUnit.test('qtiServiceConfig.getServiceController', 3, function(assert) {
+        var expectedServiceController = 'MockRunner';
+        var config = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+        };
+        var instance = qtiServiceConfig(config);
+        coverage.getServiceController = true;
+
+        assert.notEqual(instance.getServiceController(), expectedServiceController, 'The qtiServiceConfig.getServiceController() method must return the default value');
+        assert.ok(!!instance.getServiceController(), 'The qtiServiceConfig.getServiceController() method must not return a null value');
+
+        config.serviceController = expectedServiceController;
+        instance = qtiServiceConfig(config);
+        assert.equal(instance.getServiceController(), expectedServiceController, 'The qtiServiceConfig.getServiceController() method has returned the expected value');
+    });
+
+
+    QUnit.test('qtiServiceConfig.getServiceExtension', 3, function(assert) {
+        var expectedServiceExtension = 'MockExtension';
+        var config = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123'
+        };
+        var instance = qtiServiceConfig(config);
+        coverage.getServiceExtension = true;
+
+        assert.notEqual(instance.getServiceExtension(), expectedServiceExtension, 'The qtiServiceConfig.getServiceExtension() method must return the default value');
+        assert.ok(!!instance.getServiceExtension(), 'The qtiServiceConfig.getServiceExtension() method must not return a null value');
+
+        config.serviceExtension = expectedServiceExtension;
+        instance = qtiServiceConfig(config);
+        assert.equal(instance.getServiceExtension(), expectedServiceExtension, 'The qtiServiceConfig.getServiceExtension() method has returned the expected value');
+    });
+
+
+    QUnit.test('qtiServiceConfig.getTestActionUrl', 1, function(assert) {
+        var config = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+            serviceController: 'MockRunner',
+            serviceExtension: 'MockExtension'
+        };
+        var actionName = 'MockAction';
+        var expectedUrl = helpers._url(actionName, config.serviceController, config.serviceExtension, {
+            testDefinition : config.testDefinition,
+            testCompilation : config.testCompilation,
+            serviceCallId : config.serviceCallId
+        });
+        var instance = qtiServiceConfig(config);
+        coverage.getTestActionUrl = true;
+
+        assert.equal(instance.getTestActionUrl(actionName), expectedUrl, 'The qtiServiceConfig.getTestActionUrl() method has returned the expected value');
+    });
+
+
+    QUnit.test('qtiServiceConfig.getItemActionUrl', 1, function(assert) {
+        var itemUri = 'http://tao.dev/mockItem#123';
+        var config = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+            serviceController: 'MockRunner',
+            serviceExtension: 'MockExtension'
+        };
+        var actionName = 'MockAction';
+        var expectedUrl = helpers._url(actionName, config.serviceController, config.serviceExtension, {
+            testDefinition : config.testDefinition,
+            testCompilation : config.testCompilation,
+            testServiceCallId : config.serviceCallId,
+            itemDefinition : itemUri
+        });
+        var instance = qtiServiceConfig(config);
+        coverage.getItemActionUrl = true;
+
+        assert.equal(instance.getItemActionUrl(itemUri, actionName), expectedUrl, 'The qtiServiceConfig.getItemActionUrl() method has returned the expected value');
+    });
+});

--- a/views/js/test/runner/proxy/qtiServiceProxy/test.html
+++ b/views/js/test/runner/proxy/qtiServiceProxy/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner - qtiServiceProxyProxy</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="runner/proxy/qtiServiceProxy.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiTest/test/runner/proxy/qtiServiceProxy/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/proxy/qtiServiceProxy/test.js
+++ b/views/js/test/runner/proxy/qtiServiceProxy/test.js
@@ -30,6 +30,16 @@ define([
     QUnit.module('qtiServiceProxy');
 
 
+    // backup/restore ajax method between each test
+    var ajaxBackup;
+    QUnit.testStart(function() {
+        ajaxBackup = $.ajax;
+    });
+    QUnit.testDone(function() {
+        $.ajax = ajaxBackup;
+    });
+
+
     /**
      * A simple AJAX mock factory that fakes a successful ajax call.
      * To use it, just replace $.ajax with the returned value:

--- a/views/js/test/runner/proxy/qtiServiceProxy/test.js
+++ b/views/js/test/runner/proxy/qtiServiceProxy/test.js
@@ -1,0 +1,892 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'helpers',
+    'taoTests/runner/proxy',
+    'taoQtiTest/runner/proxy/qtiServiceProxy'
+], function($, _, helpers, proxyFactory, qtiServiceProxy) {
+    'use strict';
+
+    QUnit.module('qtiServiceProxy');
+
+
+    /**
+     * A simple AJAX mock factory that fakes a successful ajax call.
+     * To use it, just replace $.ajax with the returned value:
+     * <pre>$.ajax = ajaxMockSuccess(mockData);</pre>
+     * @param {*} response - The mock data used as response
+     * @param {Function} [validator] - An optional function called instead of the ajax method
+     * @returns {Function}
+     */
+    function ajaxMockSuccess(response, validator) {
+        var deferred = $.Deferred().resolve(response);
+        return function() {
+            validator && validator.apply(this, arguments);
+            return deferred.promise();
+        };
+    }
+
+
+    /**
+     * A simple AJAX mock factory that fakes a failing ajax call.
+     * To use it, just replace $.ajax with the returned value:
+     * <pre>$.ajax = ajaxMockError(mockData);</pre>
+     * @param {*} response - The mock data used as response
+     * @param {Function} [validator] - An optional function called instead of the ajax method
+     * @returns {Function}
+     */
+    function ajaxMockError(response, validator) {
+        var deferred = $.Deferred().reject(response);
+        return function() {
+            validator && validator.apply(this, arguments);
+            return deferred.promise();
+        };
+    }
+
+
+    QUnit.test('module', 6, function(assert) {
+        assert.equal(typeof qtiServiceProxy, 'object', "The qtiServiceProxy module exposes an object");
+        assert.equal(typeof proxyFactory, 'function', "The proxyFactory module exposes a function");
+        assert.equal(typeof proxyFactory.registerProxy, 'function', "The proxyFactory module exposes a registerProxy method");
+        assert.equal(typeof proxyFactory.getProxy, 'function', "The proxyFactory module exposes a getProxy method");
+
+        proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+        assert.equal(typeof proxyFactory('qtiServiceProxy'), 'object', "The proxyFactory factory has registered the qtiServiceProxy definition and produces an instance");
+        assert.notStrictEqual(proxyFactory('qtiServiceProxy'), proxyFactory('qtiServiceProxy'), "The proxyFactory factory provides a different instance of qtiServiceProxy on each call");
+    });
+
+
+    // small coverage check to facilitate dev of unit tests
+    var coverage = {};
+    QUnit.moduleDone(function() {
+        _.forEach(proxyApi, function(api) {
+            if (!coverage[api.name]) {
+                console.log('Missing unit test for method qtiServiceProxy.' + api.name);
+            }
+        });
+    });
+
+
+    var proxyApi = [
+        { name : 'init', title : 'init' },
+        { name : 'destroy', title : 'destroy' },
+        { name : 'getTestData', title : 'getTestData' },
+        { name : 'getTestContext', title : 'getTestContext' },
+        { name : 'callTestAction', title : 'callTestAction' },
+        { name : 'getItemData', title : 'getItemData' },
+        { name : 'getItemState', title : 'getItemState' },
+        { name : 'submitItemState', title : 'submitItemState' },
+        { name : 'storeItemResponse', title : 'storeItemResponse' },
+        { name : 'callItemAction', title : 'callItemAction' }
+    ];
+
+    QUnit
+        .cases(proxyApi)
+        .test('proxy API ', 1, function(data, assert) {
+            assert.equal(typeof qtiServiceProxy[data.name], 'function', 'The qtiServiceProxy definition exposes a "' + data.title + '" function');
+        });
+
+
+    var qtiServiceProxyInitChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        response: {
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyInitChecks)
+        .asyncTest('qtiServiceProxy.init ', 6, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url('init', initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                serviceCallId : initConfig.serviceCallId
+            });
+
+            coverage.init = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.on('init', function(promise, config) {
+                assert.ok(true, 'The proxy has fired the "init" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "init" event');
+                assert.equal(config, initConfig, 'The proxy has provided the config object through the "init" event');
+            });
+
+            var result = proxy.init();
+
+            assert.equal(typeof result, 'object', 'The proxy.init method has returned a promise');
+
+            result
+                .then(function(data) {
+                    if (caseData.success) {
+                        assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                    } else {
+                        assert.ok(false, 'The proxy must throw an error!');
+                    }
+                    QUnit.start();
+                })
+                .catch(function(err) {
+                    assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                    QUnit.start();
+                });
+        });
+
+
+    QUnit.asyncTest('qtiServiceProxy.destroy', 4, function(assert) {
+        var initConfig = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+            serviceController: 'MockRunner',
+            serviceExtension: 'taoRunnerMock'
+        };
+
+        coverage.destroy = true;
+
+        proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+        $.ajax = ajaxMockSuccess({success: true});
+
+        var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+        proxy.init();
+
+        $.ajax = ajaxMockError(false, function() {
+            assert.ok(false, 'The proxy must not use an ajax request to destroy the instance!');
+        });
+
+        proxy.on('destroy', function(promise) {
+            assert.ok(true, 'The proxyFactory has fired the "destroy" event');
+            assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "destroy" event');
+        });
+
+        var result = proxy.destroy();
+
+        assert.equal(typeof result, 'object', 'The proxy.destroy method has returned a promise');
+
+        result
+            .then(function() {
+                assert.ok(true, 'The proxy has resolved the promise provided by the "destroy" method!');
+                QUnit.start();
+            })
+            .catch(function() {
+                assert.ok(false, 'The proxy cannot reject the promise provided by the "destroy" method!');
+                QUnit.start();
+            });
+    });
+
+
+    var qtiServiceProxyGetTestDataChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        response: {
+            title: 'MyTest',
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyGetTestDataChecks)
+        .asyncTest('qtiServiceProxy.getTestData ', 5, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url('getTestData', initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                serviceCallId : initConfig.serviceCallId
+            });
+
+            coverage.getTestData = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('getTestData', function(promise) {
+                assert.ok(true, 'The proxy has fired the "getTestData" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "getTestData" event');
+            });
+
+            var result = proxy.getTestData();
+
+            assert.equal(typeof result, 'object', 'The proxy.getTestData method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+
+
+    var qtiServiceProxyGetTestContextChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        response: {
+            map: [{}],
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyGetTestContextChecks)
+        .asyncTest('qtiServiceProxy.getTestContext ', 5, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url('getTestContext', initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                serviceCallId : initConfig.serviceCallId
+            });
+
+            coverage.getTestContext = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('getTestContext', function(promise) {
+                assert.ok(true, 'The proxy has fired the "getTestContext" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "getTestContext" event');
+            });
+
+            var result = proxy.getTestContext();
+
+            assert.equal(typeof result, 'object', 'The proxy.getTestContext method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+
+
+    var qtiServiceProxyCallTestActionChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        action: 'move',
+        params: {
+            type: 'forward'
+        },
+        response: {
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        action: 'move',
+        params: {
+            type: 'forward'
+        },
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        action: 'move',
+        params: {
+            type: 'forward'
+        },
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyCallTestActionChecks)
+        .asyncTest('qtiServiceProxy.callTestAction ', 7, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url(caseData.action, initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                serviceCallId : initConfig.serviceCallId
+            });
+
+            coverage.callTestAction = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('callTestAction', function(promise, action, params) {
+                assert.ok(true, 'The proxy has fired the "callTestAction" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "callTestAction" event');
+                assert.equal(action, caseData.action, 'The proxy has provided the action through the "callTestAction" event');
+                assert.equal(params, caseData.params, 'The proxy has provided the params through the "callTestAction" event');
+            });
+
+            var result = proxy.callTestAction(caseData.action, caseData.params);
+
+            assert.equal(typeof result, 'object', 'The proxy.callTestAction method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+
+
+    var qtiServiceProxyGetItemDataChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        response: {
+            interactions: [{}],
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyGetItemDataChecks)
+        .asyncTest('qtiServiceProxy.getItemData ', 6, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url('getItemData', initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                testServiceCallId : initConfig.serviceCallId,
+                itemDefinition : caseData.uri
+            });
+
+            coverage.getItemData = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('getItemData', function(promise, uri) {
+                assert.ok(true, 'The proxy has fired the "getItemData" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "getItemData" event');
+                assert.equal(uri, caseData.uri, 'The proxy has provided the URI through the "getItemData" event');
+            });
+
+            var result = proxy.getItemData(caseData.uri);
+
+            assert.equal(typeof result, 'object', 'The proxy.getItemData method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+
+
+    var qtiServiceProxyGetItemStateChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        response: {
+            response: [{}],
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyGetItemStateChecks)
+        .asyncTest('qtiServiceProxy.getItemState ', 6, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url('getItemState', initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                testServiceCallId : initConfig.serviceCallId,
+                itemDefinition : caseData.uri
+            });
+
+            coverage.getItemState = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('getItemState', function(promise, uri) {
+                assert.ok(true, 'The proxy has fired the "getItemState" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "getItemState" event');
+                assert.equal(uri, caseData.uri, 'The proxy has provided the URI through the "getItemState" event');
+            });
+
+            var result = proxy.getItemState(caseData.uri);
+
+            assert.equal(typeof result, 'object', 'The proxy.getItemState method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+
+
+    var qtiServiceProxySubmitItemStateChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        state: {response: [{}]},
+        response: {
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        state: {response: [{}]},
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        state: {response: [{}]},
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxySubmitItemStateChecks)
+        .asyncTest('qtiServiceProxy.submitItemState ', 7, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url('submitItemState', initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                testServiceCallId : initConfig.serviceCallId,
+                itemDefinition : caseData.uri
+            });
+
+            coverage.submitItemState = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('submitItemState', function(promise, uri, state) {
+                assert.ok(true, 'The proxy has fired the "submitItemState" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "submitItemState" event');
+                assert.equal(uri, caseData.uri, 'The proxy has provided the URI through the "submitItemState" event');
+                assert.equal(state, caseData.state, 'The proxy has provided the state through the "submitItemState" event');
+            });
+
+            var result = proxy.submitItemState(caseData.uri, caseData.state);
+
+            assert.equal(typeof result, 'object', 'The proxy.submitItemState method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+
+
+    var qtiServiceProxyStoreItemResponseChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        itemResponse: {response: [{}]},
+        response: {
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        itemResponse: {response: [{}]},
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        itemResponse: {response: [{}]},
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyStoreItemResponseChecks)
+        .asyncTest('qtiServiceProxy.storeItemResponse ', 7, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url('storeItemResponse', initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                testServiceCallId : initConfig.serviceCallId,
+                itemDefinition : caseData.uri
+            });
+
+            coverage.storeItemResponse = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('storeItemResponse', function(promise, uri, response) {
+                assert.ok(true, 'The proxy has fired the "storeItemResponse" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "storeItemResponse" event');
+                assert.equal(uri, caseData.uri, 'The proxy has provided the URI through the "storeItemResponse" event');
+                assert.equal(response, caseData.itemResponse, 'The proxy has provided the response through the "storeItemResponse" event');
+            });
+
+            var result = proxy.storeItemResponse(caseData.uri, caseData.itemResponse);
+
+            assert.equal(typeof result, 'object', 'The proxy.storeItemResponse method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+
+
+    var qtiServiceProxyCallItemActionChecks = [{
+        title: 'success',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        action: 'comment',
+        params: {
+            text: 'lorem ipsum'
+        },
+        response: {
+            success: true
+        },
+        success: true
+    }, {
+        title: 'failing data',
+        ajaxMock: ajaxMockSuccess,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        action: 'comment',
+        params: {
+            text: 'lorem ipsum'
+        },
+        response: {
+            success: false
+        },
+        success: false
+    }, {
+        title: 'failing request',
+        ajaxMock: ajaxMockError,
+        uri: 'http://tao.dev/mockItemDefinition#123',
+        action: 'comment',
+        params: {
+            text: 'lorem ipsum'
+        },
+        response: "error",
+        success: false
+    }] ;
+
+    QUnit
+        .cases(qtiServiceProxyCallItemActionChecks)
+        .asyncTest('qtiServiceProxy.callItemAction ', 8, function(caseData, assert) {
+            var initConfig = {
+                testDefinition: 'http://tao.dev/mockTestDefinition#123',
+                testCompilation: 'http://tao.dev/mockTestCompilation#123',
+                serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+                serviceController: 'MockRunner',
+                serviceExtension: 'taoRunnerMock'
+            };
+
+            var expectedUrl = helpers._url(caseData.action, initConfig.serviceController, initConfig.serviceExtension, {
+                testDefinition : initConfig.testDefinition,
+                testCompilation : initConfig.testCompilation,
+                testServiceCallId : initConfig.serviceCallId,
+                itemDefinition : caseData.uri
+            });
+
+            coverage.callItemAction = true;
+
+            proxyFactory.registerProxy('qtiServiceProxy', qtiServiceProxy);
+
+            $.ajax = ajaxMockSuccess({success: true});
+
+            var proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+            proxy.init();
+
+            $.ajax = caseData.ajaxMock(caseData.response, function(ajaxConfig) {
+                assert.equal(ajaxConfig.url, expectedUrl, 'The proxy has called the right service');
+            });
+
+            proxy.on('callItemAction', function(promise, uri, action, params) {
+                assert.ok(true, 'The proxy has fired the "callItemAction" event');
+                assert.equal(typeof promise, 'object', 'The proxy has provided the promise through the "callItemAction" event');
+                assert.equal(uri, caseData.uri, 'The proxy has provided the URI through the "callItemAction" event');
+                assert.equal(action, caseData.action, 'The proxy has provided the action through the "callItemAction" event');
+                assert.equal(params, caseData.params, 'The proxy has provided the params through the "callItemAction" event');
+            });
+
+            var result = proxy.callItemAction(caseData.uri, caseData.action, caseData.params);
+
+            assert.equal(typeof result, 'object', 'The proxy.callItemAction method has returned a promise');
+
+            result.then(function(data) {
+                if (caseData.success) {
+                    assert.equal(data, caseData.response, 'The proxy has returned the expected data');
+                } else {
+                    assert.ok(false, 'The proxy must throw an error!');
+                }
+                QUnit.start();
+            }).catch(function(err) {
+                assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
+                QUnit.start();
+            });
+        });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-1906

Requires: https://github.com/oat-sa/extension-tao-test/pull/58

TestRunner Proxy implementation for QTI tests.