### PR TITLE
fixed response serialization for boolean

### DIFF
--- a/views/js/runner/helpers/messages.js
+++ b/views/js/runner/helpers/messages.js
@@ -63,9 +63,13 @@ define([
         var mappedCardinality = responseCardinalities[cardinality];
         var response = {};
 
+        value = _.map(value || [], function(v){
+            return (baseType === 'boolean') ? (v === true || v === 'true') : v;
+        });
+
         if (mappedCardinality) {
             if (mappedCardinality === 'base') {
-                if (!value || value.length === 0) {
+                if (value.length === 0) {
                     //return empty response:
                     response.base = null;
                 } else {


### PR DESCRIPTION
Fixed the wrong number of item counted as unresponded for response having a boolean type basetype.
This is related to https://github.com/oat-sa/extension-tao-itemqti/pull/793 which fixes sometimes missing defaultValue in responseDeclaration upon saving in the authoring tool.
