### PR TITLE
Show/hide the review screen when the item is loaded

### DIFF
--- a/views/js/runner/plugins/controls/review/review.js
+++ b/views/js/runner/plugins/controls/review/review.js
@@ -192,12 +192,15 @@ define([
                 }
             });
 
+            this.explicitlyHidden = false;
             this.$toggleButton = createButton(getToggleButtonData(this.navigator), function (e) {
                 e.preventDefault();
                 if (self.getState('enabled') !== false) {
                     if (self.navigator.is('hidden')) {
+                        self.explicitlyHidden = false;
                         self.navigator.show();
                     } else {
+                        self.explicitlyHidden = true;
                         self.navigator.hide();
                     }
 
@@ -227,13 +230,14 @@ define([
                     var map = testRunner.getTestMap();
 
                     if (isEnabled()) {
-                        self.show();
                         updateButton(self.$flagItemButton, getFlagItemButtonData(context));
                         self.navigator
                             .update(map, context)
                             .updateConfig({
                                 canFlag: !context.isLinear && context.options.markReview
                             });
+                        self.show();
+                        updateButton(self.$toggleButton, getToggleButtonData(self.navigator));
                     } else {
                         self.hide();
                     }
@@ -307,7 +311,11 @@ define([
                 hider.hide(this.$flagItemButton);
             }
             hider.show(this.$toggleButton);
-            this.navigator.show();
+            if (!this.explicitlyHidden) {
+                this.navigator.show();
+            } else {
+                this.navigator.hide();
+            }
         },
 
         /**

--- a/views/js/runner/plugins/controls/review/review.js
+++ b/views/js/runner/plugins/controls/review/review.js
@@ -227,12 +227,15 @@ define([
                     var map = testRunner.getTestMap();
 
                     if (isEnabled()) {
+                        self.show();
                         updateButton(self.$flagItemButton, getFlagItemButtonData(context));
                         self.navigator
                             .update(map, context)
                             .updateConfig({
                                 canFlag: !context.isLinear && context.options.markReview
                             });
+                    } else {
+                        self.hide();
                     }
                 })
                 .on('enabletools', function () {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2774

The review screen was only shown at render time, so if it is enabled later, it will not be displayed until a refresh.

This patch shows/hides the review screen for each loaded item.