### PR TITLE
Remove double timer closing

### DIFF
--- a/helpers/class.TestSession.php
+++ b/helpers/class.TestSession.php
@@ -581,12 +581,6 @@ class taoQtiTest_helpers_TestSession extends AssessmentTestSession {
             $placeId = $source->getIdentifier();
             if ($placeId === $identifier) {
                 if (($timeLimits = $source->getTimeLimits()) !== null && ($maxTime = $timeLimits->getMaxTime()) !== null) {
-                    $placeDuration = $this[$placeId . '.duration'];
-                    if ($placeDuration instanceof Duration) {
-                        $placeDuration->sub($placeDuration);
-                        $placeDuration->add($maxTime);
-                    }
-
                     $constraintDuration = $constraint->getDuration();
                     if ($constraintDuration instanceof Duration) {
                         $constraintDuration->sub($constraintDuration);


### PR DESCRIPTION
Remove useless double timer closing: this is the same instance in timeConstraints and session, so it is a non-sense to alter it twice from two different references. Moreover, the access to the session produces a new duration compute.