### PR TITLE
Fix/php compaction time extended

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.31.0',
+    'version' => '5.31.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',

--- a/models/classes/class.QtiTestCompiler.php
+++ b/models/classes/class.QtiTestCompiler.php
@@ -696,7 +696,7 @@ class taoQtiTest_models_classes_QtiTestCompiler extends taoTests_models_classes_
      */
     protected function compileTest(AssessmentTest $test) {
         // Compiling a test may require extra processing time.
-        helpers_TimeOutHelper::setTimeOutLimit(helpers_TimeOutHelper::SHORT);
+        helpers_TimeOutHelper::setTimeOutLimit(helpers_TimeOutHelper::MEDIUM);
 
         $phpCompiledDoc = new PhpDocument('2.1', $test);
         $data = $phpCompiledDoc->saveToString();

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -713,7 +713,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $extension->setConfig('testRunner', $config);
 
-            $this->setVersion('5.31.0');
+            $this->setVersion('5.31.1');
         }
     }
 }


### PR DESCRIPTION
30 seconds is sometimes not enough for test php compaction, on very very large tests containing hundreds of items.