### PR TITLE
Feature/tao 3008 autocomplete timeout

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,12 +33,12 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.8.3',
+    'version' => '5.9.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.0.0',
         'taoQtiItem' => '>=4.2',
-        'tao'        => '>=6.0.0'
+        'tao'        => '>=7.6.0'
     ),
 	'models' => array(
 		'http://www.tao.lu/Ontologies/TAOTest.rdf'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -561,6 +561,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.7.0');
         }
 
-        $this->skip('5.7.0', '5.8.3');
+        $this->skip('5.7.0', '5.9.0');
     }
 }

--- a/views/js/runner/plugins/content/dialog/dialog.js
+++ b/views/js/runner/plugins/content/dialog/dialog.js
@@ -57,11 +57,13 @@ define([
             }
 
             function removeHandle(stack, dialog) {
-                _.forEach(stack, function(handle, index) {
-                    if (handle && dialog && dialog === handle.dialog) {
-                        stack[index] = null;
-                    }
-                });
+                if (dialog) {
+                    _.remove(stack, function(handle) {
+                        if (handle && dialog === handle.dialog) {
+                            return true;
+                        }
+                    });
+                }
             }
 
             function closeDialogs(namespace, accept, stack) {
@@ -69,6 +71,7 @@ define([
                     _.forEach(stack, function(handle) {
                         if (handle && (namespace === '@' || namespace === handle.context)) {
                             if (accept) {
+                                // TODO: improve the dialog implementation in order to provide a better API
                                 handle.dialog.trigger('okbtn.modal');
                             }
                             handle.dialog.hide();
@@ -80,24 +83,16 @@ define([
                 }
             }
 
-            function cleanUp() {
-                alerts = _.compact(alerts);
-                confirms = _.compact(confirms);
-            }
-
             //change plugin state
             testRunner
                 .before('alert.*', function(e, msg, accept) {
                     addHandle(e.namespace, alerts, dialogAlert(msg, accept));
-                    _.defer(cleanUp);
                 })
                 .before('confirm.*', function(e, msg, accept, reject) {
                     addHandle(e.namespace, confirms, dialogConfirm(msg, accept, reject));
-                    _.defer(cleanUp);
                 })
                 .before('closedialog.*', function(e, accept) {
                     closeDialogs(e.namespace, accept);
-                    _.defer(cleanUp);
                 });
         }
     });

--- a/views/js/runner/plugins/content/dialog/exitMessages.js
+++ b/views/js/runner/plugins/content/dialog/exitMessages.js
@@ -59,7 +59,7 @@ define([
                     }
 
                     // wait for the message acknowledge before leaving the runner
-                    testRunner.trigger('alert', data.message, function () {
+                    testRunner.trigger('alert.leave', data.message, function () {
                         testRunner.trigger('endsession', 'teststate', data.code);
                         done();
                     });

--- a/views/js/runner/plugins/content/dialog/exitMessages.js
+++ b/views/js/runner/plugins/content/dialog/exitMessages.js
@@ -20,8 +20,9 @@
  */
 define([
     'lodash',
+    'core/promise',
     'taoTests/runner/plugin'
-], function (_, pluginFactory) {
+], function (_, Promise, pluginFactory) {
     'use strict';
 
     /**
@@ -49,19 +50,20 @@ define([
             // then if a message needs to be displayed displays it and waits the user acknowledges it
             testRunner.before('leave', function leave(e, data) {
                 if (_.isObject(data) && data.message) {
-                    var done = e.done();
-                    var context = testRunner.getTestContext();
+                    return new Promise(function(resolve) {
+                        var context = testRunner.getTestContext();
 
-                    // the leave can occurs when the runner is in inconsistent state (i.e. error)
-                    // prevent side error with item disabling
-                    if (context && context.itemUri) {
-                        testRunner.disableItem(context.itemUri);
-                    }
+                        // the leave can occurs when the runner is in inconsistent state (i.e. error)
+                        // prevent side error with item disabling
+                        if (context && context.itemUri) {
+                            testRunner.disableItem(context.itemUri);
+                        }
 
-                    // wait for the message acknowledge before leaving the runner
-                    testRunner.trigger('alert.leave', data.message, function () {
-                        testRunner.trigger('endsession', 'teststate', data.code);
-                        done();
+                        // wait for the message acknowledge before leaving the runner
+                        testRunner.trigger('alert.leave', data.message, function () {
+                            testRunner.trigger('endsession', 'teststate', data.code);
+                            resolve();
+                        });
                     });
                 }
             });

--- a/views/js/runner/plugins/content/feedback/feedback.js
+++ b/views/js/runner/plugins/content/feedback/feedback.js
@@ -92,7 +92,7 @@ define([
                 .on('info', function(message){
                     currentFeedback = feedback().info(message);
                 })
-                .on('alert confirm unloaditem', closeCurrent);
+                .on('alert.* confirm.* unloaditem', closeCurrent);
         }
     });
 });

--- a/views/js/runner/plugins/controls/duration/duration.js
+++ b/views/js/runner/plugins/controls/duration/duration.js
@@ -106,7 +106,7 @@ define([
                                 self.enable();
                             })
 
-                            .before('move disableitem skip error', function(e){
+                            .before('move disableitem skip error', function(){
                                 if (self.getState('enabled')) {
                                     self.disable();
                                 }
@@ -131,12 +131,12 @@ define([
                                 }
                             })
 
-                            .before('finish', function(e){
-                                var done = e.done();
-
-                                durationStore.removeStore()
-                                    .then(done)
-                                    .catch(done);
+                            .before('finish', function(){
+                                return new Promise(function(resolve) {
+                                    durationStore.removeStore()
+                                        .then(resolve)
+                                        .catch(resolve);
+                                });
                             });
                     });
             });

--- a/views/js/runner/plugins/controls/timer/timer.js
+++ b/views/js/runner/plugins/controls/timer/timer.js
@@ -25,6 +25,7 @@ define([
     'jquery',
     'lodash',
     'i18n',
+    'core/promise',
     'core/polling',
     'core/timer',
     'core/store',
@@ -33,7 +34,7 @@ define([
     'taoQtiTest/runner/plugins/controls/timer/timerComponent',
     'taoQtiTest/runner/helpers/messages',
     'tpl!taoQtiTest/runner/plugins/controls/timer/timers'
-], function ($, _, __, pollingFactory, timerFactory, store, hider, pluginFactory, timerComponentFactory, messages, timerBoxTpl) {
+], function ($, _, __, Promise, pollingFactory, timerFactory, store, hider, pluginFactory, timerComponentFactory, messages, timerBoxTpl) {
     'use strict';
 
     /**
@@ -333,37 +334,36 @@ define([
                             }
                         })
                         .before('move', function(e, type, scope, position){
-                            var done = e.done();
+                            var movePromise = new Promise(function(resolve, reject) {
+                                //pause the timers
+                                if (self.getState('enabled')) {
+                                    self.disable();
+                                }
 
-                            var doMove = function doMove(){
-                                removeTimer(timerTypes.item);
-                                done();
-                            };
+                                //display a message if we exit a timed section
+                                if(leaveTimedSection(type, scope, position)){
+                                    testRunner.trigger('confirm.exittimed', messages.getExitMessage(exitMessage, 'section', testRunner), resolve, reject);
+                                } else {
+                                    resolve();
+                                }
+                            });
 
-                            var cancelMove = function cancelMove() {
-                                testRunner.trigger('enableitem enablenav');
-                                e.prevent();
-                            };
+                            movePromise
+                                .then(function doMove(){
+                                    removeTimer(timerTypes.item);
+                                })
+                                .catch(function cancelMove() {
+                                    testRunner.trigger('enableitem enablenav');
+                                });
 
-                            //pause the timers
-                            if (self.getState('enabled')) {
-                                self.disable();
-                            }
-
-                            //display a mesage if we exit a timed section
-                            if(leaveTimedSection(type, scope, position)){
-                                testRunner.trigger('confirm.exittimed', messages.getExitMessage(exitMessage, 'section', testRunner), doMove, cancelMove);
-                            } else {
-                                doMove();
-                            }
+                            return movePromise;
                         })
-                        .before('finish', function(e){
-                            var done = e.done();
-
-                            //clean up the storage at the end
-                            self.storage.removeStore()
-                                .then(done)
-                                .catch(done);
+                        .before('finish', function(){
+                            return new Promise(function(resolve) {
+                                self.storage.removeStore()
+                                    .then(resolve)
+                                    .catch(resolve);
+                            });
                         });
                 });
         },

--- a/views/js/runner/plugins/controls/timer/timer.js
+++ b/views/js/runner/plugins/controls/timer/timer.js
@@ -352,7 +352,7 @@ define([
 
                             //display a mesage if we exit a timed section
                             if(leaveTimedSection(type, scope, position)){
-                                testRunner.trigger('confirm', messages.getExitMessage(exitMessage, 'section', testRunner), doMove, cancelMove);
+                                testRunner.trigger('confirm.exittimed', messages.getExitMessage(exitMessage, 'section', testRunner), doMove, cancelMove);
                             } else {
                                 doMove();
                             }

--- a/views/js/runner/plugins/navigation/nextSection.js
+++ b/views/js/runner/plugins/navigation/nextSection.js
@@ -68,7 +68,7 @@ define([
 
                     if(context.options.nextSectionWarning){
                         testRunner.trigger(
-                            'confirm',
+                            'confirm.nextsection',
                             messages.getExitMessage(
                                 __('After you complete the section it would be impossible to return to this section to make changes. Are you sure you want to end the section?'),
                                 'section', testRunner),

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -634,20 +634,20 @@ define([
                 // will be executed after the runner has been flushed
                 // use the "before" queue to ensure the query will be fully processed before destroying
                 // we do not use the "destroy" event because the proxy is destroyed before this event is triggered
-                this.before('flush', function(e) {
-                    var done = e.done();
-
-                    this.getProxy()
+                this.before('flush', function() {
+                    var finishPromise = this.getProxy()
                         .callTestAction('finish')
                         .then(function() {
                             if (self.stateStorage) {
                                 return self.stateStorage.removeStore();
                             }
-                        })
-                        .then(done)
-                        .catch(function(err) {
-                            self.trigger('error', err);
                         });
+
+                    finishPromise.catch(function(err) {
+                        self.trigger('error', err);
+                    });
+
+                    return finishPromise;
                 });
             }
         },

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -246,7 +246,7 @@ define([
                                     self.trigger('resumeitem');
 
                                     if (result.message) {
-                                        self.trigger('alert', result.message);
+                                        self.trigger('alert.notallowed', result.message);
                                     }
 
                                     return reject(true);
@@ -388,7 +388,7 @@ define([
                     submit(true)
                         .then(updateStats)
                         .then(function() {
-                            self.trigger('alert', __('Time limit reached, this part of the test has ended.'), function() {
+                            self.trigger('alert.timeout', __('Time limit reached, this part of the test has ended.'), function() {
                                 computeNext('timeout', {
                                     scope: scope,
                                     ref: ref

--- a/views/js/test/runner/mocks/dialogAlertMock.js
+++ b/views/js/test/runner/mocks/dialogAlertMock.js
@@ -1,0 +1,57 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'core/eventifier'
+], function (_, eventifier) {
+    'use strict';
+
+    function dialogAlert(message, action) {
+        var dlg = eventifier({
+            hide: function() {
+                this.trigger('closed.modal');
+            }
+        });
+
+        if (_.isFunction(action)) {
+            dlg.on('closed.modal', function() {
+                if (_.isFunction(action)) {
+                    action.call(this);
+                }
+                dialogAlert.trigger('accept', dlg);
+                dialogAlert.trigger('close', dlg);
+            });
+        }
+
+        dialogAlert.trigger('create', message, dlg);
+
+        return dlg;
+    }
+
+    dialogAlert.hit = function hit(dlg, button) {
+        dlg.trigger((button || 'ok') + 'btn.modal');
+        _.defer(function() {
+            dlg.hide();
+        });
+    };
+
+    return eventifier(dialogAlert);
+});

--- a/views/js/test/runner/mocks/dialogConfirmMock.js
+++ b/views/js/test/runner/mocks/dialogConfirmMock.js
@@ -1,0 +1,70 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'core/eventifier'
+], function (_, eventifier) {
+    'use strict';
+
+    function dialogConfirm(message, accept, refuse) {
+        var accepted = false;
+        var dlg = eventifier({
+            hide: function() {
+                this.trigger('closed.modal');
+            }
+        });
+
+        dlg.on('okbtn.modal', function() {
+            accepted = true;
+        });
+
+        if (_.isFunction(refuse)) {
+            dlg.on('closed.modal', function() {
+                if (!accepted) {
+                    if (_.isFunction(refuse)) {
+                        refuse.call(this);
+                    }
+                    dialogConfirm.trigger('reject', dlg);
+                } else {
+                    if (_.isFunction(accept)) {
+                        accept.call(this);
+                    }
+                    dialogConfirm.trigger('accept', dlg);
+                }
+
+                dialogConfirm.trigger('close', dlg);
+            });
+        }
+
+        dialogConfirm.trigger('create', message, dlg);
+
+        return dlg;
+    }
+
+    dialogConfirm.hit = function hit(dlg, button) {
+        dlg.trigger((button || 'cancel') + 'btn.modal');
+        _.defer(function() {
+            dlg.hide();
+        });
+    };
+
+    return eventifier(dialogConfirm);
+});

--- a/views/js/test/runner/plugins/content/dialog/test.html
+++ b/views/js/test/runner/plugins/content/dialog/test.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner - Plugin Dialog</title>
+        <base href="../../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="runner/plugins/content/dialog/dialog.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //fake modules
+                requirejs.config({
+                    "paths": {
+                        "ui/dialog/alert" : "/taoQtiTest/views/js/test/runner/mocks/dialogAlertMock",
+                        "ui/dialog/confirm" : "/taoQtiTest/views/js/test/runner/mocks/dialogConfirmMock"
+                    }
+                });
+
+                //load the test
+                require(['taoQtiTest/test/runner/plugins/content/dialog/test'], function(){
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/plugins/content/dialog/test.js
+++ b/views/js/test/runner/plugins/content/dialog/test.js
@@ -1,0 +1,823 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'helpers',
+    'core/promise',
+    'ui/dialog/alert',
+    'ui/dialog/confirm',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/runner/plugins/content/dialog/dialog'
+], function(_, helpers, Promise, dialogAlert, dialogConfirm, runnerFactory, providerMock, dialogFactory) {
+    'use strict';
+
+    var providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+
+    QUnit.module('dialogFactory');
+
+
+    QUnit.test('module', function(assert) {
+        var runner = runnerFactory(providerName);
+
+        QUnit.expect(3);
+
+        assert.equal(typeof dialogFactory, 'function', "The dialogFactory module exposes a function");
+        assert.equal(typeof dialogFactory(runner), 'object', "The dialogFactory factory produces an instance");
+        assert.notStrictEqual(dialogFactory(runner), dialogFactory(runner), "The dialogFactory factory provides a different instance on each call");
+    });
+
+
+    var pluginApi = [
+        { name : 'init', title : 'init' },
+        { name : 'render', title : 'render' },
+        { name : 'finish', title : 'finish' },
+        { name : 'destroy', title : 'destroy' },
+        { name : 'trigger', title : 'trigger' },
+        { name : 'getTestRunner', title : 'getTestRunner' },
+        { name : 'getAreaBroker', title : 'getAreaBroker' },
+        { name : 'getConfig', title : 'getConfig' },
+        { name : 'setConfig', title : 'setConfig' },
+        { name : 'getState', title : 'getState' },
+        { name : 'setState', title : 'setState' },
+        { name : 'show', title : 'show' },
+        { name : 'hide', title : 'hide' },
+        { name : 'enable', title : 'enable' },
+        { name : 'disable', title : 'disable' }
+    ];
+
+    QUnit
+        .cases(pluginApi)
+        .test('plugin API ', function(data, assert) {
+            var runner = runnerFactory(providerName);
+            var timer = dialogFactory(runner);
+
+            QUnit.expect(1);
+
+            assert.equal(typeof timer[data.name], 'function', 'The dialogFactory instances expose a "' + data.name + '" function');
+        });
+
+
+    QUnit.asyncTest('dialog.init', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+
+        QUnit.expect(1);
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                QUnit.start();
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.module('dialog alert', {
+        setup: function () {
+            dialogAlert.removeAllListeners();
+        },
+        teardown: function () {
+            dialogAlert.removeAllListeners();
+        }
+    });
+
+
+    QUnit.asyncTest('simple alert', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'Hello';
+
+        QUnit.expect(5);
+
+        dialogAlert.on('create', function(message, dlg) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+            dlg.hide();
+        });
+
+        dialogAlert.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('alert', expectedMessage, function() {
+                    assert.ok(true, 'The message has been acknowledged');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('namespace alert', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'timeout!';
+
+        QUnit.expect(5);
+
+        dialogAlert.on('create', function(message, dlg) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+            dlg.hide();
+        });
+
+        dialogAlert.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('alert.timeout', expectedMessage, function() {
+                    assert.ok(true, 'The message has been acknowledged');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+
+    QUnit.module('dialog confirm', {
+        setup: function () {
+            dialogConfirm.removeAllListeners();
+        },
+        teardown: function () {
+            dialogConfirm.removeAllListeners();
+        }
+    });
+
+
+    QUnit.asyncTest('simple confirm accepted', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'Hello?';
+
+        QUnit.expect(5);
+
+        dialogConfirm.on('create', function(message, dlg) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+            dialogConfirm.hit(dlg, 'ok');
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm', expectedMessage, function() {
+                    assert.ok(true, 'The message has been accepted');
+                }, function() {
+                    assert.ok(false, 'The message should not be rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('namespace confirm accepted', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'exit?';
+
+        QUnit.expect(5);
+
+        dialogConfirm.on('create', function(message, dlg) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+            dialogConfirm.hit(dlg, 'ok');
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm.exit', expectedMessage, function() {
+                    assert.ok(true, 'The message has been accepted');
+                }, function() {
+                    assert.ok(false, 'The message should not be rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('simple confirm rejected', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'Hello?';
+
+        QUnit.expect(5);
+
+        dialogConfirm.on('create', function(message, dlg) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+            dlg.hide();
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm', expectedMessage, function() {
+                    assert.ok(false, 'The message should not be accepted');
+                }, function() {
+                    assert.ok(true, 'The message has been rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('namespace confirm rejected', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'exit?';
+
+        QUnit.expect(5);
+
+        dialogConfirm.on('create', function(message, dlg) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+            dlg.hide();
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm.exit', expectedMessage, function() {
+                    assert.ok(false, 'The message should not be accepted');
+                }, function() {
+                    assert.ok(true, 'The message has been rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.module('close dialogs', {
+        setup: function () {
+            dialogAlert.removeAllListeners();
+            dialogConfirm.removeAllListeners();
+        },
+        teardown: function () {
+            dialogAlert.removeAllListeners();
+            dialogConfirm.removeAllListeners();
+        }
+    });
+
+
+    QUnit.asyncTest('simple alert', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'Hello';
+
+        QUnit.expect(5);
+
+        dialogAlert.on('create', function(message) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+
+            _.defer(function() {
+                runner.trigger('closedialog');
+            });
+
+        });
+
+        dialogAlert.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('alert', expectedMessage, function() {
+                    assert.ok(true, 'The message has been acknowledged');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('simple confirm accept', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'Hello';
+
+        QUnit.expect(5);
+
+        dialogConfirm.on('create', function(message) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+
+            _.defer(function() {
+                runner.trigger('closedialog', true);
+            });
+
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm', expectedMessage, function() {
+                    assert.ok(true, 'The message has been accepted');
+                }, function() {
+                    assert.ok(false, 'The message should not be rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('simple confirm reject', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'Hello';
+
+        QUnit.expect(5);
+
+        dialogConfirm.on('create', function(message) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+
+            _.defer(function() {
+                runner.trigger('closedialog');
+            });
+
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm', expectedMessage, function() {
+                    assert.ok(false, 'The message should not be accepted');
+                }, function() {
+                    assert.ok(true, 'The message has been rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('alert and confirm', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedAlertMessage = 'Hello';
+        var expectedConfirmMessage = 'exit?';
+        var stack = [];
+
+        QUnit.expect(9);
+        QUnit.stop();
+
+        stack.push(new Promise(function (resolve) {
+            dialogAlert.on('create', function(message) {
+                assert.ok(true, 'A alert dialog has been created');
+                assert.equal(message, expectedAlertMessage, 'The expected alert message has been displayed');
+                resolve();
+            });
+        }));
+
+        stack.push(new Promise(function (resolve) {
+            dialogConfirm.on('create', function(message) {
+                assert.ok(true, 'A confirm dialog has been created');
+                assert.equal(message, expectedConfirmMessage, 'The expected confirm message has been displayed');
+                resolve();
+            });
+        }));
+
+        Promise.all(stack).then(function() {
+            runner.trigger('closedialog');
+        });
+
+        dialogAlert.on('close', function() {
+            assert.ok(true, 'The alert dialog has been closed');
+            QUnit.start();
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The confirm dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('alert', expectedAlertMessage, function() {
+                    assert.ok(true, 'The alert message has been acknowledged');
+                });
+
+                runner.trigger('confirm', expectedConfirmMessage, function() {
+                    assert.ok(false, 'The confirm message should not be accepted');
+                }, function() {
+                    assert.ok(true, 'The confirm message has been rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('namespace alert', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'Hello';
+        var count = 0;
+
+        QUnit.expect(7);
+
+        dialogAlert.on('create', function(message) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+
+            if (++count === 2) {
+                _.defer(function() {
+                    runner.trigger('closedialog.timeout');
+                });
+            }
+        });
+
+        dialogAlert.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('alert', expectedMessage, function() {
+                    assert.ok(false, 'The message without namespace should not be acknowledged');
+                });
+
+                runner.trigger('alert.timeout', expectedMessage, function() {
+                    assert.ok(true, 'The message with namespace has been acknowledged');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('namespace confirm accept', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'exit?';
+        var count = 0;
+
+        QUnit.expect(7);
+
+        dialogConfirm.on('create', function(message) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+
+            if (++count === 2) {
+                _.defer(function() {
+                    runner.trigger('closedialog.exit', true);
+                });
+            }
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm', expectedMessage, function() {
+                    assert.ok(false, 'The message without namespace should not be accepted');
+                }, function() {
+                    assert.ok(false, 'The message without namespace should not be rejected');
+                });
+
+                runner.trigger('confirm.exit', expectedMessage, function() {
+                    assert.ok(true, 'The message with namespace has been accepted');
+                }, function() {
+                    assert.ok(false, 'The message with namespace should not be rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('namespace confirm reject', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedMessage = 'exit?';
+        var count = 0;
+
+        QUnit.expect(7);
+
+        dialogConfirm.on('create', function(message) {
+            assert.ok(true, 'A dialog has been created');
+            assert.equal(message, expectedMessage, 'The expected message has been displayed');
+
+            if (++count === 2) {
+                _.defer(function() {
+                    runner.trigger('closedialog.exit');
+                });
+            }
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('confirm', expectedMessage, function() {
+                    assert.ok(false, 'The message without namespace should not be accepted');
+                }, function() {
+                    assert.ok(false, 'The message without namespace should not be rejected');
+                });
+
+                runner.trigger('confirm.exit', expectedMessage, function() {
+                    assert.ok(false, 'The message with namespace should not be accepted');
+                }, function() {
+                    assert.ok(true, 'The message with namespace has been rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('same namespace alert and confirm', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedAlertMessage = 'Hello';
+        var expectedConfirmMessage = 'exit?';
+        var stack = [];
+        var countAlert = 0;
+        var countConfirm = 0;
+
+        QUnit.expect(13);
+        QUnit.stop();
+
+        stack.push(new Promise(function (resolve) {
+            dialogAlert.on('create', function(message) {
+                assert.ok(true, 'A alert dialog has been created');
+                assert.equal(message, expectedAlertMessage, 'The expected alert message has been displayed');
+
+                if (++countAlert === 2) {
+                    resolve();
+                }
+            });
+        }));
+
+        stack.push(new Promise(function (resolve) {
+            dialogConfirm.on('create', function(message) {
+                assert.ok(true, 'A confirm dialog has been created');
+                assert.equal(message, expectedConfirmMessage, 'The expected confirm message has been displayed');
+
+                if (++countConfirm === 2) {
+                    resolve();
+                }
+            });
+        }));
+
+        Promise.all(stack).then(function() {
+            runner.trigger('closedialog.ns');
+        });
+
+        dialogAlert.on('close', function() {
+            assert.ok(true, 'The alert dialog has been closed');
+            QUnit.start();
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The confirm dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('alert', expectedAlertMessage, function() {
+                    assert.ok(false, 'The alert message without namespace should not be acknowledged');
+                });
+
+                runner.trigger('alert.ns', expectedAlertMessage, function() {
+                    assert.ok(true, 'The alert message with namespace has been acknowledged');
+                });
+
+                runner.trigger('confirm', expectedConfirmMessage, function() {
+                    assert.ok(false, 'The confirm message without namespace should not be accepted');
+                }, function() {
+                    assert.ok(false, 'The confirm message without namespace should not be rejected');
+                });
+
+                runner.trigger('confirm.ns', expectedConfirmMessage, function() {
+                    assert.ok(false, 'The confirm message with namespace should not be accepted');
+                }, function() {
+                    assert.ok(true, 'The confirm message with namespace has been rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('different namespace alert and confirm', function(assert) {
+        var runner = runnerFactory(providerName);
+        var dialog = dialogFactory(runner, runner.getAreaBroker());
+        var expectedAlertMessage = 'Hello';
+        var expectedConfirmMessage = 'exit?';
+        var stack = [];
+        var countAlert = 0;
+        var countConfirm = 0;
+
+        QUnit.expect(11);
+
+        stack.push(new Promise(function (resolve) {
+            dialogAlert.on('create', function(message) {
+                assert.ok(true, 'A alert dialog has been created');
+                assert.equal(message, expectedAlertMessage, 'The expected alert message has been displayed');
+
+                if (++countAlert === 2) {
+                    resolve();
+                }
+            });
+        }));
+
+        stack.push(new Promise(function (resolve) {
+            dialogConfirm.on('create', function(message) {
+                assert.ok(true, 'A confirm dialog has been created');
+                assert.equal(message, expectedConfirmMessage, 'The expected confirm message has been displayed');
+
+                if (++countConfirm === 2) {
+                    resolve();
+                }
+            });
+        }));
+
+        Promise.all(stack).then(function() {
+            runner.trigger('closedialog.ns1');
+        });
+
+        dialogAlert.on('close', function() {
+            assert.ok(true, 'The alert dialog has been closed');
+            QUnit.start();
+        });
+
+        dialogConfirm.on('close', function() {
+            assert.ok(true, 'The confirm dialog has been closed');
+            QUnit.start();
+        });
+
+        dialog.init()
+            .then(function() {
+                assert.equal(dialog.getState('init'), true, 'The plugin is initialized');
+
+                runner.trigger('alert', expectedAlertMessage, function() {
+                    assert.ok(false, 'The alert message without namespace should not be acknowledged');
+                });
+
+                runner.trigger('alert.ns1', expectedAlertMessage, function() {
+                    assert.ok(true, 'The alert message with namespace has been acknowledged');
+                });
+
+                runner.trigger('confirm', expectedConfirmMessage, function() {
+                    assert.ok(false, 'The confirm message without namespace should not be accepted');
+                }, function() {
+                    assert.ok(false, 'The confirm message without namespace should not be rejected');
+                });
+
+                runner.trigger('confirm.ns2', expectedConfirmMessage, function() {
+                    assert.ok(false, 'The confirm message with namespace should not be accepted');
+                }, function() {
+                    assert.ok(false, 'The confirm message with namespace should not be rejected');
+                });
+            })
+            .catch(function(err) {
+                console.log(err);
+                assert.ok(false, 'The init method must not fail');
+                QUnit.start();
+            });
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3008

Requires: https://github.com/oat-sa/tao-core/pull/976

Use namespace for alert/confirm events
Use the new async events syntaxe.

The dialogs can now be closed by the `closedialog` event.  The namespace allows to only target particular kinds of dialogs.

```javascript
// display simple alerts
runner.trigger('alert.hello', 'Hello!');
runner.trigger('alert.welcome', 'Welcome here');

// close only .hello dialog
runner.trigger('closedialog.hello');

// close all dialogs
runner.trigger('closedialog');


// display confirms
runner.trigger('confirm.want', 'Do you want?', function() {
    console.log('sure you want!');
}, function() {
    console.log('oh! really?');
});

runner.trigger('confirm.quit', 'You will leave if you hit Ok'), function() {
    console.log('Bye!');
}, function() {
    console.log('Take a sit...');
});

runner.trigger('confirm.stupid', 'Are you a piece of cake ?'), function() {
    console.log("Oh... that's your life");
}, function() {
    console.log('Are you sure?');
});

// close only .want dialog, with reject
runner.trigger('closedialog.want');

// close only .quit dialog, with accept
runner.trigger('closedialog.quit', true);

// close all dialogs, with reject
runner.trigger('closedialog');
```
