### PR TITLE
Add default client range when adjust with null duration

### DIFF
--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1046,7 +1046,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
             $session = $context->getTestSession();
             $session->endItemTimer();
 
-            if (isset($duration)) {
+            if (is_numeric($duration) || is_null($duration)) {
                 $session->adjustItemTimer($duration);
             }
         } else {

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -133,7 +133,10 @@ class TestSession extends taoQtiTest_helpers_TestSession
      */
     public function adjustItemTimer($duration)
     {
-        $this->getTimer()->adjust($this->getCurrentRouteItem(), floatval($duration))->save();
+        if (!is_null($duration)) {
+            $duration = floatval($duration);
+        }
+        $this->getTimer()->adjust($this->getCurrentRouteItem(), $duration)->save();
     }
 
     /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2487

Create a default client range when the client duration is null.