### PR TITLE
Fix/tao 2734 mark for review overwritten

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '3.1.0',
+    'version' => '3.1.1',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=2.19.0',

--- a/models/classes/ExtendedStateService.php
+++ b/models/classes/ExtendedStateService.php
@@ -32,7 +32,7 @@ class ExtendedStateService
     const VAR_SECURITY_TOKEN = 'security_token';
     const VAR_SESSION_TOKEN = 'session_token';
 
-    private $cache = null;
+    private static $cache = null;
 
     /**
      * Retrieves extended state information
@@ -42,7 +42,7 @@ class ExtendedStateService
      */
     protected function getExtra($testSessionId)
     {
-        if (!isset($this->cache[$testSessionId])) {
+        if (!isset(self::$cache[$testSessionId])) {
             $storageService = \tao_models_classes_service_StateStorage::singleton();
             $userUri = \common_session_SessionManager::getSession()->getUserUri();
 
@@ -54,12 +54,12 @@ class ExtendedStateService
                 }
             } else {
                 $data = array(
-                	self::VAR_REVIEW => array()
+                    self::VAR_REVIEW => array()
                 );
             }
-            $this->cache[$testSessionId] = $data;
+            self::$cache[$testSessionId] = $data;
         }
-        return $this->cache[$testSessionId];
+        return self::$cache[$testSessionId];
     }
 
     /**
@@ -69,7 +69,9 @@ class ExtendedStateService
      */
     protected function saveExtra($testSessionId, $extra)
     {
-        $this->cache[$testSessionId] = $extra;
+
+        self::$cache[$testSessionId] = $extra;
+
         $storageService = \tao_models_classes_service_StateStorage::singleton();
         $userUri = \common_session_SessionManager::getSession()->getUserUri();
 
@@ -102,6 +104,7 @@ class ExtendedStateService
     {
         $extra = $this->getExtra($testSessionId);
         $extra[self::VAR_REVIEW][$itemRef] = $flag;
+
         $this->saveExtra($testSessionId, $extra);
     }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -441,6 +441,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('3.1.0');
         }
 
-        $this->skip('3.0.0', '3.0.1');
+        $this->skip('3.1.0', '3.0.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -440,5 +440,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             
             $this->setVersion('3.1.0');
         }
+
+        $this->skip('3.0.0', '3.0.1');
     }
 }


### PR DESCRIPTION
since the ExtendedState is accessed across multiple instances, the cache is shared accross them... 
