### PR TITLE
Feature/test options

### DIFF
--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -25,8 +25,10 @@ namespace oat\taoQtiTest\models\runner;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoQtiItem\model\QtiJsonItemCompiler;
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use oat\taoQtiTest\models\runner\map\QtiRunnerMap;
 use oat\taoQtiTest\models\runner\navigation\QtiRunnerNavigation;
+use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
 use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
 use qtism\data\NavigationMode;
 use qtism\data\SubmissionMode;
@@ -50,9 +52,9 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
 
     /**
      * The test runner config
-     * @var array
+     * @var RunnerConfig
      */
-    protected $config;
+    protected $testConfig;
 
     /**
      * Get the data folder from a given item definition
@@ -125,19 +127,6 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     }
 
     /**
-     * Gets the test runner config
-     * @return array
-     * @throws \common_ext_ExtensionException
-     */
-    public function getConfig()
-    {
-        if (is_null($this->config)) {
-            $this->config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
-        }
-        return $this->config;
-    }
-
-    /**
      * Initializes the delivery execution session
      * @param RunnerServiceContext $context
      * @return boolean
@@ -165,6 +154,19 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         }
 
         return true;
+    }
+
+    /**
+     * Gets the test runner config
+     * @return RunnerConfig
+     * @throws \common_ext_ExtensionException
+     */
+    public function getTestConfig()
+    {
+        if (is_null($this->testConfig)) {
+            $this->testConfig = new QtiRunnerConfig();
+        }
+        return $this->testConfig;
     }
 
     /**
@@ -224,7 +226,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 }
             }
 
-            $response['config'] = $this->getConfig();
+            $response['config'] = $this->getTestConfig()->getConfig();
 
         } else {
             throw new \common_exception_InvalidArgumentType('Context must be an instance of QtiRunnerServiceContext');
@@ -258,7 +260,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
 
             // Context of interacting test
             if ($session->getState() === AssessmentTestSessionState::INTERACTING) {
-                $config = $this->getConfig();
+                $config = $this->getTestConfig();
 
                 // The navigation mode.
                 $response['navigationMode'] = $session->getCurrentNavigationMode();
@@ -316,7 +318,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $response['numberPresented'] = $session->numberPresented();
 
                 // Whether or not the progress of the test can be inferred.
-                $response['considerProgress'] = \taoQtiTest_helpers_TestRunnerUtils::considerProgress($session, $context->getTestMeta(), $config);
+                $response['considerProgress'] = \taoQtiTest_helpers_TestRunnerUtils::considerProgress($session, $context->getTestMeta(), $config->getConfig());
 
                 // Whether or not the deepest current section is visible.
                 $response['isDeepestSectionVisible'] = $session->getCurrentAssessmentSection()->isVisible();
@@ -327,12 +329,8 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 //Number of rubric blocks
                 $response['numberRubrics'] = count($session->getRoute()->current()->getRubricBlockRefs());
 
-                // Comment allowed? Skipping allowed? Logout or Exit allowed ?
-                $response['allowComment'] = \taoQtiTest_helpers_TestRunnerUtils::doesAllowComment($session);
-                $response['allowSkipping'] = \taoQtiTest_helpers_TestRunnerUtils::doesAllowSkipping($session);
-                $response['exitButton'] = \taoQtiTest_helpers_TestRunnerUtils::doesAllowExit($session);
-                $response['logoutButton'] = \taoQtiTest_helpers_TestRunnerUtils::doesAllowLogout($session);
-                $response['categories'] = \taoQtiTest_helpers_TestRunnerUtils::getCategories($session);
+                // append dynamic options
+                $response['options'] = $config->getOptions($context);
             }
 
         } else {
@@ -352,7 +350,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     {
         if ($context instanceof QtiRunnerServiceContext) {
             $map = new QtiRunnerMap();
-            return $map->getMap($context, $this->getConfig());
+            return $map->getMap($context, $this->getTestConfig());
         } else {
             throw new \common_exception_InvalidArgumentType('Context must be an instance of QtiRunnerServiceContext');
         }

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -688,6 +688,8 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         } else {
             throw new \common_exception_InvalidArgumentType('Context must be an instance of QtiRunnerServiceContext');
         }
+        
+        return true;
     }
 
 
@@ -715,9 +717,6 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         } else {
             throw new \common_exception_InvalidArgumentType('Context must be an instance of QtiRunnerServiceContext');
         }
-
-
-        
 
         return $result;
     }

--- a/models/classes/runner/RunnerService.php
+++ b/models/classes/runner/RunnerService.php
@@ -21,6 +21,8 @@
  */
 namespace oat\taoQtiTest\models\runner;
 
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
+
 /**
  * Interface RunnerService
  * 
@@ -37,6 +39,13 @@ interface RunnerService
      * @throws \common_Exception
      */
     public function init(RunnerServiceContext $context);
