### PR TITLE
Fix/tao 2809 concurrency issues

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,10 +33,10 @@ return array(
     'label' => 'QTI test model',
 	'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '4.2.0',
+    'version' => '4.3.0',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
-        'taoTests' => '>=2.22.0',
+        'taoTests' => '>=2.23.0',
         'taoQtiItem' => '>=3.1',
         'tao'        => '>=5.3.0'
     ),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -455,6 +455,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '4.2.0');
+        $this->skip('4.0.0', '4.3.0');
     }
 }

--- a/views/js/runner/plugins/content/dialog/exitMessages.js
+++ b/views/js/runner/plugins/content/dialog/exitMessages.js
@@ -48,17 +48,6 @@ define([
             // intercepts the `leave` event,
             // then if a message needs to be displayed displays it and waits the user acknowledges it
             testRunner.before('leave', function leave(e, data) {
-                // safely stop the communicator to prevent inconsistent communication while leaving
-                testRunner.getProxy().getCommunicator()
-                    .then(function (communicator) {
-                        return communicator.close();
-                    })
-                    // Silently catch the potential errors to avoid polluting the console.
-                    // The code above is present to close an already open communicator in order to avoid later
-                    // communication while the test is destroying. So if any error occurs here it is not very important,
-                    // the most time it will be a missing communicator error, due to disabled config.
-                    .catch(_.noop);
-
                 if (_.isObject(data) && data.message) {
                     var done = e.done();
                     var context = testRunner.getTestContext();

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -587,17 +587,17 @@ define([
                 this.before('flush', function(e) {
                     var done = e.done();
 
-                    this.getProxy().callTestAction('finish').then(function() {
-                        if (self.stateStorage) {
-                            self.stateStorage.clear()
-                                .then(done)
-                                .catch(function(err) {
-                                    self.trigger('error', err);
-                                })
-                        } else {
-                            done();
-                        }
-                    });
+                    this.getProxy()
+                        .callTestAction('finish')
+                        .then(function() {
+                            if (self.stateStorage) {
+                                return self.stateStorage.clear();
+                            }
+                        })
+                        .then(done)
+                        .catch(function(err) {
+                            self.trigger('error', err);
+                        });
                 });
             }
         },

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -569,7 +569,7 @@ define([
         /**
          * Finish phase of the test runner
          *
-         * Calls proxy.finish to close the testj
+         * Calls proxy.finish to close the test
          *
          * @this {runner} the runner context, not the provider
          * @returns {Promise} proxy.finish
@@ -577,26 +577,29 @@ define([
         finish : function finish(){
             var self = this;
 
-            this.trigger('disablenav disabletools')
-                .trigger('endsession', 'finish');
+            if (!this.getState('finish')) {
+                this.trigger('disablenav disabletools')
+                    .trigger('endsession', 'finish');
 
-            // will be executed after the runner has been flushed
-            // use the "before" queue to ensure the query will be fully processed before destroying
-            // we do not use the "destroy" event because the proxy is destroyed before this event is triggered
-            this.before('flush', function(e) {
-                var done = e.done();
-                this.getProxy().callTestAction('finish').then(function() {
-                    if (self.stateStorage) {
-                        self.stateStorage.clear()
-                            .then(done)
-                            .catch(function(err) {
-                                self.trigger('error', err);
-                            })
-                    } else {
-                        done();
-                    }
+                // will be executed after the runner has been flushed
+                // use the "before" queue to ensure the query will be fully processed before destroying
+                // we do not use the "destroy" event because the proxy is destroyed before this event is triggered
+                this.before('flush', function(e) {
+                    var done = e.done();
+
+                    this.getProxy().callTestAction('finish').then(function() {
+                        if (self.stateStorage) {
+                            self.stateStorage.clear()
+                                .then(done)
+                                .catch(function(err) {
+                                    self.trigger('error', err);
+                                })
+                        } else {
+                            done();
+                        }
+                    });
                 });
-            });
+            }
         },
 
         /**
@@ -609,10 +612,12 @@ define([
         flush : function flush(){
             var self = this;
             var probeOverseer = this.getProbeOverseer();
+            var proxy = this.getProxy();
+            var flushPromise;
 
             //if there is trace data collected by the probes
             if(probeOverseer && !this.getState('disconnected')){
-                return probeOverseer.flush()
+                flushPromise = probeOverseer.flush()
                     .then(function(data){
 
                         //we reformat the time set into a trace variables
@@ -633,7 +638,24 @@ define([
                     .then(function(){
                         probeOverseer.stop();
                     });
+            } else {
+                flushPromise = Promise.resolve();
             }
+            
+            return flushPromise.then(function () {
+                // safely stop the communicator to prevent inconsistent communication while leaving
+                if (proxy.hasCommunicator()) {
+                    proxy.getCommunicator()
+                        .then(function (communicator) {
+                            return communicator.close();
+                        })
+                        // Silently catch the potential errors to avoid polluting the console.
+                        // The code above is present to close an already open communicator in order to avoid later
+                        // communication while the test is destroying. So if any error occurs here it is not very important,
+                        // the most time it will be a missing communicator error, due to disabled config.
+                        .catch(_.noop);
+                }
+            });
         },
 
         /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2809

Requires: https://github.com/oat-sa/extension-tao-test/pull/132

The issue can be reproduced with the blurPause plugin enabled:
1. start/resume a test
2. finish it
3. while it finishing, do not wait and loose the focus (click on another tab, selection of the console panel, etc.)
4. the finish action has been called twice