### PR TITLE
Feature/tao 2489 client sync

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -749,32 +749,4 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
         $this->returnJson($response, $code);
     }
-
-    /**
-     * Used to manage time
-     */
-    public function time()
-    {
-        $code = 200;
-
-        try {
-            if($this->hasRequestParameter('timerPaused')){
-                $duration = floatval($this->getRequestParameter('timerPaused'));
-                if($duration > 0){
-                    $serviceContext = $this->getServiceContext(false);
-                    $this->runnerService->updateTimers($serviceContext, $duration);
-                    $this->runnerService->persist($serviceContext);
-                }
-            }
-            $response = [
-                'success' => true
-            ];
-
-        } catch (common_Exception $e) {
-            $response = $this->getErrorResponse($e);
-            $code = $this->getErrorCode($e);
-        }
-
-        $this->returnJson($response, $code);
-    }
 }

--- a/views/js/runner/plugins/controls/duration/duration.js
+++ b/views/js/runner/plugins/controls/duration/duration.js
@@ -1,0 +1,133 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Test Runner Control Plugin : Duration (record exact spent time duration)
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/polling',
+    'core/timer',
+    'taoTests/runner/plugin',
+], function (_, pollingFactory, timerFactory, pluginFactory) {
+    'use strict';
+
+    /**
+     * Time interval between duration capture in ms
+     * @type {Number}
+     */
+    var refresh = 1000;
+
+
+    /**
+     * Creates the timer plugin
+     */
+    return pluginFactory({
+
+        name: 'duration',
+
+        /**
+         * Initializes the plugin (called during runner's init)
+         */
+        init: function init() {
+
+            var self = this;
+            var testRunner   = this.getTestRunner();
+
+
+            //one stopwatch to count the time
+            this.stopwatch = timerFactory({
+                autoStart : false
+            });
+
+            //update the duration on a regular basis
+            this.polling = pollingFactory({
+
+                action : function updateDuration() {
+
+                    //how many time elapsed from the last tick ?
+                    var elapsed = self.stopwatch.tick();
+                    var context = testRunner.getTestContext();
+                    var storage = testRunner.durationStore;
+
+                    //store by attempt
+                    var itemAttemptId = context.itemIdentifier + '#' + context.attempt;
+
+                    if(storage){
+                        storage.getItem(itemAttemptId).then(function(duration){
+                            duration = _.isNumber(duration) ? duration : 0;
+                            elapsed  = _.isNumber(elapsed) && elapsed > 0 ? (elapsed / 1000) : 0;
+
+                            //store the last duration
+                            storage.setItem(itemAttemptId, duration + elapsed);
+                        });
+                    }
+                },
+                interval : refresh,
+                autoStart : false
+            });
+
+            //change plugin state
+            testRunner
+
+                .after('renderitem enableitem', function(){
+                    self.enable();
+                })
+
+                .before('move disableitem skip error', function(e){
+                    if (self.getState('enabled')) {
+                        self.disable();
+                    }
+                })
+
+                .before('finish', function(e){
+                    var done = e.done();
+
+                    self.storage.clear()
+                        .then(done)
+                        .catch(done);
+                });
+        },
+
+        /**
+         * Called during the runner's destroy phase
+         */
+        destroy : function destroy (){
+            this.polling.stop();
+            this.stopwatch.stop();
+        },
+
+        /**
+         * Enables the duration count
+         */
+        enable : function enable (){
+            this.polling.start();
+            this.stopwatch.resume();
+        },
+
+        /**
+         * Disables the duration count
+         */
+        disable : function disable (){
+            this.polling.stop();
+            this.stopwatch.pause();
+        }
+    });
+});

