### PR TITLE
Fix/duration reflection issue

### DIFF
--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -318,7 +318,7 @@ class taoQtiTest_models_classes_QtiTestConverter
             if (is_array($value)) {
                 return $this->createComponentCollection(new ReflectionClass($class->name), $value);
             } else
-                if ($class->name === 'qtism\common\datatypes\Duration') {
+                if ($class->name === 'qtism\common\datatypes\QtiDuration') {
                     return new qtism\common\datatypes\QtiDuration('PT' . $value . 'S');
                 }
         }

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -310,7 +310,7 @@ class taoQtiTest_models_classes_QtiTestConverter
      *
      * @param mixed $value
      * @param object $class
-     * @return \qtism\common\datatypes\Duration
+     * @return \qtism\common\datatypes\QtiDuration
      */
     private function componentValue($value, $class)
     {


### PR DESCRIPTION
With the new version of qtism, if you try to save a test using the Creator you had an error, because of a wrong type reflection.