### PR TITLE
Feature/tao 2873 informational items

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -305,5 +305,12 @@ return array(
      * Always allow jumps, even if the current navigation mode is linear.
      * @type boolean
      */
-    'always-allow-jumps' => false
+    'always-allow-jumps' => false,
+
+    /**
+     * Checks if items are informational. This will change the behavior of the review panel: 
+     * the informational items are not taken into account in the answered/flagged counters
+     * @type boolean
+     */
+    'check-informational' => false,
 );

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -670,6 +670,15 @@ class taoQtiTest_helpers_TestRunnerUtils {
     }
 
     /**
+     * Checks if an item is informational
+     * @param AssessmentItemSession $itemSession
+     * @return bool
+     */
+    static public function isItemInformational(AssessmentItemSession $itemSession) {
+        return !count($itemSession->getAssessmentItem()->getResponseDeclarations());
+    }
+
+    /**
      * Checks if an item has been completed
      * @param RouteItem $routeItem
      * @param AssessmentItemSession $itemSession

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -670,12 +670,35 @@ class taoQtiTest_helpers_TestRunnerUtils {
     }
 
     /**
+     * Gets the usage of an item
+     * @param RouteItem $routeItem
+     * @return string Return the usage, can be: default, informational, seeding
+     */
+    static public function getItemUsage(RouteItem $routeItem)
+    {
+        $itemRef = $routeItem->getAssessmentItemRef();
+        $categories = $itemRef->getCategories()->getArrayCopy();
+        $prefixCategory = 'x-tao-itemusage-';
+        $prefixCategoryLen = strlen($prefixCategory);
+        foreach ($categories as $category) {
+            if (!strncmp($category, $prefixCategory, $prefixCategoryLen)) {
+                // extract the option name from the category, transform to camelCase if needed
+                return lcfirst(str_replace(' ', '', ucwords(strtr(substr($category, $prefixCategoryLen), ['-' => ' ', '_' => ' ']))));
+            }
+        }
+        
+        return 'default';
+    }
+
+    /**
      * Checks if an item is informational
+     * @param RouteItem $routeItem
      * @param AssessmentItemSession $itemSession
      * @return bool
      */
