### PR TITLE
Fix/timer single attempt

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -511,6 +511,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
         try {
             $serviceContext = $this->getServiceContext();
+            $serviceContext->getTestSession()->initItemTimer();
             $result = $this->runnerService->move($serviceContext, $direction, $scope, $ref);
             
             $response = [

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.8.1',
+    'version' => '5.8.2',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -535,32 +535,32 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('5.5.0', '5.5.3');
-        
+
         if ($this->isVersion('5.5.3')) {
-            
+
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
-            
+
             $config = $extension->getConfig('testRunner');
             $config['force-branchrules'] = false;
             $config['force-preconditions'] = false;
             $config['path-tracking'] = false;
-            
+
             $extension->setConfig('testRunner', $config);
-            
+
             $this->setVersion('5.6.0');
         }
-        
+
         if ($this->isVersion('5.6.0')) {
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
-            
+
             $config = $extension->getConfig('testRunner');
             $config['always-allow-jumps'] = false;
-            
+
             $extension->setConfig('testRunner', $config);
-            
+
             $this->setVersion('5.7.0');
         }
-        
-        $this->skip('5.7.0', '5.8.1');
+
+        $this->skip('5.7.0', '5.8.2');
     }
 }


### PR DESCRIPTION
When navigating on a test that contains single-attempt items, an error occurs when we passthrough an already responded item. This error is due to the timing API, the timer being started by `getItem` and closed by `submitItem`: as no `submitItem` is done, the timer is inconsistent.