+
+    /**
+     * Gets the test runner config
+     * @return RunnerConfig
+     * @throws \common_ext_ExtensionException
+     */
+    public function getTestConfig();
 
     /**
      * Gets the test definition data

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+
+namespace oat\taoQtiTest\models\runner\config;
+
+use oat\taoQtiTest\models\runner\RunnerServiceContext;
+
+/**
+ * Class QtiRunnerOptions
+ * @package oat\taoQtiTest\models\runner\options
+ */
+class QtiRunnerConfig implements RunnerConfig
+{
+    /**
+     * The test runner config
+     * @var array
+     */
+    protected $config;
+
+    /**
+     * Returns the config of the test runner
+     * @return mixed
+     */
+    public function getConfig()
+    {
+        if (is_null($this->config)) {
+            // get the raw server config, using the old notation
+            $rawConfig = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+
+            // build the test config using the new notation
+            $this->config = [
+                'timerWarning' => $rawConfig['timerWarning'],
+                'progressIndicator' => [
+                    'type' => $rawConfig['progress-indicator'],
+                    'scope' => $rawConfig['progress-indicator-scope'],
+                    'forced' => $rawConfig['progress-indicator-forced'],
+                ],
+                'review' => [
+                    'enabled' => !!$rawConfig['test-taker-review'],
+                    'scope' => $rawConfig['test-taker-review-scope'],
+                    'forceTitle' => !!$rawConfig['test-taker-review-force-title'],
+                    'itemTile' => $rawConfig['test-taker-review-item-title'],
+                    'preventsUnseen' => !!$rawConfig['test-taker-review-prevents-unseen'],
+                    'canCollapse' => !!$rawConfig['test-taker-review-can-collapse'],
+                ],
+                'exitButton' => !!$rawConfig['exitButton'],
+                'nextSection' => !!$rawConfig['next-section'],
+                'resetTimerAfterResume' => !!$rawConfig['reset-timer-after-resume'],
+            ];
+        }
+        return $this->config;
+    }
+
+
+    /**
+     * Returns the options related to the current test context
+     * @param RunnerServiceContext $context The test context
+     * @return mixed
+     */
+    public function getOptions(RunnerServiceContext $context)
+    {
+        $session = $context->getTestSession();
+
+        // Comment allowed? Skipping allowed? Logout or Exit allowed ?
+        $options = [
+            'allowComment' => \taoQtiTest_helpers_TestRunnerUtils::doesAllowComment($session),
+            'allowSkipping' => \taoQtiTest_helpers_TestRunnerUtils::doesAllowSkipping($session),
+            'exitButton' => \taoQtiTest_helpers_TestRunnerUtils::doesAllowExit($session),
+            'logoutButton' => \taoQtiTest_helpers_TestRunnerUtils::doesAllowLogout($session),
+        ];
+
+        // get the options from the categories owned by the current item
+        $categories = \taoQtiTest_helpers_TestRunnerUtils::getCategories($session);
+        $prefixCategory = 'x-tao-option-';
+        $prefixCategoryLen = strlen($prefixCategory);
+        foreach ($categories as $category) {
+            if (!strncmp($category, $prefixCategory, $prefixCategoryLen)) {
+                // extract the option name from the category, transform to camelCase if needed
+                $optionName = strtr(lcfirst(ucwords(substr($category, $prefixCategoryLen), '-_')), ['-'=>'', '_'=>'']);
+                
+                // the options added by the categories are just flags
+                $options[$optionName] = true;
+            }
+        }
+
+        return $options;
+    }
+}

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -58,7 +58,7 @@ class QtiRunnerConfig implements RunnerConfig
                     'enabled' => !!$rawConfig['test-taker-review'],
                     'scope' => $rawConfig['test-taker-review-scope'],
                     'forceTitle' => !!$rawConfig['test-taker-review-force-title'],