-    static public function isItemInformational(AssessmentItemSession $itemSession) {
-        return !count($itemSession->getAssessmentItem()->getResponseDeclarations());
+    static public function isItemInformational(RouteItem $routeItem, AssessmentItemSession $itemSession)
+    {
+        return !count($itemSession->getAssessmentItem()->getResponseDeclarations()) || 'informational' == self::getItemUsage($routeItem);
     }
 
     /**

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.10.1',
+    'version' => '5.11.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -72,7 +72,8 @@ class QtiRunnerConfig implements RunnerConfig
                     'target' => isset($rawConfig['timer']) && isset($rawConfig['timer']['target']) ? $rawConfig['timer']['target'] : null,
                     'resetAfterResume' => !empty($rawConfig['reset-timer-after-resume']),
                 ],
-                'enableAllowSkipping' => isset($rawConfig['enable-allow-skipping']) ? $rawConfig['enable-allow-skipping'] : false
+                'enableAllowSkipping' => isset($rawConfig['enable-allow-skipping']) ? $rawConfig['enable-allow-skipping'] : false,
+                'checkInformational' => isset($rawConfig['check-informational']) ? $rawConfig['check-informational'] : false,
             ];
         }
         return $this->config;

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -25,9 +25,8 @@ namespace oat\taoQtiTest\models\runner\map;
 use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use qtism\data\NavigationMode;
-use qtism\runtime\tests\AssessmentItemSession;
 use qtism\runtime\tests\AssessmentTestSession;
-use qtism\runtime\tests\RouteItem;
+use taoQtiTest_helpers_TestRunnerUtils as TestRunnerUtils;
 
 /**
  * Class QtiRunnerMap
@@ -50,6 +49,7 @@ class QtiRunnerMap implements RunnerMap
 
         // get config for the sequence number option
         $reviewConfig = $config->getConfigValue('review');
+        $checkInformational = $config->getConfigValue('checkInformational');
         $forceTitles = !empty($reviewConfig['forceTitle']);
         $uniqueTitle = isset($reviewConfig['itemTitle']) ? $reviewConfig['itemTitle'] : '%d';
         
@@ -107,10 +107,14 @@ class QtiRunnerMap implements RunnerMap
                     'index' => $offsetSection + 1,
                     'occurrence' => $occurrence,
                     'remainingAttempts' => $itemSession->getRemainingAttempts(),
-                    'answered' => \taoQtiTest_helpers_TestRunnerUtils::isItemCompleted($routeItem, $itemSession),
-                    'flagged' => \taoQtiTest_helpers_TestRunnerUtils::getItemFlag($session, $routeItem),
+                    'answered' => TestRunnerUtils::isItemCompleted($routeItem, $itemSession),
+                    'flagged' => TestRunnerUtils::getItemFlag($session, $routeItem),
                     'viewed' => $itemSession->isPresented(),
                 ];
+                
+                if ($checkInformational) {
+                    $itemInfos['informational'] = TestRunnerUtils::isItemInformational($itemSession);
+                }
                 
                 // update the map
                 $map['jumps'][] = [
@@ -156,11 +160,16 @@ class QtiRunnerMap implements RunnerMap
     {
         if (!isset($target['stats'])) {
             $target['stats'] = [
+                'questions' => 0,
                 'answered' => 0,
                 'flagged' => 0,
                 'viewed' => 0,
                 'total' => 0,
             ];
+        }
+
+        if (empty($itemInfos['informational'])) {
+            $target['stats']['questions'] ++;
         }
         
         if (!empty($itemInfos['answered'])) {

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -113,7 +113,7 @@ class QtiRunnerMap implements RunnerMap
                 ];
                 
                 if ($checkInformational) {
-                    $itemInfos['informational'] = TestRunnerUtils::isItemInformational($itemSession);
+                    $itemInfos['informational'] = TestRunnerUtils::isItemInformational($routeItem, $itemSession);
                 }
                 
                 // update the map

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -582,5 +582,16 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('5.9.0', '5.10.1');
+
+        if ($this->isVersion('5.10.1')) {
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+
+            $config = $extension->getConfig('testRunner');
+            $config['check-informational'] = false;
+
+            $extension->setConfig('testRunner', $config);
+
+            $this->setVersion('5.11.0');
+        }
     }
 }

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -24,20 +24,20 @@ define([
     'use strict';
 
     var _ns = '.sectionCategory';
-    
+
     /**
      * Check if the given object is a valid assessmentSection model object
-     * 
+     *
      * @param {object} model
      * @returns {boolean}
      */
     function isValidSectionModel(model){
         return (_.isObject(model) && model['qti-type'] === 'assessmentSection' && _.isArray(model.sectionParts));
     }
-    
+
     /**
      * Set an array of categories to the section model (affect the childen itemRef)
-     * 
+     *
      * @param {object} model
      * @param {array} categories
      * @returns {undefined}
@@ -45,21 +45,21 @@ define([
     function setCategories(model, categories){
 
         var oldCategories = getCategories(model);
-        
+
         //the categories that are no longer in the new list of categories should be removed
         var removed = _.difference(oldCategories.all, categories);
-        
+
         //the categories that are not in the old categories collection should be added to the children
         var propagated = _.difference(categories, oldCategories.all);
-        
+
         //process the modification
         addCategories(model, propagated);
         removeCategories(model, removed);
     }
-    
+
     /**
      * Get the categories assign to the section model, infered by its interal itemRefs
-     * 
+     *
      * @param {object} model
      * @returns {object}
      */
@@ -74,13 +74,13 @@ define([
             //array of categories
             var arrays = _.values(categories);
             var union = _.union.apply(null, arrays);
-            
+
             //categories that are common to all itemRef
             var propagated = _.intersection.apply(null, arrays);
-            
+
             //the categories that are only partially covered on the section level : complementary of "propagated"
             var partial = _.difference(union, propagated);
-            
+
             return {
                 all : union.sort(),
                 propagated : propagated.sort(),
@@ -90,10 +90,10 @@ define([
             errorHandler.throw(_ns, 'invalid tool config format');
         }
     }
-    
+
     /**
      * Add an array of categories to a section model (affect the childen itemRef)
-     * 
+     *
      * @param {object} model
      * @param {array} categories
      * @returns {undefined}
@@ -112,10 +112,10 @@ define([
             errorHandler.throw(_ns, 'invalid tool config format');
         }
     }
-    
+
     /**
      * Remove an array of categories from a section model (affect the childen itemRef)
-     * 
+     *
      * @param {object} model
      * @param {array} categories
      * @returns {undefined}
@@ -163,6 +163,10 @@ define([
             {
                 name : 'x-tao-option-calculator',
                 description : __('enable calculator')
+            },
+            {
+                name : 'x-tao-itemusage-informational',
+                description : __('describe the item as informational')
             }
         ];
     }

--- a/views/js/runner/helpers/map.js
+++ b/views/js/runner/helpers/map.js
@@ -258,9 +258,9 @@ define([
          */
         each: function each(map, callback) {
             if (_.isFunction(callback)) {
-                _.each(map && map.parts, function(part) {
-                    _.each(part && part.sections, function(section) {
-                        _.each(section && section.items, function(item) {
+                _.forEach(map && map.parts, function(part) {
+                    _.forEach(part && part.sections, function(section) {
+                        _.forEach(section && section.items, function(item) {
                             callback(item, section, part, map);
                         });
                     });

--- a/views/js/runner/plugins/navigation/review/navigator.js
+++ b/views/js/runner/plugins/navigation/review/navigator.js
@@ -57,6 +57,7 @@ define([
         answered: 'answered',
         viewed: 'viewed',
         unseen: 'unseen',
+        info: 'info',
         icon: 'qti-navigator-icon',
         scope: {
             test: 'scope-test',
@@ -71,6 +72,7 @@ define([
      * @private
      */
     var _iconCls = [
+        _cssCls.info,
         _cssCls.flagged,
         _cssCls.answered,
         _cssCls.viewed
@@ -112,6 +114,7 @@ define([
         flagged: '.flagged',
         notFlagged: ':not(.flagged)',
         notAnswered: ':not(.answered)',
+        notInformational: ':not(.info)',
         hidden: '.hidden'
     };
 
@@ -154,6 +157,24 @@ define([
         },
 
         /**
+         * Gets the total number of items for the provided target
+         * @param {Object} progression
+         * @param {String} target
+         * @returns {Number}
+         */
+        getProgressionTotal: function getProgressionTotal(progression, target) {
+            var total;
+
+            if ('questions' === target) {
+                total = progression.questions;
+            } else {
+                total = progression.total;
+            }
+
+            return total;
+        },
+
+        /**
          * Set the marked state of an item
          * @param {Number|String|jQuery} position
          * @param {Boolean} flag
@@ -175,7 +196,7 @@ define([
 
             // update the info panel
             progression.flagged = this.controls.$tree.find(_selectors.flagged).length;
-            this.writeCount(this.controls.$infoFlagged, progression.flagged, progression.total);
+            this.writeCount(this.controls.$infoFlagged, progression.flagged, this.getProgressionTotal(progression, 'questions'));
 
             // recompute the filters
             this.filter(this.currentFilter);
@@ -201,7 +222,7 @@ define([
             // update the section counters
             this.controls.$tree.find(_selectors.sections).each(function () {
                 var $section = $(this);
-                var $items = $section.find(_selectors.items);
+                var $items = $section.find(_selectors.items + _selectors.notInformational);
                 var $filtered = $items.filter(filtered);
                 var total = $items.length;
                 var nb = total - $filtered.length;
@@ -249,20 +270,22 @@ define([
         update: function update(map, context) {
             var scopedMap = this.getScopedMap(map, context);
             var progression = scopedMap.stats || {
-                    answered: 0,
-                    flagged: 0,
-                    viewed: 0,
-                    total: 0
-                };
+                questions: 0,
+                answered: 0,
+                flagged: 0,
+                viewed: 0,
+                total: 0
+            };
+            var totalQuestions = this.getProgressionTotal(progression, 'questions');
 
             this.map = map;
             this.progression = progression;
 
             // update the info panel
-            this.writeCount(this.controls.$infoAnswered, progression.answered, progression.total);
-            this.writeCount(this.controls.$infoUnanswered, progression.total - progression.answered, progression.total);
-            this.writeCount(this.controls.$infoViewed, progression.viewed, progression.total);
-            this.writeCount(this.controls.$infoFlagged, progression.flagged, progression.total);
+            this.writeCount(this.controls.$infoAnswered, progression.answered, totalQuestions);
+            this.writeCount(this.controls.$infoUnanswered, totalQuestions - progression.answered, totalQuestions);
+            this.writeCount(this.controls.$infoViewed, progression.viewed, this.getProgressionTotal(progression, 'total'));
+            this.writeCount(this.controls.$infoFlagged, progression.flagged, totalQuestions);
 
             // rebuild the tree
             if (!context.isLinear) {
@@ -296,48 +319,47 @@ define([
          * @returns {object} The scoped map
          */
         getScopedMap: function getScopedMap(map, context) {
-            // need a clone of the map as we will change some properties
-            var scopedMap = _.cloneDeep(map || {});
-
-            // gets the current part/section/item
-            var testPart = scopedMap.parts[context.testPartId] || {};
-            var section = testPart.sections && testPart.sections[context.sectionId] || {};
-            var item = section.items && section.items[context.itemIdentifier] || {};
+            var scopedMap = mapHelper.getScopeMap(map, context.itemPosition, this.config.scope);
+            var testPart = mapHelper.getPart(scopedMap, context.testPartId) || {};
+            var section = mapHelper.getSection(scopedMap, context.sectionId) || {};
+            var item = mapHelper.getItem(scopedMap, context.itemIdentifier) || {};
 
             // set the active part/section/item
             testPart.active = true;
             section.active = true;
             item.active = true;
 
-            // select the scoped map fragment
-            switch (this.config.scope) {
-                case 'testSection':
-                    // build a scoped map containing only the current part, the current section and its items
-                    scopedMap = {
-                        parts: {},
-                        stats: section.stats
-                    };
-                    testPart.sections = {};
-                    testPart.sections[context.sectionId] = section;
-                    scopedMap.parts[context.testPartId] = testPart;
-                    break;
+            // adjust each item with additional meta
+            return mapHelper.each(scopedMap, function(itm) {
+                var cls = [];
+                var icon = '';
 
-                case 'testPart':
-                    // build a scoped map containing only the current part and its sections
-                    scopedMap = {
-                        parts: {},
-                        stats: testPart.stats
-                    };
-                    scopedMap.parts[context.testPartId] = testPart;
-                    break;
+                if (itm.active) {
+                    cls.push('active');
+                }
+                if (itm.informational) {
+                    cls.push('info');
+                    icon = icon || 'info';
+                }
+                if (itm.flagged) {
+                    cls.push('flagged');
+                    icon = icon || 'flagged';
+                }
+                if (itm.answered) {
+                    cls.push('answered');
+                    icon = icon || 'answered';
+                }
+                if (itm.viewed) {
+                    cls.push('viewed');
+                    icon = icon || 'viewed';
+                } else {
+                    cls.push('unseen');
+                    icon = icon || 'unseen';
+                }
 
-                default:
-                case 'test':
-                    // keep the whole map
-                    break;
-            }
-
-            return scopedMap;
+                itm.cls = cls.join(' ');
+                itm.icon = icon;
+            });
         },
 
         /**
@@ -597,7 +619,7 @@ define([
                             $target = $(event.target);
                             if (self.config.canFlag && $target.is(_selectors.icons) && !$component.hasClass(_cssCls.collapsed)) {
                                 // click on the icon, just flag the item, unless the panel is collapsed
-                                if (!$item.hasClass(_cssCls.unseen)) {
+                                if (!$item.hasClass(_cssCls.unseen) && !$item.hasClass(_cssCls.info)) {
                                     flagItem($item);
                                 }
                             } else if (!$item.hasClass(_cssCls.active)){

--- a/views/js/runner/plugins/navigation/review/navigatorTree.tpl
+++ b/views/js/runner/plugins/navigation/review/navigatorTree.tpl
@@ -29,9 +29,9 @@
                 </span>
                 <ul class="qti-navigator-items collapsible-panel plain">
                     {{#each items}}
-                    <li class="qti-navigator-item{{#if active}} active{{/if}}{{#if flagged}} flagged{{/if}}{{#if answered}} answered{{/if}}{{#if viewed}} viewed{{else}} unseen{{/if}}" data-id="{{id}}" data-position="{{position}}">
+                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}">
                         <span class="qti-navigator-label truncate" title="{{label}}">
-                            <span class="qti-navigator-icon icon-{{#if flagged}}flagged{{else}}{{#if answered}}answered{{else}}{{#if viewed}}viewed{{else}}unseen{{/if}}{{/if}}{{/if}}"></span>
+                            <span class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}
                         </span>

--- a/views/js/runner/plugins/navigation/review/review.js
+++ b/views/js/runner/plugins/navigation/review/review.js
@@ -27,9 +27,10 @@ define([
     'i18n',
     'ui/hider',
     'taoTests/runner/plugin',
+    'taoQtiTest/runner/helpers/map',
     'taoQtiTest/runner/plugins/navigation/review/navigator',
     'tpl!taoQtiTest/runner/plugins/navigation/button'
-], function ($, _, __, hider, pluginFactory, navigator, buttonTpl) {
+], function ($, _, __, hider, pluginFactory, mapHelper, navigator, buttonTpl) {
     'use strict';
 
     /**
@@ -106,6 +107,18 @@ define([
             $button.find('.icon').attr('icon ' + data.icon);
             $button.find('.text').text(data.text);
         }
+    }
+
+    /**
+     * Checks if the current context allows to mark the item for review
+     * @param {Object} testRunner
+     * @returns {Boolean}
+     */
+    function canFlag(testRunner) {
+        var context = testRunner.getTestContext();
+        var map = testRunner.getTestMap();
+        var item = mapHelper.getItemAt(map, context.itemPosition);
+        return !!(!context.isLinear && context.options.markReview && !(item && item.informational));
     }
 
     /**
@@ -283,7 +296,6 @@ define([
             this.$flagItemButton.removeClass('disabled')
                 .removeProp('disabled');
             this.$toggleButton.removeClass('disabled')
-
                 .removeProp('disabled');
             this.navigator.enable();
         },
@@ -304,8 +316,7 @@ define([
          */
         show: function show() {
             var testRunner = this.getTestRunner();
-            var context = testRunner.getTestContext();
-            if(!context.isLinear && context.options.markReview){
+            if (canFlag(testRunner)) {
                 hider.show(this.$flagItemButton);
             } else {
                 hider.hide(this.$flagItemButton);

--- a/views/js/test/runner/helpers/map/map.json
+++ b/views/js/test/runner/helpers/map/map.json
@@ -20,6 +20,7 @@
               "positionInSection": 0,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": true,
               "answered": false,
               "flagged": false,
               "viewed": true
@@ -33,6 +34,7 @@
               "positionInSection": 1,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
@@ -46,12 +48,14 @@
               "positionInSection": 2,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
             }
           },
           "stats": {
+            "questions": 2,
             "answered": 0,
             "flagged": 0,
             "viewed": 1,
@@ -72,6 +76,7 @@
               "positionInSection": 0,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
@@ -85,6 +90,7 @@
               "positionInSection": 1,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
@@ -98,12 +104,14 @@
               "positionInSection": 2,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
             }
           },
           "stats": {
+            "questions": 3,
             "answered": 0,
             "flagged": 0,
             "viewed": 0,
@@ -112,6 +120,7 @@
         }
       },
       "stats": {
+        "questions": 5,
         "answered": 0,
         "flagged": 0,
         "viewed": 1,
@@ -138,6 +147,7 @@
               "positionInSection": 0,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
@@ -151,12 +161,14 @@
               "positionInSection": 1,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
             }
           },
           "stats": {
+            "questions": 2,
             "answered": 0,
             "flagged": 0,
             "viewed": 0,
@@ -177,6 +189,7 @@
               "positionInSection": 0,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
@@ -190,12 +203,14 @@
               "positionInSection": 1,
               "occurrence": 0,
               "remainingAttempts": -1,
+              "informational": false,
               "answered": false,
               "flagged": false,
               "viewed": false
             }
           },
           "stats": {
+            "questions": 2,
             "answered": 0,
             "flagged": 0,
             "viewed": 0,
@@ -204,6 +219,7 @@
         }
       },
       "stats": {
+        "questions": 4,
         "answered": 0,
         "flagged": 0,
         "viewed": 0,
@@ -284,6 +300,7 @@
     }
   ],
   "stats": {
+    "questions": 9,
     "answered": 0,
     "flagged": 0,
     "viewed": 1,

--- a/views/js/test/runner/helpers/map/test.js
+++ b/views/js/test/runner/helpers/map/test.js
@@ -29,7 +29,8 @@ define([
     QUnit.module('helpers/map');
 
 
-    QUnit.test('module', 1, function(assert) {
+    QUnit.test('module', function(assert) {
+        QUnit.expect(1);
         assert.equal(typeof mapHelper, 'object', "The map helper module exposes an object");
     });
 
@@ -45,9 +46,11 @@ define([
         { name : 'getPartStats', title : 'getPartStats' },
         { name : 'getSectionStats', title : 'getSectionStats' },
         { name : 'getScopeStats', title : 'getScopeStats' },
+        { name : 'getScopeMap', title : 'getScopeMap' },
         { name : 'getItemPart', title : 'getItemPart' },
         { name : 'getItemSection', title : 'getItemSection' },
         { name : 'getItemAt', title : 'getItemAt' },
+        { name : 'each', title : 'each' },
         { name : 'updateItemStats', title : 'updateItemStats' },
         { name : 'computeItemStats', title : 'computeItemStats' },
         { name : 'computeStats', title : 'computeStats' }
@@ -55,15 +58,18 @@ define([
 
     QUnit
         .cases(mapHelperApi)
-        .test('helpers/map API ', 1, function(data, assert) {
+        .test('helpers/map API ', function(data, assert) {
+            QUnit.expect(1);
             assert.equal(typeof mapHelper[data.name], 'function', 'The map helper expose a "' + data.name + '" function');
         });
 
 
-    QUnit.test('helpers/map.getJumps', 3, function(assert) {
+    QUnit.test('helpers/map.getJumps', function(assert) {
         var map = {
             jumps : []
         };
+
+        QUnit.expect(3);
 
         assert.equal(mapHelper.getJumps(map), map.jumps, 'The map helper getJumps provides the map jumps');
         assert.equal(mapHelper.getJumps({}), undefined, 'The map helper getJumps does not provide the map jumps when the map is wrong');
@@ -71,10 +77,12 @@ define([
     });
 
 
-    QUnit.test('helpers/map.getParts', 3, function(assert) {
+    QUnit.test('helpers/map.getParts', function(assert) {
         var map = {
             parts : {}
         };
+
+        QUnit.expect(3);
 
         assert.equal(mapHelper.getParts(map), map.parts, 'The map helper getParts provides the map parts');
         assert.equal(mapHelper.getParts({}), undefined, 'The map helper getParts does not provide the map parts when the map is wrong');
@@ -82,13 +90,15 @@ define([
     });
 
 
-    QUnit.test('helpers/map.getJump', 4, function(assert) {
+    QUnit.test('helpers/map.getJump', function(assert) {
         var map = {
             jumps : [
                 {identifier: "item-1"},
                 {identifier: "item-2"}
             ]
         };
+
+        QUnit.expect(4);
 
         assert.equal(mapHelper.getJump(map, 1), map.jumps[1], 'The map helper getJump provides the right jump');
         assert.equal(mapHelper.getJump(map, 10), undefined, 'The map helper getJump does not provide any jump when the position does not exist');
@@ -97,23 +107,29 @@ define([
     });
 
 
-    QUnit.test('helpers/map.getPart', 4, function(assert) {
+    QUnit.test('helpers/map.getPart', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getPart(mapSample, 'testPart-2'), mapSample.parts['testPart-2'], 'The map helper getPart provides the right part');
         assert.equal(mapHelper.getPart(mapSample, 'testPart-0'), undefined, 'The map helper getPart does not provide any part when the part does not exist');
         assert.equal(mapHelper.getPart({}), undefined, 'The map helper getPart does not provide any part when the map is wrong');
         assert.equal(mapHelper.getPart(), undefined, 'The map helper getPart does not provide any part when the map does not exist');
     });
 
-    
-    QUnit.test('helpers/map.getSection', 4, function(assert) {
+
+    QUnit.test('helpers/map.getSection', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getSection(mapSample, 'assessmentSection-3'), mapSample.parts['testPart-2'].sections['assessmentSection-3'], 'The map helper getSection provides the right section');
         assert.equal(mapHelper.getSection(mapSample, 'assessmentSection-0'), undefined, 'The map helper getSection does not provide any section when the section does not exist');
         assert.equal(mapHelper.getSection({}), undefined, 'The map helper getSection does not provide any section when the map is wrong');
         assert.equal(mapHelper.getSection(), undefined, 'The map helper getSection does not provide any section when the map does not exist');
     });
-    
-    
-    QUnit.test('helpers/map.getItem', 4, function(assert) {
+
+
+    QUnit.test('helpers/map.getItem', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getItem(mapSample, 'item-5'), mapSample.parts['testPart-1'].sections['assessmentSection-2'].items['item-5'], 'The map helper getItem provides the right item');
         assert.equal(mapHelper.getItem(mapSample, 'item-0'), undefined, 'The map helper getItem does not provide any item when the item does not exist');
         assert.equal(mapHelper.getItem({}), undefined, 'The map helper getItem does not provide any item when the map is wrong');
@@ -121,10 +137,12 @@ define([
     });
 
 
-    QUnit.test('helpers/map.getTestStats', 3, function(assert) {
+    QUnit.test('helpers/map.getTestStats', function(assert) {
         var map = {
             stats: {}
         };
+
+        QUnit.expect(3);
 
         assert.equal(mapHelper.getTestStats(map), map.stats, 'The map helper getTestStats provides the right stats');
         assert.equal(mapHelper.getTestStats({}), undefined, 'The map helper getTestStats does not provide any stats when the map is wrong');
@@ -132,23 +150,29 @@ define([
     });
 
 
-    QUnit.test('helpers/map.getPartStats', 4, function(assert) {
+    QUnit.test('helpers/map.getPartStats', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getPartStats(mapSample, 'testPart-2'), mapSample.parts['testPart-2'].stats, 'The map helper getPartStats provides the right stats');
         assert.equal(mapHelper.getPartStats(mapSample, 'testPart-0'), undefined, 'The map helper getPartStats does not provide any stats when the part does not exist');
         assert.equal(mapHelper.getPartStats({}), undefined, 'The map helper getPartStats does not provide any stats when the map is wrong');
         assert.equal(mapHelper.getPartStats(), undefined, 'The map helper getPartStats does not provide any stats when the map does not exist');
     });
-    
-    
-    QUnit.test('helpers/map.getSectionStats', 4, function(assert) {
+
+
+    QUnit.test('helpers/map.getSectionStats', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getSectionStats(mapSample, 'assessmentSection-3'), mapSample.parts['testPart-2'].sections['assessmentSection-3'].stats, 'The map helper getSectionStats provides the right stats');
         assert.equal(mapHelper.getSectionStats(mapSample, 'assessmentSection-0'), undefined, 'The map helper getSectionStats does not provide any stats when the section does not exist');
         assert.equal(mapHelper.getSectionStats({}), undefined, 'The map helper getSectionStats does not provide any stats when the map is wrong');
         assert.equal(mapHelper.getSectionStats(), undefined, 'The map helper getSectionStats does not provide any stats when the map does not exist');
     });
-    
-    
-    QUnit.test('helpers/map.getScopeStats', 9, function(assert) {
+
+
+    QUnit.test('helpers/map.getScopeStats', function(assert) {
+        QUnit.expect(9);
+
         assert.equal(mapHelper.getScopeStats(mapSample, 6), mapHelper.getScopeStats(mapSample, 6, 'test'), 'The map helper getScopeStats use the "test" scope by default');
         assert.equal(mapHelper.getScopeStats(mapSample, 6, 'test'), mapSample.stats, 'The map helper getScopeStats provides the right stats when the scope is "test"');
         assert.equal(mapHelper.getScopeStats(mapSample, 6, 'part'), mapSample.parts['testPart-2'].stats, 'The map helper getScopeStats provides the right stats when the scope is "part"');
@@ -159,9 +183,71 @@ define([
         assert.equal(mapHelper.getScopeStats({}, 1), undefined, 'The map helper getScopeStats does not provide any stats when the map is wrong');
         assert.equal(mapHelper.getScopeStats(), undefined, 'The map helper getScopeStats does not provide any stats when the map does not exist');
     });
-    
-    
-    QUnit.test('helpers/map.getItemPart', 4, function(assert) {
+
+
+    QUnit.test('helpers/map.getScopeMap', function(assert) {
+        var expectedTestMap = mapSample;
+        var expectedPartMap = {
+            jumps: mapSample.jumps,
+            parts: {
+                'testPart-2': mapSample.parts['testPart-2']
+            },
+            stats: mapSample.parts['testPart-2'].stats
+        };
+        var expectedSectionMap = {
+            jumps: mapSample.jumps,
+            parts: {
+                'testPart-2': {
+                    "id": "testPart-2",
+                    "label": "testPart-2",
+                    "position": 6,
+                    "isLinear": false,
+                    sections: {
+                        'assessmentSection-3': mapSample.parts['testPart-2'].sections['assessmentSection-3']
+                    },
+                    stats: mapSample.parts['testPart-2'].sections['assessmentSection-3'].stats
+                }
+            },
+            stats: mapSample.parts['testPart-2'].sections['assessmentSection-3'].stats
+        };
+        var expectedNotFound = {
+            jumps: mapSample.jumps,
+            parts: {},
+            stats: {
+                questions: 0,
+                answered: 0,
+                flagged: 0,
+                viewed: 0,
+                total: 0
+            }
+        };
+        var expectedEmpty = {
+            stats: {
+                questions: 0,
+                answered: 0,
+                flagged: 0,
+                viewed: 0,
+                total: 0
+            }
+        };
+
+        QUnit.expect(9);
+
+        assert.deepEqual(mapHelper.getScopeMap(mapSample, 6), mapHelper.getScopeMap(mapSample, 6, 'test'), 'The map helper getScopeMap use the "test" scope by default');
+        assert.deepEqual(mapHelper.getScopeMap(mapSample, 6, 'test'), expectedTestMap, 'The map helper getScopeMap provides the right content when the scope is "test"');
+        assert.deepEqual(mapHelper.getScopeMap(mapSample, 6, 'part'), expectedPartMap, 'The map helper getScopeMap provides the right content when the scope is "part"');
+        assert.deepEqual(mapHelper.getScopeMap(mapSample, 6, 'section'), expectedSectionMap, 'The map helper getScopeMap provides the right content when the scope is "section');
+        assert.deepEqual(mapHelper.getScopeMap(mapSample, 100, 'test'), expectedTestMap, 'The map helper getScopeMap still provide any map when the position does not exist but the scope is "test"');
+        assert.deepEqual(mapHelper.getScopeMap(mapSample, 100, 'part'), expectedNotFound, 'The map helper getScopeMap does not provide any map when the position does not exist and the scope is "part"');
+        assert.deepEqual(mapHelper.getScopeMap(mapSample, 100, 'section'), expectedNotFound, 'The map helper getScopeMap does not provide any map when the section does not exist and the scope is "section"');
+        assert.deepEqual(mapHelper.getScopeMap({}, 1), expectedEmpty, 'The map helper getScopeMap does not provide any map when the map is wrong');
+        assert.deepEqual(mapHelper.getScopeMap(), expectedEmpty, 'The map helper getScopeMap does not provide any map when the map does not exist');
+    });
+
+
+    QUnit.test('helpers/map.getItemPart', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getItemPart(mapSample, 8), mapSample.parts['testPart-2'], 'The map helper getItemPart provides the right part');
         assert.equal(mapHelper.getItemPart(mapSample, 100), undefined, 'The map helper getItemPart does not provide any part when the position does not exist');
         assert.equal(mapHelper.getItemPart({}), undefined, 'The map helper getItemPart does not provide any part when the map is wrong');
@@ -169,7 +255,9 @@ define([
     });
 
 
-    QUnit.test('helpers/map.getItemSection', 4, function(assert) {
+    QUnit.test('helpers/map.getItemSection', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getItemSection(mapSample, 8), mapSample.parts['testPart-2'].sections['assessmentSection-4'], 'The map helper getItemSection provides the right section');
         assert.equal(mapHelper.getItemSection(mapSample, 100), undefined, 'The map helper getItemSection does not provide any section when the position does not exist');
         assert.equal(mapHelper.getItemSection({}), undefined, 'The map helper getItemSection does not provide any section when the map is wrong');
@@ -177,7 +265,9 @@ define([
     });
 
 
-    QUnit.test('helpers/map.getItemAt', 4, function(assert) {
+    QUnit.test('helpers/map.getItemAt', function(assert) {
+        QUnit.expect(4);
+
         assert.equal(mapHelper.getItemAt(mapSample, 8), mapSample.parts['testPart-2'].sections['assessmentSection-4'].items['item-9'], 'The map helper getItemAt provides the right item');
         assert.equal(mapHelper.getItemAt(mapSample, 100), undefined, 'The map helper getItemAt does not provide any item when the position does not exist');
         assert.equal(mapHelper.getItemAt({}), undefined, 'The map helper getItemAt does not provide any item when the map is wrong');
@@ -185,67 +275,107 @@ define([
     });
 
 
-    QUnit.test('helpers/map.updateItemStats', 25, function(assert) {
+    QUnit.test('helpers/map.each', function(assert) {
+        var result;
+
+        QUnit.expect(42);
+
+        result = mapHelper.each(mapSample, function(item, section, part, map) {
+            assert.equal(item, mapHelper.getItemAt(mapSample, item.position), 'The right item is provided to each callback');
+            assert.equal(section, mapHelper.getItemSection(mapSample, item.position), 'The right section is provided to each callback');
+            assert.equal(part, mapHelper.getItemPart(mapSample, item.position), 'The right part is provided to each callback');
+            assert.equal(map, mapSample, 'The map is provided to each callback');
+        });
+
+        assert.equal(result, mapSample, 'The map helper each returns the provided map');
+        assert.equal(mapHelper.each(mapSample), mapSample, 'The map helper each returns the provided map even if no callback has been provided');
+    });
+
+
+    QUnit.test('helpers/map.updateItemStats', function(assert) {
         var map = _.cloneDeep(mapSample);
         var item = mapHelper.getItemAt(map, 8);
         var section = mapHelper.getItemSection(map, 8);
         var part = mapHelper.getItemPart(map, 8);
         var stats = mapHelper.getTestStats(map);
 
+        QUnit.expect(39);
+
+        assert.equal(item.informational, false, 'The item is not informational');
         assert.equal(item.answered, false, 'The item is not answered at this time');
         assert.equal(item.flagged, false, 'The item is not flagged at this time');
         assert.equal(item.viewed, false, 'The item is not viewed at this time');
 
+        assert.equal(stats.questions, 9, 'There is 9 questions at this time in the test');
         assert.equal(stats.answered, 0, 'There is no answered item at this time in the test');
         assert.equal(stats.flagged, 0, 'There is no flagged item at this time in the test');
         assert.equal(stats.viewed, 1, 'There is one viewed item at this time in the test');
+        assert.equal(stats.total, 10, 'There is 10 items at this time in the test');
 
+        assert.equal(part.stats.questions, 4, 'There is 4 questions at this time in the part');
         assert.equal(part.stats.answered, 0, 'There is no answered item at this time in the part');
         assert.equal(part.stats.flagged, 0, 'There is no flagged item at this time in the part');
         assert.equal(part.stats.viewed, 0, 'There is no viewed item at this time in the part');
+        assert.equal(part.stats.total, 4, 'There is 4 items at this time in the part');
 
+        assert.equal(section.stats.questions, 2, 'There is 2 questions at this time in the section');
         assert.equal(section.stats.answered, 0, 'There is no answered item at this time in the section');
         assert.equal(section.stats.flagged, 0, 'There is no flagged item at this time in the section');
         assert.equal(section.stats.viewed, 0, 'There is no viewed item at this time in the section');
+        assert.equal(section.stats.total, 2, 'There is 2 items at this time in the section');
 
+        item.informational = true;
         item.answered = true;
         item.flagged = true;
         item.viewed = true;
 
         assert.equal(mapHelper.updateItemStats(map, 8), map, 'The map helper updateItemStats returns the map');
 
+        assert.equal(item.informational, true, 'The item is now informational');
         assert.equal(item.answered, true, 'The item is now answered');
         assert.equal(item.flagged, true, 'The item is now flagged');
         assert.equal(item.viewed, true, 'The item is now viewed');
 
         stats = mapHelper.getTestStats(map);
+        assert.equal(stats.questions, 8, 'There is 8 questions at this time in the test');
         assert.equal(stats.answered, 1, 'There is one answered item at this time in the test');
         assert.equal(stats.flagged, 1, 'There is one flagged item at this time in the test');
         assert.equal(stats.viewed, 2, 'There is two viewed items at this time in the test');
+        assert.equal(stats.total, 10, 'There is 10 items at this time in the test');
 
+        assert.equal(part.stats.questions, 3, 'There is 3 questions at this time in the part');
         assert.equal(part.stats.answered, 1, 'There is one answered item at this time in the part');
         assert.equal(part.stats.flagged, 1, 'There is one flagged item at this time in the part');
         assert.equal(part.stats.viewed, 1, 'There is one viewed item at this time in the part');
+        assert.equal(part.stats.total, 4, 'There is 4 items at this time in the part');
 
+        assert.equal(section.stats.questions, 1, 'There is 1 questions at this time in the section');
         assert.equal(section.stats.answered, 1, 'There is one answered item at this time in the section');
         assert.equal(section.stats.flagged, 1, 'There is one flagged item at this time in the section');
         assert.equal(section.stats.viewed, 1, 'There is one viewed item at this time in the section');
+        assert.equal(section.stats.total, 2, 'There is 2 items at this time in the section');
     });
 
 
-    QUnit.test('helpers/map.computeItemStats', 13, function(assert) {
+    QUnit.test('helpers/map.computeItemStats', function(assert) {
         var item = mapHelper.getItemAt(mapSample, 6);
         var section = mapHelper.getItemSection(mapSample, 6);
         var stats;
 
+        QUnit.expect(19);
+
+        assert.equal(item.informational, false, 'The item is not informational');
         assert.equal(item.answered, false, 'The item is not answered at this time');
         assert.equal(item.flagged, false, 'The item is not flagged at this time');
         assert.equal(item.viewed, false, 'The item is not viewed at this time');
 
+        assert.equal(section.stats.questions, 2, 'There is 2 questions at this time in the section');
         assert.equal(section.stats.answered, 0, 'There is no answered item at this time in the section');
         assert.equal(section.stats.flagged, 0, 'There is no flagged item at this time in the section');
         assert.equal(section.stats.viewed, 0, 'There is no viewed item at this time in the section');
+        assert.equal(section.stats.total, 2, 'There is 2 items at this time in the section');
 
+        item.informational = true;
         item.answered = true;
         item.flagged = true;
         item.viewed = true;
@@ -254,37 +384,50 @@ define([
 
         assert.equal(typeof stats, 'object', 'The map helper computeItemStats returns an object');
 
+        assert.equal(item.informational, true, 'The item is now informational');
         assert.equal(item.answered, true, 'The item is now answered');
         assert.equal(item.flagged, true, 'The item is now flagged');
         assert.equal(item.viewed, true, 'The item is now viewed');
 
+        assert.equal(stats.questions, 1, 'There is one question at this time in the computed stats');
         assert.equal(stats.answered, 1, 'There is one answered item at this time in the computed stats');
         assert.equal(stats.flagged, 1, 'There is one flagged item at this time in the computed stats');
         assert.equal(stats.viewed, 1, 'There is one viewed item at this time in the computed stats');
+        assert.equal(stats.total, 2, 'There is 2 items at this time in the computed stats');
     });
 
 
-    QUnit.test('helpers/map.computeStats', 20, function(assert) {
+    QUnit.test('helpers/map.computeStats', function(assert) {
         var map = _.cloneDeep(mapSample);
         var section = mapHelper.getItemSection(map, 8);
         var part = mapHelper.getItemPart(map, 8);
         var stats = mapHelper.getTestStats(map);
 
+        QUnit.expect(32);
+
+        assert.equal(stats.questions, 9, 'There is 9 questions at this time in the test');
         assert.equal(stats.answered, 0, 'There is no answered item at this time in the test');
         assert.equal(stats.flagged, 0, 'There is no flagged item at this time in the test');
         assert.equal(stats.viewed, 1, 'There is one viewed item at this time in the test');
+        assert.equal(stats.total, 10, 'There is 10 items at this time in the test');
 
+        assert.equal(part.stats.questions, 4, 'There 4 questions at this time in the part');
         assert.equal(part.stats.answered, 0, 'There is no answered item at this time in the part');
         assert.equal(part.stats.flagged, 0, 'There is no flagged item at this time in the part');
         assert.equal(part.stats.viewed, 0, 'There is no viewed item at this time in the part');
+        assert.equal(part.stats.total, 4, 'There is 4 items at this time in the part');
 
+        assert.equal(section.stats.questions, 2, 'There is 2 questions at this time in the section');
         assert.equal(section.stats.answered, 0, 'There is no answered item at this time in the section');
         assert.equal(section.stats.flagged, 0, 'There is no flagged item at this time in the section');
-        assert.equal(section.stats.viewed, 0, 'There is no viewed item at this time in the section');
+        assert.equal(section.stats.viewed, 0, 'There is no viewed items at this time in the section');
+        assert.equal(section.stats.total, 2, 'There is 2 items at this time in the section');
 
+        section.stats.questions = 1;
         section.stats.answered = 2;
         section.stats.flagged = 2;
         section.stats.viewed = 2;
+        section.stats.total = 2;
 
         part.stats = mapHelper.computeStats(part.sections);
         assert.equal(typeof part.stats, 'object', 'The map helper computeStats returns an object');
@@ -292,16 +435,22 @@ define([
         stats = mapHelper.computeStats(mapHelper.getParts(map));
         assert.equal(typeof map.stats, 'object', 'The map helper computeStats returns an object');
 
+        assert.equal(stats.questions, 8, 'There is 8 questions at this time in the test');
         assert.equal(stats.answered, 2, 'There is two answered items at this time in the test');
         assert.equal(stats.flagged, 2, 'There is two flagged items at this time in the test');
         assert.equal(stats.viewed, 3, 'There is three viewed items at this time in the test');
+        assert.equal(stats.total, 10, 'There is 10 items at this time in the test');
 
+        assert.equal(part.stats.questions, 3, 'There is one question at this time in the part');
         assert.equal(part.stats.answered, 2, 'There is two answered items at this time in the part');
         assert.equal(part.stats.flagged, 2, 'There is two flagged items at this time in the part');
         assert.equal(part.stats.viewed, 2, 'There is two viewed items at this time in the part');
+        assert.equal(part.stats.total, 4, 'There is 2 items at this time in the part');
 
+        assert.equal(section.stats.questions, 1, 'There is one question at this time in the section');
         assert.equal(section.stats.answered, 2, 'There is two answered items at this time in the section');
         assert.equal(section.stats.flagged, 2, 'There is two flagged items at this time in the section');
         assert.equal(section.stats.viewed, 2, 'There is two viewed items at this time in the section');
+        assert.equal(section.stats.total, 2, 'There is two items at this time in the section');
     });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2873

Feature related to the new test runner and the review panel.

When the review panel is enabled, the items that are intended to be only informational are handled in a particular manner:
- a special icon is dedicated
- those items are not taken into account in the answered/flagged counts
- those items cannot be flagged

An item is considered as informational when it does not contains any responses (Text Block) or when the category `x-tao-itemusage-informational` is attached.

To enable this feature you will need to set the `check-informational` option in the taoQtiTest config file: `config/taoQtiTest/testRunner.conf.php`