### PR TITLE
remove directory_separator

### DIFF
--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -805,7 +805,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
             if (!file_exists($basepath.$userDataLang) && file_exists($basepath.DEFAULT_LANG)) {
                 $userDataLang = DEFAULT_LANG;
             }
-            return $directory->getPublicAccessUrl().$userDataLang;
+            return $directory->getPublicAccessUrl().$userDataLang.'/';
         } else {
             throw new \common_exception_InvalidArgumentType('Context must be an instance of QtiRunnerServiceContext');
         }

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -805,7 +805,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
             if (!file_exists($basepath.$userDataLang) && file_exists($basepath.DEFAULT_LANG)) {
                 $userDataLang = DEFAULT_LANG;
             }
-            return $directory->getPublicAccessUrl().$userDataLang.DIRECTORY_SEPARATOR;
+            return $directory->getPublicAccessUrl().$userDataLang;
         } else {
             throw new \common_exception_InvalidArgumentType('Context must be an instance of QtiRunnerServiceContext');
         }


### PR DESCRIPTION
Test runner on the windows is broken because of corrupted item data json.
I got the following value of:
```
{
    ...
    "baseUrl": "http://package-tao/tao/getFile.php/56b841a702225/1454917052/e1b51ebeb1eb81cdc5182f294eb32b60/b/b/c/59a7ac86ac1b739cbf3b818489d27/*/en-US\"}
}
```
the point is that `baseUrl` value ends on `\` (which `DIRECTORY_SEPARATOR` on the windows) and this slash escapes the last quote.
