### PR TITLE
Fix failing test: runner/plugins/controls/timer

### DIFF
--- a/views/js/test/runner/mocks/areaBrokerMock.js
+++ b/views/js/test/runner/mocks/areaBrokerMock.js
@@ -63,6 +63,8 @@ define([
             mapping[areaId] = $('<div />').addClass('test-area').addClass(areaId).appendTo($container);
         });
 
+        $('#qunit-fixture').append($container);
+
         return areaBroker($container, mapping);
     }
 

--- a/views/js/test/runner/plugins/controls/timer/test.html
+++ b/views/js/test/runner/plugins/controls/timer/test.html
@@ -5,6 +5,7 @@
         <title>Test Runner - Plugin Timer</title>
         <base href="../../../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>


### PR DESCRIPTION
This test was failing because the `.hidden` class was unknown and not applicable to a detached element.