### PR TITLE
Number of flagged items

### DIFF
--- a/views/js/runner/plugins/controls/review/navigator.js
+++ b/views/js/runner/plugins/controls/review/navigator.js
@@ -155,14 +155,14 @@ define([
                 if (section) {
                     section.stats.flagged = _.reduce(section.items, function (count, item) {
                         return count + (item.flagged ? 1 : 0);
-                    });
+                    }, 0);
                 }
 
                 if (part) {
-                    part.stats.flagged = _.reduce(part.sections, accStats);
+                    part.stats.flagged = _.reduce(part.sections, accStats, 0);
                 }
 
-                map.stats.flagged = _.reduce(map.parts, accStats);
+                map.stats.flagged = _.reduce(map.parts, accStats, 0);
             }
         },
 


### PR DESCRIPTION
Fix the number of flagged items displayed in exit messages

To reproduce the issue you need a test with review and next section warning enabled.
Flag an item for review, then immediately try to exit or go to the next section. The number of flagged item is replaced by `[object Object]0`.