### PR TITLE
Let the timer continue while the prevent skip message is displayed

### DIFF
--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -242,15 +242,11 @@ define([
                         .then(function(result){
                             return new Promise(function(resolve, reject){
 
-                                function resumeItem() {
-                                    self.trigger('resumeitem');
-                                }
-
                                 if (result.notAllowed) {
+                                    self.trigger('resumeitem');
+
                                     if (result.message) {
-                                        self.trigger('alert', result.message, resumeItem);
-                                    } else {
-                                        resumeItem();
+                                        self.trigger('alert', result.message);
                                     }
 
                                     return reject(true);


### PR DESCRIPTION
When the current item cannot be left without an response, the timer still continues while the message box is displayed