### PR TITLE
prevent converting empty categories

### DIFF
--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -349,7 +349,9 @@ class taoQtiTest_models_classes_QtiTestConverter
         }
         if ($collection instanceof IntegerCollection || $collection instanceof StringCollection) {
             foreach ($values as $value) {
-                $collection[] = $value;
+                if(!empty($value)){
+                    $collection[] = $value;
+                }
             }
             return $collection;
         }


### PR DESCRIPTION
In some conditions, adding and removing categories for items leads the authoring into an inconsistent state without being able to save the test. It's related to the given because it prevents me for going further in the fix.

Requires https://github.com/oat-sa/tao-core/pull/754