-                    'itemTile' => $rawConfig['test-taker-review-item-title'],
+                    'itemTitle' => $rawConfig['test-taker-review-item-title'],
                     'preventsUnseen' => !!$rawConfig['test-taker-review-prevents-unseen'],
                     'canCollapse' => !!$rawConfig['test-taker-review-can-collapse'],
                 ],
@@ -70,6 +70,19 @@ class QtiRunnerConfig implements RunnerConfig
         return $this->config;
     }
 
+    /**
+     * Returns the value of a config entry
+     * @param string $name
+     * @return mixed
+     */
+    public function getConfigValue($name)
+    {
+        $config = $this->getConfig();
+        if (isset($config[$name])) {
+            return $config[$name];
+        }
+        return null;
+    }
 
     /**
      * Returns the options related to the current test context
@@ -95,8 +108,8 @@ class QtiRunnerConfig implements RunnerConfig
         foreach ($categories as $category) {
             if (!strncmp($category, $prefixCategory, $prefixCategoryLen)) {
                 // extract the option name from the category, transform to camelCase if needed
-                $optionName = strtr(lcfirst(ucwords(substr($category, $prefixCategoryLen), '-_')), ['-'=>'', '_'=>'']);
-                
+                $optionName = strtr(lcfirst(ucwords(substr($category, $prefixCategoryLen), '-_')), ['-' => '', '_' => '']);
+
                 // the options added by the categories are just flags
                 $options[$optionName] = true;
             }

--- a/models/classes/runner/config/RunnerConfig.php
+++ b/models/classes/runner/config/RunnerConfig.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+
+namespace oat\taoQtiTest\models\runner\config;
+
+use oat\taoQtiTest\models\runner\RunnerServiceContext;
+
+/**
+ * Interface RunnerOptions
+ * @package oat\taoQtiTest\models\runner\options
+ */
+interface RunnerConfig
+{
+    /**
+     * Returns the config related to the runner
+     * @return mixed
+     */
+    public function getConfig();
+    
+    /**
+     * Returns the options related to the current test context
+     * @param RunnerServiceContext $context The test context
+     * @return mixed
+     */
+    public function getOptions(RunnerServiceContext $context);
+}

--- a/models/classes/runner/config/RunnerConfig.php
+++ b/models/classes/runner/config/RunnerConfig.php
@@ -37,6 +37,13 @@ interface RunnerConfig
     public function getConfig();
     
     /**
+     * Returns the value of a config entry
+     * @param string $name
+     * @return mixed
+     */
+    public function getConfigValue($name);
+    
+    /**
      * Returns the options related to the current test context
      * @param RunnerServiceContext $context The test context
      * @return mixed

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -22,6 +22,7 @@
 
 namespace oat\taoQtiTest\models\runner\map;
 
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use qtism\data\NavigationMode;
 use qtism\runtime\tests\AssessmentItemSession;
@@ -36,11 +37,11 @@ class QtiRunnerMap implements RunnerMap
 {
     /**
      * Builds the map of an assessment test
-     * @param RunnerServiceContext $context
-     * @param array $config
+     * @param RunnerServiceContext $context The test context
+     * @param RunnerConfig $config The runner config
      * @return mixed
      */
