### PR TITLE
Fix adjust overflow

### DIFF
--- a/models/classes/runner/time/QtiTimer.php
+++ b/models/classes/runner/time/QtiTimer.php
@@ -186,7 +186,8 @@ class QtiTimer implements Timer
             $duration = $serverDuration;
             \common_Logger::i("No client duration provided to adjust the timer, fallback to server duration: ${duration}");
         } else if ($duration > $serverDuration) {
-            throw new InconsistentRangeException('A client duration cannot be larger than the server time range!');
+            \common_Logger::w("A client duration must not be larger than the server time range! (${duration} > ${serverDuration})");
+            $duration = $serverDuration;
         }
 
         // extract range boundaries


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2484

When the client duration is larger than the server range, fix the value instead of throwing exception.

The issue appeared when I have forgotten a timed out delivery in background. When I tried to close it I was unable to do it because of range exception.

I was unable to reproduce the issue, but the patch fixed the stuck delivery.

Steps that may reproduce the issue:
- start a timed test
- let the timeout occurs, then wait a few moment
- refresh the page or simulate a browser crash then resume the test
- try to exit or go next, an error may occur