### PR TITLE
get test session by delivery execution

### DIFF
--- a/models/classes/SessionStateService.php
+++ b/models/classes/SessionStateService.php
@@ -22,6 +22,9 @@ namespace oat\taoQtiTest\models;
 use oat\oatbox\service\ConfigurableService;
 use qtism\runtime\tests\AssessmentTestSession;
 use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use qtism\runtime\storage\binary\BinaryAssessmentTestSeeker;
+use qtism\runtime\storage\binary\AbstractQtiBinaryStorage;
 
 /**
  * The SessionStateService
@@ -51,6 +54,16 @@ class SessionStateService extends ConfigurableService
      * @var \taoDelivery_models_classes_execution_ServiceProxy
      */
     private $deliveryExecutionService;
+
+    /**
+     * @var AssessmentTestSession[]
+     */
+    private $sessions = [];
+
+    /**
+     * @var AbstractQtiBinaryStorage[]
+     */
+    private $qtiStorage = [];
 
     public function __construct(array $options = array())
     {
@@ -153,5 +166,81 @@ class SessionStateService extends ConfigurableService
         } else {
             return __('finished');
         }
+    }
+
+    /**
+     * @param DeliveryExecution $deliveryExecution
+     * @return mixed
+     * @throws \common_exception_MissingParameter
+     * @throws \core_kernel_persistence_Exception
+     * @throws \qtism\runtime\storage\common\StorageException
+     */
+    public function getSessionByDeliveryExecution(DeliveryExecution $deliveryExecution)
+    {
+        if (!isset($this->sessions[$deliveryExecution->getIdentifier()])) {
+            $resultServer = \taoResultServer_models_classes_ResultServerStateFull::singleton();
+
+            $compiledDelivery = $deliveryExecution->getDelivery();
+            $runtime = DeliveryAssemblyService::singleton()->getRuntime($compiledDelivery);
+            $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
+
+            $testDefinition = \taoQtiTest_helpers_Utils::getTestDefinition($inputParameters['QtiTestCompilation']);
+            $testResource = new \core_kernel_classes_Resource($inputParameters['QtiTestDefinition']);
+
+            $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
+
+            $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
+                $sessionManager,
+                new BinaryAssessmentTestSeeker($testDefinition), $deliveryExecution->getUserIdentifier()
+            );
+            $this->qtiStorage[$deliveryExecution->getIdentifier()] = $qtiStorage;
+
+            $sessionId = $deliveryExecution->getIdentifier();
+
+            if ($qtiStorage->exists($sessionId)) {
+                $session = $qtiStorage->retrieve($testDefinition, $sessionId);
+
+                $resultServerUri = $compiledDelivery->getOnePropertyValue(new \core_kernel_classes_Property(TAO_DELIVERY_RESULTSERVER_PROP));
+                $resultServerObject = new \taoResultServer_models_classes_ResultServer($resultServerUri, array());
+                $resultServer->setValue('resultServerUri', $resultServerUri->getUri());
+                $resultServer->setValue('resultServerObject', array($resultServerUri->getUri() => $resultServerObject));
+                $resultServer->setValue('resultServer_deliveryResultIdentifier', $deliveryExecution->getIdentifier());
+            } else {
+                $session = null;
+            }
+
+            $this->sessions[$deliveryExecution->getIdentifier()] = $session;
+        }
+
+        return $this->sessions[$deliveryExecution->getIdentifier()];
+    }
+
+    /**
+     * @param DeliveryExecution $deliveryExecution
+     * @throws \common_exception_Error
+     * @return AbstractQtiBinaryStorage
+     */
+    public function getQtiStorageByDeliveryExecution(DeliveryExecution $deliveryExecution)
+    {
+        if (!isset($this->qtiStorage[$deliveryExecution->getIdentifier()])) {
+            $resultServer = \taoResultServer_models_classes_ResultServerStateFull::singleton();
+
+            $compiledDelivery = $deliveryExecution->getDelivery();
+            $runtime = DeliveryAssemblyService::singleton()->getRuntime($compiledDelivery);
+            $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
+
+            $testDefinition = \taoQtiTest_helpers_Utils::getTestDefinition($inputParameters['QtiTestCompilation']);
+            $testResource = new \core_kernel_classes_Resource($inputParameters['QtiTestDefinition']);
+
+            $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
+
+            $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
+                $sessionManager,
+                new BinaryAssessmentTestSeeker($testDefinition), $deliveryExecution->getUserIdentifier()
+            );
+            $this->qtiStorages[$deliveryExecution->getIdentifier()] = $qtiStorage;
+        }
+
+        return $this->qtiStorage[$deliveryExecution->getIdentifier()];
     }
 }

--- a/models/classes/SessionStateService.php
+++ b/models/classes/SessionStateService.php
@@ -184,31 +184,32 @@ class SessionStateService extends ConfigurableService
             $runtime = DeliveryAssemblyService::singleton()->getRuntime($compiledDelivery);
             $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
 
