### PR TITLE
Fix/tao 3230 timed section

### DIFF
--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -35,6 +35,7 @@ use qtism\data\SubmissionMode;
 use qtism\data\NavigationMode;
 use oat\taoQtiItem\helpers\QtiRunner;
 use oat\taoQtiTest\models\TestSessionMetaData;
+
 /**
  * Runs a QTI Test.
  *
@@ -488,31 +489,35 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
 
     protected function endTimedSection($nextPosition)
     {
-        $isJumpOutOfSection = false;
-        $session = $this->getTestSession();
-        $section = $session->getCurrentAssessmentSection();
+        $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
 
-        $route = $session->getRoute();
+        if (empty($config['keep-timer-up-to-timeout'])) {
+            $isJumpOutOfSection = false;
+            $session = $this->getTestSession();
+            $section = $session->getCurrentAssessmentSection();
 
-        if( ($nextPosition >= 0) && ($nextPosition < $route->count()) ){
-            $nextSection = $route->getRouteItemAt($nextPosition);
+            $route = $session->getRoute();
 
-            $isJumpOutOfSection = ($section->getIdentifier() !== $nextSection->getAssessmentSection()->getIdentifier());
-        }
+            if (($nextPosition >= 0) && ($nextPosition < $route->count())) {
+                $nextSection = $route->getRouteItemAt($nextPosition);
 
-        $limits = $section->getTimeLimits();
+                $isJumpOutOfSection = ($section->getIdentifier() !== $nextSection->getAssessmentSection()->getIdentifier());
+            }
 
-        //ensure that jumping out and section is timed
-        if( $isJumpOutOfSection && $limits != null && $limits->hasMaxTime() ) {
-            $components = $section->getComponents();
+            $limits = $section->getTimeLimits();
 
-            foreach( $components as $object ){
-                if( $object instanceof \qtism\data\ExtendedAssessmentItemRef ){
-                    $items = $session->getAssessmentItemSessions( $object->getIdentifier() );
+            //ensure that jumping out and section is timed
+            if ($isJumpOutOfSection && $limits != null && $limits->hasMaxTime()) {
+                $components = $section->getComponents();
 
-                    foreach ($items as $item) {
-                        if( $item instanceof \qtism\runtime\tests\AssessmentItemSession ){
-                            $item->endItemSession();
+                foreach ($components as $object) {
+                    if ($object instanceof \qtism\data\ExtendedAssessmentItemRef) {
+                        $items = $session->getAssessmentItemSessions($object->getIdentifier());
+
+                        foreach ($items as $item) {
+                            if ($item instanceof \qtism\runtime\tests\AssessmentItemSession) {
+                                $item->endItemSession();
+                            }
                         }
                     }
                 }

--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -319,4 +319,10 @@ return array(
      * @type boolean
      */
     'check-informational' => true,
