### PR TITLE
Feature/tao 3151 sync categories on itemrefs

### DIFF
--- a/actions/class.Creator.php
+++ b/actions/class.Creator.php
@@ -46,6 +46,7 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule {
             $this->setData('loadUrl', _url('getTest', null, null, array('uri' => $testUri)));
             $this->setData('saveUrl', _url('saveTest', null, null, array('uri' => $testUri)));
             $this->setData('itemsUrl', _url('get', 'Items'));
+            $this->setData('categoriesUrl', _url('getCategories', 'Items'));
             $this->setData('identifierUrl', _url('getIdentifier', null, null, array('uri' => $testUri)));
             
             $this->setView('creator.tpl');

--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -79,6 +79,7 @@ class taoQtiTest_actions_Items extends tao_actions_CommonModule
         $uris = $this->getRequestParameter('uris');
         $uris = (!is_array($uris)) ? array($uris) : $uris;
 
+        \common_Logger::d($uris);
 
         $items = $this->getItems($uris);
         $itemCategories = $this->getServiceManager()->get(\oat\taoQtiItem\model\ItemCategoriesService::SERVICE_ID);

--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -79,8 +79,6 @@ class taoQtiTest_actions_Items extends tao_actions_CommonModule
         $uris = $this->getRequestParameter('uris');
         $uris = (!is_array($uris)) ? array($uris) : $uris;
 
-        \common_Logger::d($uris);
-
         $items = $this->getItems($uris);
         $itemCategories = $this->getServiceManager()->get(\oat\taoQtiItem\model\ItemCategoriesService::SERVICE_ID);
         $this->returnJson($itemCategories->getCategories($items));

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.22.1',
+    'version' => '5.23.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -646,6 +646,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.18.0');
         }
 
-        $this->skip('5.18.0', '5.22.1');
+        $this->skip('5.18.0', '5.23.0');
     }
 }

--- a/views/js/controller/creator/templates/item.tpl
+++ b/views/js/controller/creator/templates/item.tpl
@@ -1,6 +1,6 @@
 {{#each .}}
-     <li data-uri='{{uri}}' class='truncate'>
-        {{label}} 
+     <li data-uri='{{uri}} data-categories="{{categories}}" class='truncate'>
+        {{label}}
         {{#if parent}}<span class='flag truncate' title="{{parent}}">{{parent}}</span>{{/if}}
      </li>
 {{/each}}

--- a/views/js/controller/creator/templates/item.tpl
+++ b/views/js/controller/creator/templates/item.tpl
@@ -1,5 +1,5 @@
 {{#each .}}
-     <li data-uri='{{uri}} data-categories="{{categories}}" class='truncate'>
+     <li data-uri='{{uri}}' data-categories='{{categories}}' class='truncate'>
         {{label}}
         {{#if parent}}<span class='flag truncate' title="{{parent}}">{{parent}}</span>{{/if}}
      </li>

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -44,6 +44,9 @@ define([
 
         var getItems = function getItems(pattern){
             return loadItems(pattern).then(function(items){
+                if(!items || !items.length){
+                    return update();
+                }
                 return getCategories(_.pluck(items, 'uri')).then(function(categories){
                     update(_.map(items, function(item){
                         item.categories = _.isArray(categories[item.uri]) ? categories[item.uri] : [];

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -84,8 +84,6 @@ define([
          * @param {Array} items - the new items
          */
         function update (items){
-
-            console.log(items);
             disableSelection();
             $itemBox.empty().append(itemTemplate(items));
             enableSelection();

--- a/views/templates/creator.tpl
+++ b/views/templates/creator.tpl
@@ -76,6 +76,7 @@ requirejs.config({
                 get  : '<?=get_data('loadUrl')?>',
                 save  : '<?=get_data('saveUrl')?>',
                 items : '<?=get_data('itemsUrl')?>',
+                categories : '<?=get_data('categoriesUrl')?>',
                 identifier : '<?=get_data('identifierUrl')?>'
             },
             labels : <?=get_data('labels')?>


### PR DESCRIPTION
Front end to sync metadata categories. 
You need to define a mapping in  `config/taoQtiItem/ItemCategories.conf.php` and create the according properties on items. For example, I'm testing with : 

```php
return new oat\taoQtiItem\model\ItemCategoriesService([
    'properties' => [
        'http://bertaodev/tao.rdf#i14757674659611422' => [
            'math' => 'math',
            'Math' => 'math',
            'algebra' => 'math',
            'geometry' => 'math'
        ], 
        'http://bertaodev/tao.rdf#i14758263433677423' => [
            'noob' => 'easy',
            'guru' => 'difficult',
        ]    
    ]
]);
``` 

Then try to add an item with a property that matches the mapping into a test. The categories should be created.

Please note there's a bug when you add an item with categories in an empty section : the section gets the categories and they're inherited to other items. I have to clarify this bug in a separate PR.