### PR TITLE
TestRunner: always store the item state

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -341,7 +341,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
         $serviceCallId = $this->getRequestParameter('testServiceCallId');
 
         try {
-            $serviceContext = $this->getServiceContext();
+            $serviceContext = $this->getServiceContext(false);
             $stateId = $serviceCallId . $serviceContext->getTestSession()->getCurrentAssessmentItemRef()->getIdentifier();
 
             $response = [


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2333

Allow to store the item state even if the test session is closed or suspended.