+    
+    /**
+     * Keep the timer when the test taker leaves a section, in order to restore it when he/she goes back 
+     * @type boolean
+     */
+    'keep-timer-up-to-timeout' => false,
 );

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -570,6 +570,7 @@ class taoQtiTest_helpers_TestRunnerUtils {
                 'test-taker-review-prevents-unseen' => 'reviewPreventsUnseen',
                 'test-taker-review-can-collapse'    => 'reviewCanCollapse',
                 'next-section'                      => 'nextSection',
+                'keep-timer-up-to-timeout'          => 'keepTimerUpToTimeout',
             );
             foreach ($configMap as $configKey => $contextKey) {
                 if (isset($config[$configKey])) {

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.27.0',
+    'version' => '5.28.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -154,6 +154,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         // initialize the test session and related objects
         $serviceContext = new QtiRunnerServiceContext($testDefinitionUri, $testCompilationUri, $testExecutionUri);
         $serviceContext->setServiceManager($this->getServiceManager());
+        $serviceContext->setTestConfig($this->getTestConfig());
 
         $testSession = $serviceContext->getTestSession();
         if ($testSession instanceof TestSession) {

--- a/models/classes/runner/RunnerServiceContext.php
+++ b/models/classes/runner/RunnerServiceContext.php
@@ -21,26 +21,54 @@
  */
 
 namespace oat\taoQtiTest\models\runner;
+
 use oat\oatbox\service\ServiceManager;
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
 /**
  * Class RunnerServiceContext
- * 
+ *
  * Defines a container to store and to share runner service context
- * 
+ *
  * @package oat\taoQtiTest\models
  */
-class RunnerServiceContext  implements ServiceLocatorAwareInterface
+class RunnerServiceContext implements ServiceLocatorAwareInterface
 {
     use ServiceLocatorAwareTrait;
-    
+
     /**
      * The test session
      * @var mixed
      */
     protected $testSession;
+
+    /**
+     * The test runner config
+     * @var RunnerConfig
+     */
+    protected $testConfig;
+
+    /**
+     * Gets the test runner config
+     * @return RunnerConfig
+     */
+    public function getTestConfig()
+    {
+        return $this->testConfig;
+    }
+
+    /**
+     * Sets the test runner config
+     * 
+     * @param RunnerConfig $testConfig
+     */
+    public function setTestConfig(RunnerConfig $testConfig)
+    {
+        $this->testConfig = $testConfig;
+    }
+    
 
     /**
      * Gets the test session

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -71,6 +71,7 @@ class QtiRunnerConfig implements RunnerConfig
                 'timer' => [
                     'target' => isset($rawConfig['timer']) && isset($rawConfig['timer']['target']) ? $rawConfig['timer']['target'] : null,
                     'resetAfterResume' => !empty($rawConfig['reset-timer-after-resume']),
+                    'keepUpToTimeout' => !empty($rawConfig['keep-timer-up-to-timeout']),
                 ],
                 'enableAllowSkipping' => isset($rawConfig['enable-allow-skipping']) ? $rawConfig['enable-allow-skipping'] : false,
                 'checkInformational' => isset($rawConfig['check-informational']) ? $rawConfig['check-informational'] : false,

--- a/models/classes/runner/navigation/QtiRunnerNavigation.php
+++ b/models/classes/runner/navigation/QtiRunnerNavigation.php
@@ -96,29 +96,33 @@ class QtiRunnerNavigation
      */
     public static function checkTimedSectionExit(RunnerServiceContext $context, $nextPosition)
     {
-        /* @var AssessmentTestSession $session */
-        $session = $context->getTestSession();
-        $route = $session->getRoute();
-        $section = $session->getCurrentAssessmentSection();
-        $limits = $section->getTimeLimits();
+        $timerConfig = $context->getTestConfig()->getConfigValue('timer');
+        
+        if (empty($timerConfig['keepUpToTimeout'])) {
+            /* @var AssessmentTestSession $session */
+            $session = $context->getTestSession();
+            $route = $session->getRoute();
+            $section = $session->getCurrentAssessmentSection();
+            $limits = $section->getTimeLimits();
 
-        $isJumpOutOfSection = false;
-        if (($nextPosition >= 0) && ($nextPosition < $route->count())) {
-            $nextSection = $route->getRouteItemAt($nextPosition);
+            $isJumpOutOfSection = false;
+            if (($nextPosition >= 0) && ($nextPosition < $route->count())) {
+                $nextSection = $route->getRouteItemAt($nextPosition);
 
-            $isJumpOutOfSection = ($section->getIdentifier() !== $nextSection->getAssessmentSection()->getIdentifier());
-        }
+                $isJumpOutOfSection = ($section->getIdentifier() !== $nextSection->getAssessmentSection()->getIdentifier());
+            }
 
-        if ($isJumpOutOfSection && $limits != null && $limits->hasMaxTime()) {
-            $components = $section->getComponents();
+            if ($isJumpOutOfSection && $limits != null && $limits->hasMaxTime()) {
+                $components = $section->getComponents();
 
-            foreach ($components as $object) {
-                if ($object instanceof ExtendedAssessmentItemRef) {
-                    $items = $session->getAssessmentItemSessions($object->getIdentifier());
+                foreach ($components as $object) {
+                    if ($object instanceof ExtendedAssessmentItemRef) {
+                        $items = $session->getAssessmentItemSessions($object->getIdentifier());
 
-                    foreach ($items as $item) {
-                        if ($item instanceof AssessmentItemSession) {
-                            $item->endItemSession();
+                        foreach ($items as $item) {
+                            if ($item instanceof AssessmentItemSession) {
+                                $item->endItemSession();
+                            }
                         }
                     }
                 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -674,5 +674,17 @@ class Updater extends \common_ext_ExtensionUpdater {
             ]));
             $this->setVersion('5.27.0');
         }
+
+        if ($this->isVersion('5.27.0')) {
+
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+
+            $config = $extension->getConfig('testRunner');
+            $config['keep-timer-up-to-timeout'] = false;
+
+            $extension->setConfig('testRunner', $config);
+
+            $this->setVersion('5.28.0');
+        }
     }
 }

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -329,6 +329,7 @@ function (
 
                 if ((action === 'moveForward' && this.shouldDisplayEndTestWarning())    // prevent duplicate warning
                     || this.hasOption(optionNoExitTimedSectionWarning)                  // check if warning is disabled
+                    || this.testContext.keepTimerUpToTimeout                            // no need to display the message as we may be able to go back
                 ) {
                     doExitTimedSection();
                 } else {

--- a/views/js/runner/plugins/controls/timer/timer.js
+++ b/views/js/runner/plugins/controls/timer/timer.js
@@ -339,13 +339,17 @@ define([
                         .after('renderitem', doEnable)
                         .before('move', function(e, type, scope, position){
                             var context = testRunner.getTestContext();
+                            var testData = testRunner.getTestData();
+                            var config = testData && testData.config;
+                            var timerConfig = config && config.timer || {};
+                            var options = context && context.options || {};
 
                             var movePromise = new Promise(function(resolve, reject) {
                                 // endTestWarning has already been displayed, so we don't repeat the warning
-                                if (context.isLast && context.options.endTestWarning) {
+                                if (context.isLast && options.endTestWarning) {
                                     resolve();
                                 // display a message if we exit a timed section
-                                } else if(leaveTimedSection(type, scope, position) && !context.options.noExitTimedSectionWarning) {
+                                } else if(leaveTimedSection(type, scope, position) && !options.noExitTimedSectionWarning && !timerConfig.keepUpToTimeout) {
                                     testRunner.trigger('confirm.exittimed', messages.getExitMessage(exitMessage, 'section', testRunner), resolve, reject);
                                 } else {
                                     resolve();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3230

By default the TestRunner closes the session of each item contained by the timed section the TestTaler is leaving. This is not the standard wanted behavior.

This patch add an option to keep the timer until its timeout, even if we leave a timed section. So it is now possible to go back on a timed section and restore the timer to the state it had before leaving.

The name of the option: `keep-timer-up-to-timeout`.
This option is disabled by default, in order to prevent regression on existing installs.