-    public function getMap(RunnerServiceContext $context, $config = [])
+    public function getMap(RunnerServiceContext $context, RunnerConfig $config)
     {
         $map = [
             'parts' => [],
@@ -48,8 +49,9 @@ class QtiRunnerMap implements RunnerMap
         ];
 
         // get config for the sequence number option
-        $forceTitles = !empty($config['test-taker-review-force-title']);
-        $uniqueTitle = isset($config['test-taker-review-item-title']) ? $config['test-taker-review-item-title'] : '%d';
+        $reviewConfig = $config->getConfigValue('review');
+        $forceTitles = !empty($reviewConfig['forceTitle']);
+        $uniqueTitle = isset($reviewConfig['itemTitle']) ? $reviewConfig['itemTitle'] : '%d';
         
         /* @var AssessmentTestSession $session */
         $session = $context->getTestSession();

--- a/models/classes/runner/map/RunnerMap.php
+++ b/models/classes/runner/map/RunnerMap.php
@@ -22,6 +22,7 @@
 
 namespace oat\taoQtiTest\models\runner\map;
 
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 
 /**
@@ -32,9 +33,9 @@ interface RunnerMap
 {
     /**
      * Builds the map of an assessment test
-     * @param RunnerServiceContext $context
-     * @param array $config
+     * @param RunnerServiceContext $context The test context
+     * @param RunnerConfig $config The runner config
      * @return mixed
      */
-    public function getMap(RunnerServiceContext $context, $config = []);
+    public function getMap(RunnerServiceContext $context, RunnerConfig $config);
 }

