### PR TITLE
Fix stacking of pause/terminate dialogs

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -1,22 +1,22 @@
 <?php
-/*  
+/*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *               
- * 
+ *
+ *
  */
 ?>
 <?php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '4.5.2',
+    'version' => '4.5.3',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests'   => '>=2.23.0',
@@ -72,22 +72,22 @@ return array(
 	'constants' => array(
 		# actions directory
 		"DIR_ACTIONS"			=> $extpath."actions".DIRECTORY_SEPARATOR,
-	
+
 		# views directory
 		"DIR_VIEWS"				=> $extpath."views".DIRECTORY_SEPARATOR,
-	
+
 		# default module name
 		'DEFAULT_MODULE_NAME'	=> 'Main',
-	
+
 		#default action name
 		'DEFAULT_ACTION_NAME'	=> 'index',
-	
+
 		#BASE PATH: the root path in the file system (usually the document root)
 		'BASE_PATH'				=> $extpath,
-	
+
 		#BASE URL (usually the domain root)
 		'BASE_URL'				=> ROOT_URL	.'taoQtiTest/',
-	
+
 		#BASE WWW the web resources path
 		'BASE_WWW'				=> ROOT_URL	.'taoQtiTest/views/',
 	)

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -32,16 +32,16 @@ use oat\tao\scripts\update\OntologyUpdater;
  * @author Jean-S�bastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
 class Updater extends \common_ext_ExtensionUpdater {
-    
+
     /**
-     * 
+     *
      * @param string $initialVersion
      * @return string $versionUpdatedTo
      */
     public function update($initialVersion) {
 
         $currentVersion = $initialVersion;
-        
+
         // add testrunner config
         if ($currentVersion == '2.6') {
 
@@ -56,7 +56,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.6.1';
         }
-   
+
         if ($currentVersion == '2.6.1') {
             $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
             $config['exitButton'] = false;
@@ -64,7 +64,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.6.2';
         }
-        
+
         // add testrunner review screen config
         if ($currentVersion == '2.6.2') {
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
@@ -78,7 +78,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.6.3';
         }
-        
+
         // adjust testrunner config
         if ($currentVersion == '2.6.3') {
             $defaultConfig = array(
@@ -115,13 +115,13 @@ class Updater extends \common_ext_ExtensionUpdater {
         // add markForReview button
         if ($currentVersion === '2.7.0') {
             $registry = TestRunnerClientConfigRegistry::getRegistry();
-            
+
             $registry->registerQtiTools('markForReview', array(
                 'label' => 'Mark for review',
                 'icon' => 'anchor',
                 'hook' => 'taoQtiTest/testRunner/actionBar/markForReview'
             ));
-            
+
             $currentVersion = '2.8.0';
          }
 
@@ -140,7 +140,7 @@ class Updater extends \common_ext_ExtensionUpdater {
         // adjust testrunner config: set the "can collapse" option
         if ($currentVersion == '2.9.0') {
             $registry = TestRunnerClientConfigRegistry::getRegistry();
-            
+
             $registry->registerQtiTools('collapseReview', array(
                 'title' => 'Show/Hide the review screen',
                 'label' => 'Review',
@@ -181,7 +181,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.12.0';
         }
-        
+
         // update the test taker review action buttons
         if ($currentVersion == '2.12.0') {
             $registry = TestRunnerClientConfigRegistry::getRegistry();
@@ -214,7 +214,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.14.0';
         }
-        
+
         if ($currentVersion === '2.14.0') {
             try {
                 $this->getServiceManager()->get('taoQtiTest/SessionStateService');
@@ -236,7 +236,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $currentVersion = '2.16.0';
         }
-        
+
         $this->setVersion($currentVersion);
 
         if ($this->isBetween('2.16.0','2.17.0')) {
@@ -252,12 +252,12 @@ class Updater extends \common_ext_ExtensionUpdater {
 
                 $this->getServiceManager()->register(QtiRunnerService::CONFIG_ID, $service);
             }
-            
+
             $this->setVersion('2.17.0');
         }
-        
+
         $this->skip('2.17.0','2.19.1');
-        
+
         if ($this->isVersion('2.19.1')) {
             // sets default plugin options
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
@@ -290,7 +290,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('2.23.0');
         }
-        
+
         $this->skip('2.23.0','2.24.0');
 
         if ($this->isVersion('2.24.0')) {
@@ -322,7 +322,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('2.26.0');
         }
-        
+
         $this->skip('2.26.0', '2.27.0');
 
         if ($this->isVersion('2.27.0')) {
@@ -424,37 +424,37 @@ class Updater extends \common_ext_ExtensionUpdater {
                         'params' => []
                     ],
                 ]);
-                
+
                 $extension->setConfig('testRunner', $config);
             }
-            
+
             $this->setVersion('2.31.1');
         }
 
         $this->skip('2.31.1', '3.0.0');
-        
+
         if ($this->isVersion('3.0.0')) {
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
             $config = $extension->getConfig('testRunner');
             $config['enable-allow-skipping'] = false;
             $extension->setConfig('testRunner', $config);
-            
+
             $this->setVersion('3.1.0');
         }
 
         $this->skip('3.1.0', '3.4.0');
-        
+
         if ($this->isVersion('3.4.0')) {
             $ext = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
             $uri = $ext->getConfig(\taoQtiTest_models_classes_QtiTestService::CONFIG_QTITEST_FILESYSTEM);
             $dir = new \core_kernel_file_File($uri);
-            
+
             $fs = $dir->getFileSystem();
             \taoQtiTest_models_classes_QtiTestService::singleton()->setQtiTestFileSystem($fs);
-            
+
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '4.5.2');
+        $this->skip('4.0.0', '4.5.3');
     }
 }

--- a/views/js/runner/plugins/controls/testState/testState.js
+++ b/views/js/runner/plugins/controls/testState/testState.js
@@ -67,11 +67,13 @@ define([
          */
         init: function init() {
             var testRunner = this.getTestRunner();
+            var isLeaving = false;
 
             // immediate handling of proctor's actions
             testRunner.getProxy()
                 .channel('teststate', function (data) {
-                    if (data && ('close' === data.type || 'pause' === data.type)) {
+                    if (!isLeaving && data && ('close' === data.type || 'pause' === data.type)) {
+                        isLeaving = true;
                         testRunner.trigger('leave', data);
                     }
                 });


### PR DESCRIPTION
Prevent the pause/terminate alerts to be stacked each time the heartbeat occurs once the test is paused/closed.

Steps to reproduce:

1. Start a test
2. As a proctor, pause or terminate the test
3. Wait for the pause/terminate alert and, do not close it
4. Wait for the next heartbeat: a new alert will be stacked over the previous one, and so on for each hearbeat