### PR TITLE
Feature/send variables

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,10 +33,10 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.29.0',
+    'version' => '2.30.0',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
-        'taoTests' => '>=2.17.1',
+        'taoTests' => '>=2.18.0',
         'taoQtiItem' => '>=2.6'
     ),
 	'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -379,5 +379,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('2.29.0');
         }
+
+        $this->skip('2.29.0', '2.30.0');
     }
 }

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -200,6 +200,17 @@ define([
         },
 
         /**
+         * Sends the test variables
+         * @param {Object} variables
+         * @returns {Promise} - Returns a promise. The result of the request will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         * @fires sendVariables
+         */
+        sendVariables: function sendVariables(variables) {
+            return request(this, this.configStorage.getTestActionUrl('storeTraceData'), { traceData : JSON.stringify(variables) });
+        },
+
+        /**
          * Calls an action related to the test
          * @param {String} action - The name of the action to call
          * @param {Object} [params] - Some optional parameters to join to the call


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2585

Requires: https://github.com/oat-sa/extension-tao-test/pull/115

Ensure the variables are sent before the test is finished.
Add a `flush` step in the runner's life cycle. This step is placed before the destroy. 

Now the workflow is:
- event `leave` *or* event `finish` -> flush() -> event `flush` -> destroy() -> event `destroy` -> browser redirect