--- a/views/js/runner/plugins/controls/progressbar/progressbar.js
+++ b/views/js/runner/plugins/controls/progressbar/progressbar.js
@@ -154,13 +154,13 @@ define([
          * Initialize the plugin (called during runner's init)
          */
         init : function init(){
-            var self = this;
             var $progressLabel,
                 $progressControl;
             var testRunner = this.getTestRunner();
             var testData   = testRunner.getTestData();
-            var progressIndicator = testData.config['progress-indicator'] || 'percentage';
-            var progressScope = testData.config['progress-indicator-scope'] || 'test';
+            var config     = testData.config.progressIndicator || {};
+            var progressIndicator = config.type || 'percentage';
+            var progressScope = config.scope || 'test';
 
             /**
              * Updae the progress bar

--- a/views/js/runner/plugins/controls/review/navigator.js
+++ b/views/js/runner/plugins/controls/review/navigator.js
@@ -224,10 +224,40 @@ define([
         },
 
         /**
+         * Update the config
+         * @param {Object} [config]
+         * @returns {navigatorApi}
+         */
+        updateConfig: function updateConfig(config) {
+            var $component = this.getElement();
+            var scopeClass = _cssCls.scope[this.config.scope || _defaults.scope];
+
+            // apply the new config
+            config = _.merge(this.config, config || {});
+
+            // enable/disable the collapsing of the panel
+            $component.toggleClass(_cssCls.collapsible, config.canCollapse);
+
+            // update the component CSS class according to the scope
+            $component.removeClass(scopeClass);
+            scopeClass = _cssCls.scope[this.config.scope || _defaults.scope];
+            $component.addClass(scopeClass);
+
+            // update component visibility
+            if (config.hidden) {
+                this.hide();
+            } else {
+                this.show();
+            }
+
+            return this;
+        },
+
+        /**
          * Updates the review screen
          * @param {Object} map The current test map
          * @param {Object} context The current test context
-         * @returns {testReview}
+         * @returns {navigatorApi}
          */
         update: function update(map, context) {
             var scopedMap = this.getScopedMap(map, context);
@@ -404,7 +434,7 @@ define([
         /**
          * Toggles the display state of the component
          * @param {Boolean} [show] External condition that's tells if the component must be shown or hidden
-         * @returns {testReview}
+         * @returns {navigatorApi}
          */
         toggle: function toggle(show) {
             if (undefined === show) {
@@ -427,6 +457,8 @@ define([
      * @param {String} [config.scope] Limit the review screen to a particular scope: test, testPart, testSection
      * @param {Boolean} [config.preventsUnseen] Prevents the test taker to access unseen items
      * @param {Boolean} [config.canCollapse] Allow the test taker to collapse the component
+     * @param {Boolean} [config.canFlag] Allow the test taker to flag items
+     * @param {Boolean} [config.hidden] Hide the component at init
      * @param {Object} map The current test map
      * @param {Object} context The current test context
      * @returns {*}
@@ -477,10 +509,6 @@ define([
                     this.render();
                 }
 
-                if (this.config.hidden) {
-                    this.hide();
-                }
-
                 this.update(map, context);
             })
 
@@ -492,7 +520,6 @@ define([
             // renders the component
             .on('render', function () {
                 var self = this;
-                var scopeClass = _cssCls.scope[this.config.scope || _defaults.scope];
 
                 // main component elements
                 var $component = this.getElement();
@@ -520,10 +547,7 @@ define([
                 };
 
                 // apply options
-                if (scopeClass) {
-                    $component.addClass(scopeClass);
-                }
-                $component.toggleClass(_cssCls.collapsible, this.config.canCollapse);
+                this.updateConfig();
 
                 // click on the collapse handle: collapse/expand the review panel
                 $component.on('click' + _selectors.component, _selectors.collapseHandle, function () {
@@ -576,7 +600,7 @@ define([
 
                         if (!$item.hasClass(_cssCls.disabled)) {
                             $target = $(event.target);
-                            if ($target.is(_selectors.icons) && !$component.hasClass(_cssCls.collapsed)) {
+                            if (self.config.canFlag && $target.is(_selectors.icons) && !$component.hasClass(_cssCls.collapsed)) {
                                 // click on the icon, just flag the item, unless the panel is collapsed
                                 if (!$item.hasClass(_cssCls.unseen)) {
                                     flagItem($item);

--- a/views/js/runner/plugins/navigation/nextSection.js
+++ b/views/js/runner/plugins/navigation/nextSection.js
@@ -34,15 +34,20 @@ define([
         init : function init(){
             var self = this;
             var testRunner = this.getTestRunner();
+            var testConfig = testRunner.getTestData().config;
 
-            var toggle = function toggle(){
-                var context = testRunner.getTestContext();
-                if(context.nextSection === true){
+            function toggle(){
+                var options = testRunner.getTestContext().options;
+                if(testConfig.nextSection && (options.nextSection || options.nextSectionWarning)){
                     self.show();
                 } else {
                     self.hide();
                 }
             };
+
+            function nextSection() {
+                testRunner.next('section');
+            }
 
             this.$element = $(buttonTpl({
                 control : 'next-section',
@@ -51,12 +56,23 @@ define([
                 text    : __('Next Section')
             }));
 
-          this.$element.on('click', function(e){
+            this.$element.on('click', function(e){
+                var context = testRunner.getTestContext();
+                var enable = _.bind(self.enable, self);
                 e.preventDefault();
                 if(self.getState('enabled') !== false){
                     self.disable();
 
-                    testRunner.next('section');
+                    if(context.options.nextSectionWarning){
+                        testRunner.trigger(
+                            'confirm',
+                            __('After you complete the section it would be impossible to return to this section to make changes. Are you sure you want to end the section?'),
+                            nextSection, // if the test taker accept
+                            enable       // if the test taker refuse
+                        );
+                    } else {
+                        nextSection();
+                    }
                 }
             });
 

--- a/views/js/runner/plugins/navigation/skip.js
+++ b/views/js/runner/plugins/navigation/skip.js
@@ -88,7 +88,7 @@ define([
 
             var toggle = function toggle(){
                 var context = testRunner.getTestContext();
-                if(context.allowSkipping === true){
+                if(context.options.allowSkipping === true){
                     self.show();
                     return true;
                 }


### PR DESCRIPTION
Added a class to handle testRunner config and context options

The new test runner uses now a more consistent format for the config, but a mapping is made to convert the current server config to the new format. So if new entries are added to current config, the class has to be updated to support this new entry.

Now the review plugin is related to the item categories, so the category `x-tao-option-reviewScreen` need to be set on each navigable item. The mark for review button is related to the category `x-tao-option-markReview`

Here is a list of known category options:

| Option | Description |
| --- | --- |
| `x-tao-option-reviewScreen` | Enable the review/navigation panel |
| `x-tao-option-markReview` | Enable the mark for review button when the review/navigation panel is enabled |
| `x-tao-option-exit` | Allow to finish and exit the test |
| `x-tao-option-nextSection` | Enable the next section button |
| `x-tao-option-nextSectionWarning` | Enable the next section button, display a confirm message |