### PR TITLE
Removed useless dependency to tao-lib-qti, as the extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "oat-sa/lib-tao-qti": "~0.1.0",
     "oat-sa/oatbox-extension-installer": "dev-master"
   },
   "autoload": {

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '2.32.0',
+    'version' => '2.32.1',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=2.19.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             
             $this->setVersion('2.31.1');
         }
-        $this->skip('2.31.1', '2.32.0');
+        $this->skip('2.31.1', '2.32.1');
     }
 }


### PR DESCRIPTION
depends on extension-item-qti, which has a dependency on
tao-lib-qti as well.