### PR TITLE
Update the current context after a submit not allowed

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -444,6 +444,8 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
         $emptyAllowed = isset($data['emptyAllowed']) ? $data['emptyAllowed'] : false;
 
         try {
+            // get the service context, but do not perform the test state check,
+            // as we need to store the item state whatever the test state is 
             $serviceContext = $this->getServiceContext(false);
 
             if (!$this->runnerService->isTerminated($serviceContext)) {
@@ -482,12 +484,20 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
                 $this->runnerService->persist($serviceContext);
             } else {
-                $this->runnerService->startTimer($serviceContext);
+                // we need a complete service context in order to build the test context
+                $serviceContext->init();
+                
                 $response = [
                     'success' => true,
                     'notAllowed' => true,
                     'message' => __('A response to this item is required.'),
+                    
+                    // send an updated version of the test context
+                    'testContext' => $this->runnerService->getTestContext($serviceContext),
                 ];
+                
+                // start the timer only after context build to avoid timing error
+                $this->runnerService->startTimer($serviceContext);
             }
 
         } catch (common_Exception $e) {

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -257,6 +257,12 @@ define([
                             return new Promise(function(resolve, reject){
 
                                 if (result.notAllowed) {
+                                    // the context might be updated
+                                    if (result.testContext) {
+                                        self.setTestContext(result.testContext);
+                                        context = self.getTestContext();
+                                    }
+
                                     self.trigger('resumeitem');
 
                                     if (result.message) {


### PR DESCRIPTION
Prevent the item timer to be reseted after an item resume (submit not allowed).

The test context is rebuilt and sent back after a prevented submit.
This fix the allowSkipping timer reset issue, but a more consistent approach would be to detect the empty responses and prevent the submit instead of only relying on the server.