### PR TITLE
Tao 2440 timeout next available item

### DIFF
--- a/helpers/class.TestSession.php
+++ b/helpers/class.TestSession.php
@@ -261,7 +261,15 @@ class taoQtiTest_helpers_TestSession extends AssessmentTestSession {
             throw new AssessmentTestSessionException($msg, AssessmentTestSessionException::FORBIDDEN_JUMP, $e);
         }
     }
-    
+
+    /**
+     * AssessmentTestSession implementations must override this method in order to submit test results
+     * from the current AssessmentTestSession to the appropriate data source.
+     *
+     * This method is triggered once at the end of the AssessmentTestSession.
+     *
+     * * @throws AssessmentTestSessionException With error code RESULT_SUBMISSION_ERROR if an error occurs while transmitting results.
+     */
     protected function submitTestResults() {
         $testUri = $this->getTest()->getUri();
         $sessionId = $this->getSessionId();
@@ -324,48 +332,126 @@ class taoQtiTest_helpers_TestSession extends AssessmentTestSession {
         $this->triggerEventChange();
     }
 
+    /**
+     * Begins the test session. Calling this method will make the state
+     * change into AssessmentTestSessionState::INTERACTING.
+     *
+     * @qtism-test-interaction
+     * @qtism-test-duration-update
+     */
     public function beginTestSession()
     {
         parent::beginTestSession();
         $this->triggerEventChange();
     }
-    
+
+    /**
+     * Perform a 'jump' to a given position in the Route sequence. The current navigation
+     * mode must be LINEAR to be able to jump.
+     *
+     * @param integer $position The position in the route the jump has to be made.
+     * @param boolean $allowTimeout Whether or not it is allowed to jump if the timeLimits in force of the jump target are not respected.
+     * @throws AssessmentTestSessionException If $position is out of the Route bounds or the jump is not allowed because of time constraints.
+     * @qtism-test-interaction
+     * @qtism-test-duration-update
+     */
     public function jumpTo($position, $allowTimeout = false)
     {
         parent::jumpTo($position);
         $this->triggerEventChange();
     }
-    
+
+    /**
+     * Ask the test session to move to next RouteItem in the Route sequence.
+     *
+     * If $allowTimeout is set to true, the very next RouteItem in the Route sequence will bet set
+     * as the current RouteItem, whether or not it is timed out or not.
+     *
+     * On the other hand, if $allowTimeout is set to false, the next RouteItem in the Route sequence
+     * which is not timed out will be set as the current RouteItem. If there is no more following RouteItems
+     * that are not timed out in the Route sequence, the test session ends gracefully.
+     *
+     * @param boolean $allowTimeout If set to true, the next RouteItem in the Route sequence does not have to respect the timeLimits in force. Default value is false.
+     * @throws AssessmentTestSessionException If the test session is not running or an issue occurs during the transition (e.g. branching, preConditions, ...).
+     * @qtism-test-interaction
+     * @qtism-test-duration-update
+     */
     public function moveNext($allowTimeout = false)
     {
         parent::moveNext($allowTimeout);
         $this->triggerEventChange();
     }
-    
+
+    /**
+     * Ask the test session to move to the previous RouteItem in the Route sequence.
+     *
+     * If $allowTimeout is set to true, the previous RouteItem in the Route sequence will bet set
+     * as the current RouteItem, whether or not it is timed out.
+     *
+     * On the other hand, if $allowTimeout is set to false, the previous RouteItem in the Route sequence
+     * which is not timed out will be set as the current RouteItem. If there is no more previous RouteItems
+     * that are not timed out in the Route sequence, the current RouteItem remains the same and an
+     * AssessmentTestSessionException with the appropriate timing error code is thrown.
+     *
+     * @param boolean $allowTimeout If set to true, the next RouteItem in the sequence does not have to respect timeLimits in force. Default value is false.
+     * @throws AssessmentTestSessionException If the test session is not running or an issue occurs during the transition (e.g. branching, preConditions, ...) or if $allowTimeout = false and there absolutely no possibility to move backward (even the first RouteItem is timed out).
+     * @qtism-test-interaction
+     * @qtism-test-duration-update
+     */
     public function moveBack($allowTimeout = false)
     {
         parent::moveBack($allowTimeout);
         $this->triggerEventChange();
     }
-    
+
+    /**
+     * Skip the current item.
+     *
+     * @throws AssessmentTestSessionException If the test session is not running or it is the last route item of the testPart but the SIMULTANEOUS submission mode is in force and not all responses were provided.
+     * @qtism-test-interaction
+     * @qtism-test-duration-update
+     */
     public function skip()
     {
         parent::skip();
         $this->triggerEventChange();
     }
-    
+
+    /**
+     * Set the position in the Route at the very next TestPart in the Route sequence or, if the current
+     * testPart is the last one of the test session, the test session ends gracefully. If the submission mode
+     * is simultaneous, the pending responses are processed.
+     *
+     * @throws AssessmentTestSessionException If the test is currently not running.
+     */
     public function moveNextTestPart()
     {
         parent::moveNextTestPart();
         $this->triggerEventChange();
     }
-    
+
+    /**
+     * Set the position in the Route at the very next assessmentSection in the route sequence.
+     *
+     * * If there is no assessmentSection left in the flow, the test session ends gracefully.
+     * * If there are still pending responses, they are processed.
+     *
+     * @throws AssessmentTestSessionException If the test is not running.
+     */
     public function moveNextAssessmentSection()
     {
         parent::moveNextAssessmentSection();
         $this->triggerEventChange();
     }
-    
+
+    /**
+     * Set the position in the Route at the very next assessmentItem in the route sequence.
+     *
+     * * If there is no item left in the flow, the test session ends gracefully.
+     * * If there are still pending responses, they are processed.
+     *
+     * @throws AssessmentTestSessionException If the test is not running.
+     */
     public function moveNextAssessmentItem()
     {
         parent::moveNextAssessmentItem();

--- a/helpers/class.TestSession.php
+++ b/helpers/class.TestSession.php
@@ -457,6 +457,93 @@ class taoQtiTest_helpers_TestSession extends AssessmentTestSession {
         parent::moveNextAssessmentItem();
         $this->triggerEventChange();
     }
+
+    /**
+     * Set the position in the Route at the very next TestPart in the Route sequence or, if the current
+     * testPart is the last one of the test session, the test session ends gracefully. If the submission mode
+     * is simultaneous, the pending responses are processed.
+     *
+     * @throws AssessmentTestSessionException If the test is currently not running.
+     */
+    public function closeTestPart() {
+
+        if ($this->isRunning() === false) {
+            $msg = "Cannot move to the next testPart while the state of the test session is INITIAL or CLOSED.";
+            throw new AssessmentTestSessionException($msg, AssessmentTestSessionException::STATE_VIOLATION);
+        }
+
+        $route = $this->getRoute();
+        $from = $route->current();
+
+        while ($route->valid() === true && $route->current()->getTestPart() === $from->getTestPart()) {
+            $itemSession = $this->getCurrentAssessmentItemSession();
+            $itemSession->endItemSession();
+            $this->nextRouteItem();
+        }
+
+        if ($this->isRunning() === true) {
+            $this->interactWithItemSession();
+        }
+
+        $this->triggerEventChange();
+    }
+
+    /**
+     * Set the position in the Route at the very next assessmentSection in the route sequence.
+     *
+     * * If there is no assessmentSection left in the flow, the test session ends gracefully.
+     * * If there are still pending responses, they are processed.
+     *
+     * @throws AssessmentTestSessionException If the test is not running.
+     */
+    public function closeAssessmentSection() {
+
+        if ($this->isRunning() === false) {
+            $msg = "Cannot move to the next assessmentSection while the state of the test session is INITIAL or CLOSED.";
+            throw new AssessmentTestSessionException($msg, AssessmentTestSessionException::STATE_VIOLATION);
+        }
+
+        $route = $this->getRoute();
+        $from = $route->current();
+
+        while ($route->valid() === true && $route->current()->getAssessmentSection() === $from->getAssessmentSection()) {
+            $itemSession = $this->getCurrentAssessmentItemSession();
+            $itemSession->endItemSession();
+            $this->nextRouteItem();
+        }
+
+        if ($this->isRunning() === true) {
+            $this->interactWithItemSession();
+        }
+
+        $this->triggerEventChange();
+    }
+
+    /**
+     * Set the position in the Route at the very next assessmentItem in the route sequence.
+     *
+     * * If there is no item left in the flow, the test session ends gracefully.
+     * * If there are still pending responses, they are processed.
+     *
+     * @throws AssessmentTestSessionException If the test is not running.
+     */
+    public function closeAssessmentItem() {
+
+        if ($this->isRunning() === false) {
+            $msg = "Cannot move to the next testPart while the state of the test session is INITIAL or CLOSED.";
+            throw new AssessmentTestSessionException($msg, AssessmentTestSessionException::STATE_VIOLATION);
+        }
+
+        $itemSession = $this->getCurrentAssessmentItemSession();
+        $itemSession->endItemSession();
+        $this->nextRouteItem();
+
+        if ($this->isRunning() === true) {
+            $this->interactWithItemSession();
+        }
+
+        $this->triggerEventChange();
+    }
     
     protected function triggerEventChange() {
         $event = new QtiTestChangeEvent($this);

--- a/manifest.php
+++ b/manifest.php
@@ -33,10 +33,10 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.20.2',
+    'version' => '2.21.0',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
-        'taoTests' => '>=2.6',
+        'taoTests' => '>=2.13',
         'taoQtiItem' => '>=2.6'
     ),
 	'models' => array(

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -681,9 +681,10 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     public function timeout(RunnerServiceContext $context, $scope, $ref)
     {
         if ($context instanceof QtiRunnerServiceContext) {
-            /* @var AssessmentTestSession $session */
+            /* @var \taoQtiTest_helpers_TestSession $session */
             $session = $context->getTestSession();
             try {
+                $session->closeTimer($ref, $scope);
                 $session->checkTimeLimits(false, true, false);
             } catch (AssessmentTestSessionException $e) {
                 $this->onTimeout($context, $e);
@@ -900,29 +901,36 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         $isLinear = $session->getCurrentNavigationMode() === NavigationMode::LINEAR;
         switch ($timeOutException->getCode()) {
             case AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW:
+                \common_Logger::i('TIMEOUT: closing the assessment test session');
                 $session->endTestSession();
                 break;
 
             case AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW:
                 if ($isLinear) {
+                    \common_Logger::i('TIMEOUT: moving to the next test part');
                     $session->moveNextTestPart();
                 } else {
+                    \common_Logger::i('TIMEOUT: closing the assessment test part');
                     $session->closeTestPart();
                 }
                 break;
 
             case AssessmentTestSessionException::ASSESSMENT_SECTION_DURATION_OVERFLOW:
                 if ($isLinear) {
+                    \common_Logger::i('TIMEOUT: moving to the next assessment section');
                     $session->moveNextAssessmentSection();
                 } else {
+                    \common_Logger::i('TIMEOUT: closing the assessment section session');
                     $session->closeAssessmentSection();
                 }
                 break;
 
             case AssessmentTestSessionException::ASSESSMENT_ITEM_DURATION_OVERFLOW:
                 if ($isLinear) {
+                    \common_Logger::i('TIMEOUT: moving to the next item');
                     $session->moveNextAssessmentItem();
                 } else {
+                    \common_Logger::i('TIMEOUT: closing the assessment item session');
                     $session->closeAssessmentItem();
                 }
                 break;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -268,6 +268,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.20.0');
         }
 
-        $this->skip('2.20.0','2.20.2');
+        $this->skip('2.20.0','2.21.0');
     }
 }

--- a/views/js/runner/plugins/controls/timer/timer.js
+++ b/views/js/runner/plugins/controls/timer/timer.js
@@ -215,8 +215,9 @@ define([
                     //how many time elapsed from the last tick ?
                     var elapsed = self.stopwatch.tick();
                     var timeout = false;
+                    var timeoutScope, timeoutRef;
 
-                    _.forEach(currentTimers, function(timer) {
+                    _.forEach(currentTimers, function(timer, type) {
                         var currentVal,
                             warnMessage;
                         if (timer.running()) {
@@ -228,6 +229,8 @@ define([
                             if (currentVal === 0) {
                                 timer.running(false);
                                 timeout = true;
+                                timeoutRef = timer.id();
+                                timeoutScope = type;
                             }
 
                             if (!timeout) {
@@ -239,7 +242,7 @@ define([
                         }
                     });
                     if (timeout) {
-                        testRunner.timeout();
+                        testRunner.timeout(timeoutScope, timeoutRef);
                         self.disable();
                     }
                 },

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -272,7 +272,7 @@ define([
                         self.trigger('error', err);
                     });
             })
-            .on('timeout', function(){
+            .on('timeout', function(scope, ref){
 
                 var context = self.getTestContext();
 
@@ -284,7 +284,10 @@ define([
                     .then(updateStats)
                     .then(function() {
                         self.trigger('alert', __('Time limit reached, this part of the test has ended.'), function() {
-                            computeNext('timeout');
+                            computeNext('timeout', {
+                                scope: scope,
+                                ref: ref
+                            });
                         });
                     })
                     .catch(function(err){


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2440

Requires: https://github.com/oat-sa/extension-tao-test/pull/83

Close the timer when a timeout occurs, and finishes all the item sessions, then move to the next available item.