### PR TITLE
Fix duration clearing at the end of the test

### DIFF
--- a/views/js/runner/plugins/controls/duration/duration.js
+++ b/views/js/runner/plugins/controls/duration/duration.js
@@ -120,7 +120,7 @@ define([
                 .before('finish', function(e){
                     var done = e.done();
 
-                    self.storage.clear()
+                    durationStore.clear()
                         .then(done)
                         .catch(done);
                 });


### PR DESCRIPTION
 There was an error at the end of the test because the property was missing