--- a/views/js/runner/plugins/loader.js
+++ b/views/js/runner/plugins/loader.js
@@ -21,6 +21,7 @@ define([
     'taoQtiTest/runner/plugins/content/overlay/overlay',
     'taoQtiTest/runner/plugins/content/dialog/dialog',
     'taoQtiTest/runner/plugins/content/feedback/feedback',
+    'taoQtiTest/runner/plugins/controls/duration/duration',
     'taoQtiTest/runner/plugins/controls/title/title',
     'taoQtiTest/runner/plugins/controls/timer/timer',
     'taoQtiTest/runner/plugins/controls/progressbar/progressbar',
@@ -30,7 +31,7 @@ define([
     'taoQtiTest/runner/plugins/navigation/nextSection',
     'taoQtiTest/runner/plugins/navigation/skip',
     'taoQtiTest/runner/plugins/tools/comment/comment'
-], function(pluginLoader, rubricBlock, overlay, dialog, feedback, title, timer, progressbar, review, next, previous, nextSection, skip, comment) {
+], function(pluginLoader, rubricBlock, overlay, dialog, feedback, duration, title, timer, progressbar, review, next, previous, nextSection, skip, comment) {
     'use strict';
 
     /**
@@ -38,7 +39,7 @@ define([
      */
     return pluginLoader({
         content    : [rubricBlock, overlay, dialog, feedback],
-        controls   : [title, timer, progressbar],
+        controls   : [title, timer, progressbar, duration],
         navigation : [review, previous, next, nextSection, skip],
         tools      : [comment]
     });

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -23,9 +23,10 @@ define([
     'lodash',
     'i18n',
     'core/promise',
+    'core/store',
     'helpers',
     'taoQtiTest/runner/config/qtiServiceConfig'
-], function($, _, __, Promise, helpers, configFactory) {
+], function($, _, __, Promise, store, helpers, configFactory) {
     'use strict';
 
     /**
@@ -147,11 +148,11 @@ define([
         init: function init(config) {
             var initConfig = config || {};
 
-            // store config in a dedicated storage
-            this.storage = configFactory(initConfig);
+            // store config in a dedicated configStorage
+            this.configStorage = configFactory(initConfig);
 
             // request for initialization
-            return request(this, this.storage.getTestActionUrl('init'));
+            return request(this, this.configStorage.getTestActionUrl('init'));
         },
 
         /**
@@ -164,7 +165,7 @@ define([
             // the method must return a promise
             return new Promise(function(resolve) {
                 // no request, just a resources cleaning
-                self.storage = null;
+                self.configStorage = null;
                 self._runningPromise = null;
                 resolve();
             });
@@ -176,7 +177,7 @@ define([
          *                      Any error will be provided if rejected.
          */
         getTestData: function getTestData() {
-            return request(this, this.storage.getTestActionUrl('getTestData'));
+            return request(this, this.configStorage.getTestActionUrl('getTestData'));
         },
 
         /**
@@ -185,7 +186,7 @@ define([
          *                      Any error will be provided if rejected.
          */
         getTestContext: function getTestContext() {
-            return request(this, this.storage.getTestActionUrl('getTestContext'));
+            return request(this, this.configStorage.getTestActionUrl('getTestContext'));
         },
 
         /**
@@ -194,7 +195,7 @@ define([
          *                      Any error will be provided if rejected.
          */
         getTestMap: function getTestMap() {
-            return request(this, this.storage.getTestActionUrl('getTestMap'));
+            return request(this, this.configStorage.getTestActionUrl('getTestMap'));
         },
 
         /**
@@ -205,7 +206,7 @@ define([
          *                      Any error will be provided if rejected.
          */
         callTestAction: function callTestAction(action, params) {
-            return request(this, this.storage.getTestActionUrl(action), params);
+            return request(this, this.configStorage.getTestActionUrl(action), params);
         },
 
         /**
@@ -215,7 +216,7 @@ define([
          *                      Any error will be provided if rejected.
          */
         getItem: function getItem(uri) {
-            return request(this, this.storage.getItemActionUrl(uri, 'getItem'));
+            return request(this, this.configStorage.getItemActionUrl(uri, 'getItem'));
         },
 
         /**
@@ -226,11 +227,13 @@ define([
          * @returns {Promise} - Returns a promise. The result of the request will be provided on resolve.
          *                      Any error will be provided if rejected.
          */
-        submitItem: function submitItem(uri, state, response) {
-            return request(this, this.storage.getItemActionUrl(uri, 'submitItem'), JSON.stringify({
+        submitItem: function submitItem(uri, state, response, params) {
+            var body = JSON.stringify( _.merge({
                 itemState : state,
                 itemResponse : response
-            }), 'application/json');
+            }, params || {}));
+
+            return request(this, this.configStorage.getItemActionUrl(uri, 'submitItem'), body, 'application/json');
         },
 
         /**
@@ -242,7 +245,7 @@ define([
          *                      Any error will be provided if rejected.
          */
         callItemAction: function callItemAction(uri, action, params) {
-            return request(this, this.storage.getItemActionUrl(uri, action), params);
+            return request(this, this.configStorage.getItemActionUrl(uri, action), params);
         },
 
         /**
@@ -255,7 +258,7 @@ define([
          * @fires telemetry
          */
         telemetry: function telemetry(uri, signal, params) {
-            return request(this, this.storage.getTelemetryUrl(uri, signal), params, null, true);
+            return request(this, this.configStorage.getTelemetryUrl(uri, signal), params, null, true);
         }
     };
 


### PR DESCRIPTION
 - unit tests to come after
 - duration stored and and send through `submitItem`
 - timer's duration is also stored

I'm not happy with the location of `durationStorage` (into the `testRunner` instance), but I'm not sure where to add it.