### PR TITLE
Fix content type override

### DIFF
--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -60,7 +60,7 @@ define([
                     headers: headers,
                     async: true,
                     dataType: 'json',
-                    contentType : contentType
+                    contentType : contentType || undefined
                 })
                 .done(function(data) {
                     if (data && data.token) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2437

Due to changes made to implement the CSRF token, the content type of queries may be corrupted.