### PR TITLE
Hotfix/empty test export

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.17.0',
+    'version' => '5.17.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',

--- a/models/classes/export/class.QtiTestExporter.php
+++ b/models/classes/export/class.QtiTestExporter.php
@@ -247,11 +247,13 @@ class taoQtiTest_models_classes_export_QtiTestExporter extends taoItems_models_c
     {
         $testXmlDocument = $this->postProcessing($this->getTestDocument()->saveToString());
 
-        $newTestDir = 'tests/' . tao_helpers_Uri::getUniqueId($this->getItem()->getUri());
+        $newTestDir = 'tests/' . tao_helpers_Uri::getUniqueId($this->getItem()->getUri()).'/';
         $testRootDir = $this->getTestService()->getQtiTestDir($this->getItem());
         $file = $this->getTestService()->getQtiTestFile($this->getItem());
 
-        $testHref = $newTestDir . dirname($testRootDir->getRelPath($file)) . 'test.xml';
+        $relPath = ltrim(dirname($testRootDir->getRelPath($file)), '/');
+        $testHref = $newTestDir . (empty($relPath) ? '' : $relPath.'/') . 'test.xml';
+
         common_Logger::t('TEST DEFINITION AT: ' . $testHref);
         $this->getZip()->addFromString($testHref, $testXmlDocument);
         $this->referenceTest($testHref, $itemIdentifiers);
@@ -261,7 +263,7 @@ class taoQtiTest_models_classes_export_QtiTestExporter extends taoItems_models_c
             // Only add dependency files...
             if ($f->getBasename() !== TAOQTITEST_FILENAME) {
                 // Add the file to the archive.
-                $fileHref = $newTestDir . $testRootDir->getRelPath($f);
+                $fileHref = $newTestDir . ltrim($testRootDir->getRelPath($f), '/');
                 common_Logger::t('AUXILIARY FILE AT: ' . $fileHref);
                 $this->getZip()->addFromString($fileHref, $f->read());
                 $this->referenceAuxiliaryFile($fileHref);

--- a/models/classes/export/class.QtiTestExporter.php
+++ b/models/classes/export/class.QtiTestExporter.php
@@ -251,8 +251,7 @@ class taoQtiTest_models_classes_export_QtiTestExporter extends taoItems_models_c
         $testRootDir = $this->getTestService()->getQtiTestDir($this->getItem());
         $file = $this->getTestService()->getQtiTestFile($this->getItem());
 
-        $testHref = $newTestDir . dirname($testRootDir->getRelPath($file)) . '/test.xml';
-
+        $testHref = $newTestDir . dirname($testRootDir->getRelPath($file)) . 'test.xml';
         common_Logger::t('TEST DEFINITION AT: ' . $testHref);
         $this->getZip()->addFromString($testHref, $testXmlDocument);
         $this->referenceTest($testHref, $itemIdentifiers);
@@ -356,6 +355,6 @@ class taoQtiTest_models_classes_export_QtiTestExporter extends taoItems_models_c
     
     protected function postProcessing($testXmlDocument)
     {
-        return;
+        return $testXmlDocument;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -618,5 +618,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->getServiceManager()->register(TestMetadataExporter::SERVICE_ID, $service);
             $this->setVersion('5.17.0');
         }
+        
+        $this->skip('5.17.0', '5.17.1');
     }
 }


### PR DESCRIPTION
**This is a HOTFIX!**

- Solves empty folder in exported archive for both QTI 2.1 & 2.2 export
- Solves empty test.xml with QTI 2.1 export

**Please also make a PR on develop and merge it as required in a usual git workflow + RELEASE 5.17.1**

Thanks in advance!