-            $testDefinition = \taoQtiTest_helpers_Utils::getTestDefinition($inputParameters['QtiTestCompilation']);
-            $testResource = new \core_kernel_classes_Resource($inputParameters['QtiTestDefinition']);
+            $session = null;
 
-            $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
+            if (isset($inputParameters['QtiTestCompilation']) && isset($inputParameters['QtiTestDefinition'])) {
+                $testDefinition = \taoQtiTest_helpers_Utils::getTestDefinition($inputParameters['QtiTestCompilation']);
+                $testResource = new \core_kernel_classes_Resource($inputParameters['QtiTestDefinition']);
 
-            $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
-                $sessionManager,
-                new BinaryAssessmentTestSeeker($testDefinition), $deliveryExecution->getUserIdentifier()
-            );
-            $this->qtiStorage[$deliveryExecution->getIdentifier()] = $qtiStorage;
+                $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
 
-            $sessionId = $deliveryExecution->getIdentifier();
+                $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
+                    $sessionManager,
+                    new BinaryAssessmentTestSeeker($testDefinition), $deliveryExecution->getUserIdentifier()
+                );
+                $this->qtiStorage[$deliveryExecution->getIdentifier()] = $qtiStorage;
 
-            if ($qtiStorage->exists($sessionId)) {
-                $session = $qtiStorage->retrieve($testDefinition, $sessionId);
+                $sessionId = $deliveryExecution->getIdentifier();
 
-                $resultServerUri = $compiledDelivery->getOnePropertyValue(new \core_kernel_classes_Property(TAO_DELIVERY_RESULTSERVER_PROP));
-                $resultServerObject = new \taoResultServer_models_classes_ResultServer($resultServerUri, array());
-                $resultServer->setValue('resultServerUri', $resultServerUri->getUri());
-                $resultServer->setValue('resultServerObject', array($resultServerUri->getUri() => $resultServerObject));
-                $resultServer->setValue('resultServer_deliveryResultIdentifier', $deliveryExecution->getIdentifier());
-            } else {
-                $session = null;
+                if ($qtiStorage->exists($sessionId)) {
+                    $session = $qtiStorage->retrieve($testDefinition, $sessionId);
+
+                    $resultServerUri = $compiledDelivery->getOnePropertyValue(new \core_kernel_classes_Property(TAO_DELIVERY_RESULTSERVER_PROP));
+                    $resultServerObject = new \taoResultServer_models_classes_ResultServer($resultServerUri, array());
+                    $resultServer->setValue('resultServerUri', $resultServerUri->getUri());
+                    $resultServer->setValue('resultServerObject', array($resultServerUri->getUri() => $resultServerObject));
+                    $resultServer->setValue('resultServer_deliveryResultIdentifier', $deliveryExecution->getIdentifier());
+                }
             }
-
             $this->sessions[$deliveryExecution->getIdentifier()] = $session;
         }
 
@@ -228,16 +229,21 @@ class SessionStateService extends ConfigurableService
             $compiledDelivery = $deliveryExecution->getDelivery();
             $runtime = DeliveryAssemblyService::singleton()->getRuntime($compiledDelivery);
             $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
+            
+            $qtiStorage = null;
 
-            $testDefinition = \taoQtiTest_helpers_Utils::getTestDefinition($inputParameters['QtiTestCompilation']);
-            $testResource = new \core_kernel_classes_Resource($inputParameters['QtiTestDefinition']);
+            if (isset($inputParameters['QtiTestCompilation']) && isset($inputParameters['QtiTestDefinition'])) {
+                $testDefinition = \taoQtiTest_helpers_Utils::getTestDefinition($inputParameters['QtiTestCompilation']);
+                $testResource = new \core_kernel_classes_Resource($inputParameters['QtiTestDefinition']);
 
-            $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
+                $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
 
-            $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
-                $sessionManager,
-                new BinaryAssessmentTestSeeker($testDefinition), $deliveryExecution->getUserIdentifier()
-            );
+                $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
+                    $sessionManager,
+                    new BinaryAssessmentTestSeeker($testDefinition), $deliveryExecution->getUserIdentifier()
+                );
+            }
+
             $this->qtiStorages[$deliveryExecution->getIdentifier()] = $qtiStorage;
         }
 


### PR DESCRIPTION
I found that retrieving test session be delivery execution can be useful. It used at least it three places:
https://github.com/oat-sa/extension-tao-proctoring/blob/master/model/implementation/TestSessionService.php#L51
https://github.com/oat-sa/extension-tao-act/blob/master/scripts/endDeliveryExecutions.php#L93
https://github.com/oat-sa/extension-tao-act/blob/master/scripts/finishExpiredTests.php#L68

Also i need get test session instance by delivery execution to terminate it (i'm working on implementation of listener of this event: https://github.com/oat-sa/extension-tao-proctoring/pull/90/files#diff-df1444a5531c22723cfed8dd8c5746e2R179).