### PR TITLE
control plugins enable/disbale by groups

### DIFF
--- a/views/js/controller/runner/runner.js
+++ b/views/js/controller/runner/runner.js
@@ -33,7 +33,6 @@ define([
     'taoTests/runner/proxy',
     'taoQtiTest/runner/proxy/qtiServiceProxy',
     'taoQtiTest/runner/plugins/loader',
-
     'css!taoQtiTestCss/new-test-runner'
 ], function ($, _, __, module, Promise, loadingBar, feedback,
              runner, qtiProvider, proxy, qtiServiceProxy, pluginLoader) {
@@ -80,8 +79,10 @@ define([
     function initRunner(config) {
         var plugins = pluginLoader.getPlugins();
 
+        /**
+         *  At the end, we are redirected to the exit URL
+         */
         var leave = function leave (){
-            //at the end, we are redirected to the exit URL
             window.location = config.exitUrl;
         };
 
@@ -100,6 +101,8 @@ define([
                 if (err && err.type && err.type === 'TestState') {
 
                     if(!this.getState('ready')){
+                        //if we open an inconstent test (should never happen) we let a few sec to
+                        //read the error message then leave
                         _.delay(leave, 2000);
                     } else {
                         this.trigger('alert', err.message, function() {

--- a/views/js/runner/plugins/content/feedback/feedback.js
+++ b/views/js/runner/plugins/content/feedback/feedback.js
@@ -89,9 +89,7 @@ define([
                 .on('info', function(message){
                     currentFeedback = feedback().info(message);
                 })
-                .on('alert', closeCurrent)
-                .on('confirm', closeCurrent)
-                .on('unloaditem', closeCurrent);
+                .on('alert confirm unloaditem', closeCurrent);
         }
     });
 });

--- a/views/js/runner/plugins/content/overlay/overlay.js
+++ b/views/js/runner/plugins/content/overlay/overlay.js
@@ -42,7 +42,7 @@ define([
             var testRunner = this.getTestRunner();
 
             this.$element = $('<div />');
-            this.$element.on('click mousedown mouseup touchstart keyup keydow keypress', function(e){
+            this.$element.on('click mousedown mouseup touchstart touchend keyup keydow keypress scroll drop', function(e){
                 e.stopImmediatePropagation();
                 e.stopPropagation();
             });
@@ -57,8 +57,7 @@ define([
             //change plugin state
             testRunner
                 .on('disableitem',  shield)
-                .on('enableitem', unshield)
-                .on('unloaditem', unshield);
+                .on('enableitem unloaditem', unshield);
         },
 
         /**

--- a/views/js/runner/plugins/controls/review/review.js
+++ b/views/js/runner/plugins/controls/review/review.js
@@ -131,7 +131,7 @@ define([
              */
             function isEnabled() {
                 var context = testRunner.getTestContext();
-                return navigatorConfig.enabled && context.options.reviewScreen;
+                return navigatorConfig.enabled && context && context.options && context.options.reviewScreen;
             }
 
             /**
@@ -232,12 +232,12 @@ define([
                         self.hide();
                     }
                 })
-                .on('renderitem', function () {
+                .on('enabletools', function () {
                     if (isEnabled()) {
                         self.enable();
                     }
                 })
-                .on('unloaditem', function () {
+                .on('disabletools', function () {
                     if (isEnabled()) {
                         self.disable();
                     }
@@ -273,6 +273,7 @@ define([
             this.$flagItemButton.removeClass('disabled')
                 .removeProp('disabled');
             this.$toggleButton.removeClass('disabled')
+
                 .removeProp('disabled');
             this.navigator.enable();
         },

--- a/views/js/runner/plugins/controls/timer/timer.js
+++ b/views/js/runner/plugins/controls/timer/timer.js
@@ -41,7 +41,7 @@ define([
      */
     var timerRefresh = 1000;
 
-    /**views/js/runner/plugins/controls/timer/timer.js
+    /**
      * Duration of a second in the timer's base unit
      * @type {Number}
      */

--- a/views/js/runner/plugins/controls/timer/timer.js
+++ b/views/js/runner/plugins/controls/timer/timer.js
@@ -41,7 +41,7 @@ define([
      */
     var timerRefresh = 1000;
 
-    /**
+    /**views/js/runner/plugins/controls/timer/timer.js
      * Duration of a second in the timer's base unit
      * @type {Number}
      */
@@ -261,8 +261,7 @@ define([
                     };
 
                     var cancelMove = function cancelMove() {
-                        _.invoke(testRunner.getPlugins(), 'enable');
-                        testRunner.trigger('enableitem');
+                        testRunner.trigger('enableitem enablenav');
                         e.prevent();
                     };
 

--- a/views/js/runner/plugins/navigation/next.js
+++ b/views/js/runner/plugins/navigation/next.js
@@ -120,10 +120,10 @@ define([
                 .on('loaditem', function(){
                     updateElement(self.$element, testRunner.getTestContext());
                 })
-                .on('renderitem', function(){
+                .on('enablenav', function(){
                     self.enable();
                 })
-                .on('unloaditem', function(){
+                .on('disablenav', function(){
                     self.disable();
                 });
         },

--- a/views/js/runner/plugins/navigation/nextSection.js
+++ b/views/js/runner/plugins/navigation/nextSection.js
@@ -85,12 +85,12 @@ define([
             toggle();
 
             testRunner
-                .on('move', function(){
-                    self.disable();
-                })
-                .on('renderitem', function(){
+                .on('loaditem', toggle)
+                .on('enablenav', function(){
                     self.enable();
-                    toggle();
+                })
+                .on('disablenav', function(){
+                    self.disable();
                 });
         },
 

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -82,10 +82,10 @@ define([
             //update plugin state based on changes
             testRunner
                 .on('loaditem', toggle)
-                .on('renderitem', function(){
+                .on('enablenav', function(){
                     self.enable();
                 })
-                .on('unloaditem', function(){
+                .on('disablenav', function(){
                     self.disable();
                 });
         },

--- a/views/js/runner/plugins/navigation/skip.js
+++ b/views/js/runner/plugins/navigation/skip.js
@@ -119,10 +119,10 @@ define([
                         updateElement(self.$element, testRunner.getTestContext());
                     }
                 })
-                .on('renderitem', function(){
+                .on('enablenav', function(){
                     self.enable();
                 })
-                .on('unloaditem', function(){
+                .on('disablenav', function(){
                     self.disable();
                 });
         },


### PR DESCRIPTION
This is an improvement regarding the TR behavior when an error occurs. 
I've introduced the events for enable/disable plugins by groups (navs, tools). in order to let the navigation opened when there's an error.
There's also small fixes when opening a test in an inconsistent state. 

@no-chris please verify the coding style and run the tests (`cd tao/views/build && grunt connect taoqtitesttest`)
@boajer please do the testing