### PR TITLE
Feature/always allow jumps

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -299,5 +299,11 @@ return array(
      * Enable path tracking (consider taken route items, rather than default route item flow for navigation).
      * @type boolean
      */
-    'path-tracking' => false
+    'path-tracking' => false,
+    
+    /**
+     * Always allow jumps, even if the current navigation mode is linear.
+     * @type boolean
+     */
+    'always-allow-jumps' => false
 );

--- a/helpers/class.SessionManager.php
+++ b/helpers/class.SessionManager.php
@@ -125,9 +125,11 @@ class taoQtiTest_helpers_SessionManager extends AbstractSessionManager {
         $forceBranchrules = (isset($config['force-branchrules'])) ? $config['force-branchrules'] : false;
         $forcePreconditions = (isset($config['force-preconditions'])) ? $config['force-preconditions'] : false;
         $pathTracking = (isset($config['path-tracking'])) ? $config['path-tracking'] : false;
+        $alwaysAllowJumps = (isset($config['always-allow-jumps'])) ? $config['always-allow-jumps'] : false;
         
         $assessmentTestSession->setForceBranching($forceBranchrules);
         $assessmentTestSession->setForcePreconditions($forcePreconditions);
+        $assessmentTestSession->setAlwaysAllowJumps($alwaysAllowJumps);
         $assessmentTestSession->setPathTracking($pathTracking);
         
         return $assessmentTestSession;

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.0.0',
-        'taoQtiItem' => '>=4.1',
+        'taoQtiItem' => '>=4.2',
         'tao'        => '>=6.0.0'
     ),
 	'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.6.0',
+    'version' => '5.7.0',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -549,5 +549,16 @@ class Updater extends \common_ext_ExtensionUpdater {
             
             $this->setVersion('5.6.0');
         }
+        
+        if ($this->isVersion('5.6.0')) {
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+            
+            $config = $extension->getConfig('testRunner');
+            $config['always-allow-jumps'] = false;
+            
+            $extension->setConfig('testRunner', $config);
+            
+            $this->setVersion('5.7.0');
+        }
     }
 }


### PR DESCRIPTION
This feature makes possible to configure whether or not the candidate can jump from items to items in QTI tests even if the current navigation mode is linear.