### PR TITLE
Feature/tao 3251 item responses

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -354,17 +354,15 @@ return array(
             'toggle' => 'R',
             'flag' => 'M'
         ],
-<<<<<<< HEAD
         'responsesAccess' => [
             'previous' => 'Shift+Tab',
             'next' => 'Tab'
-=======
+        ],
         'next' => [
             'trigger' => 'J'
         ],
         'previous' => [
             'trigger' => 'K'
->>>>>>> develop
         ]
     ],
 );

--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -353,6 +353,10 @@ return array(
         'review' => [
             'toggle' => 'R',
             'flag' => 'M'
+        ],
+        'responsesAccess' => [
+            'previous' => 'Shift+Tab',
+            'next' => 'Tab'
         ]
     ],
 );

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',
-        'taoQtiItem' => '>=6.0.1',
+        'taoQtiItem' => '>=5.14.0',
         'tao'        => '>=7.21.0'
     ),
 	'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.31.0',
+    'version' => '5.32.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -99,6 +99,14 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'category' => 'content',
                 'active' => true,
                 'tags' => [ 'core', 'qti', 'required' ]
+            ], [
+                'id' => 'responsesAccess',
+                'name' => 'Shortcuts to access the item responses',
+                'module' => 'taoQtiTest/runner/plugins/content/accessibility/responsesAccess',
+                'description' => 'Provide a way to navigate between item responses using the keyboard',
+                'category' => 'content',
+                'active' => true,
+                'tags' => [ 'core', 'qti' ]
             ]
         ],
         'controls' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -715,5 +715,21 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('5.31.0');
         }
+        
+        if ($this->isVersion('5.31.0')) {
+
+            $registry = PluginRegistry::getRegistry();
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'responsesAccess',
+                'name' => 'Shortcuts to access the item responses',
+                'module' => 'taoQtiTest/runner/plugins/content/accessibility/responsesAccess',
+                'description' => 'Provide a way to navigate between item responses using the keyboard',
+                'category' => 'content',
+                'active' => true,
+                'tags' => [ 'core', 'qti' ]
+            ]));            
+
+            $this->setVersion('5.32.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -761,6 +761,16 @@ class Updater extends \common_ext_ExtensionUpdater {
                 'tags' => [ 'core', 'qti' ]
             ]));
 
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+
+            $config = $extension->getConfig('testRunner');
+            $config['shortcuts']['responsesAccess'] = [
+                'previous' => 'Shift+Tab',
+                'next' => 'Tab'
+            ];
+
+            $extension->setConfig('testRunner', $config);
+
             $this->setVersion('5.33.0');
         }
     }

--- a/views/js/runner/plugins/content/accessibility/responsesAccess.js
+++ b/views/js/runner/plugins/content/accessibility/responsesAccess.js
@@ -87,7 +87,7 @@ define([
             }
 
             /**
-             * Select the next item response
+             * Select the previous item response
              */
             function previousResponse() {
                 cursor = (getCurrentIndex() + count - 1) % count;
@@ -97,7 +97,7 @@ define([
             }
 
             /**
-             * Select the previous item response
+             * Select the next item response
              */
             function nextResponse() {
                 cursor = (getCurrentIndex() + 1) % count;

--- a/views/js/runner/plugins/content/accessibility/responsesAccess.js
+++ b/views/js/runner/plugins/content/accessibility/responsesAccess.js
@@ -58,7 +58,7 @@ define([
                 var isFocused = false;
                 var $input;
 
-                if ($.contains($content.get(0), document.activeElement)) {
+                if (document.activeElement && $.contains($content.get(0), document.activeElement)) {
                     // try to find the focused element within the known list of response elements
                     _.forEach(responses, function(response, index) {
                         if (document.activeElement === response) {
@@ -72,13 +72,15 @@ define([
                 if (!isFocused) {
                     // from the current cursor retrieve the related interaction, then find the selected response
                     $input = $(':input:eq(' + cursor +')', $content).closest('.qti-interaction').find(':checked');
-                    _.forEach(responses, function(response, index) {
-                        if ($input.is(response)) {
-                            cursor = index;
-                            isFocused = true;
-                            return false;
-                        }
-                    });
+                    if ($input.length) {
+                        _.forEach(responses, function(response, index) {
+                            if ($input.is(response)) {
+                                cursor = index;
+                                isFocused = true;
+                                return false;
+                            }
+                        });
+                    }
                 }
 
                 return cursor;

--- a/views/js/runner/plugins/content/accessibility/responsesAccess.js
+++ b/views/js/runner/plugins/content/accessibility/responsesAccess.js
@@ -25,7 +25,7 @@ define([
     'lodash',
     'util/shortcut',
     'taoTests/runner/plugin'
-], function ($, lodash, shortcut, pluginFactory) {
+], function ($, _, shortcut, pluginFactory) {
     'use strict';
 
     /**
@@ -58,11 +58,27 @@ define([
              */
             function getCurrentIndex() {
                 var $content = testRunner.getAreaBroker().getContentArea();
+                var isFocused = false;
+                var $input;
 
                 if ($.contains($content.get(0), document.activeElement)) {
+                    // try to find the focused element within the known list of response elements
                     _.forEach(responses, function(response, index) {
                         if (document.activeElement === response) {
                             cursor = index;
+                            isFocused = true;
+                            return false;
+                        }
+                    });
+                }
+
+                if (!isFocused) {
+                    // from the current cursor retrieve the related interaction, then find the selected response
+                    $input = $(':input:eq(' + cursor +')', $content).closest('.qti-interaction').find(':checked');
+                    _.forEach(responses, function(response, index) {
+                        if ($input.is(response)) {
+                            cursor = index;
+                            isFocused = true;
                             return false;
                         }
                     });

--- a/views/js/runner/plugins/content/accessibility/responsesAccess.js
+++ b/views/js/runner/plugins/content/accessibility/responsesAccess.js
@@ -1,0 +1,146 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Test Runner Content Plugin : Navigate through the item responses using the keyboard
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'util/shortcut',
+    'taoTests/runner/plugin'
+], function ($, lodash, shortcut, pluginFactory) {
+    'use strict';
+
+    /**
+     * @type {String}
+     */
+    var pluginName = 'responsesAccess';
+
+    /**
+     * Returns the configured plugin
+     */
+    return pluginFactory({
+
+        name: pluginName,
+
+        /**
+         * Initialize the plugin (called during runner's init)
+         */
+        init: function init() {
+            var self = this;
+            var testRunner = this.getTestRunner();
+            var testData = testRunner.getTestData() || {};
+            var testConfig = testData.config || {};
+            var responses = [];
+            var count = 1;
+            var cursor = 0;
+
+            /**
+             * Gets the tabindex of the currently selected response
+             * @returns {Number}
+             */
+            function getCurrentIndex() {
+                var $content = testRunner.getAreaBroker().getContentArea();
+
+                if ($.contains($content.get(0), document.activeElement)) {
+                    _.forEach(responses, function(response, index) {
+                        if (document.activeElement === response) {
+                            cursor = index;
+                            return false;
+                        }
+                    });
+                }
+
+                return cursor;
+            }
+
+            /**
+             * Select the next item response
+             */
+            function previousResponse() {
+                cursor = (getCurrentIndex() + count - 1) % count;
+                if (responses[cursor]) {
+                    responses[cursor].focus();
+                }
+            }
+
+            /**
+             * Select the previous item response
+             */
+            function nextResponse() {
+                cursor = (getCurrentIndex() + 1) % count;
+                if (responses[cursor]) {
+                    responses[cursor].focus();
+                }
+            }
+
+            if (testConfig.allowShortcuts) {
+                shortcut.add('Shift+Tab.' + pluginName, function () {
+                    testRunner.trigger('previous-response');
+                }, {
+                    prevent: true
+                });
+
+                shortcut.add('Tab.' + pluginName, function () {
+                    testRunner.trigger('next-response');
+                }, {
+                    prevent: true
+                });
+            }
+
+            //start disabled
+            this.disable();
+
+            //update plugin state based on changes
+            testRunner
+                .on('renderitem', function () {
+                    var $content = testRunner.getAreaBroker().getContentArea();
+
+                    responses = $(':input', $content).toArray();
+                    responses.sort(function (a, b) {
+                        return parseInt(a.tabIndex, 10) - parseInt(b.tabIndex, 10);
+                    });
+                    count = responses.length || 1;
+                    cursor = 0;
+                    self.enable();
+                })
+                .on('unloaditem', function () {
+                    self.disable();
+                })
+                .on('previous-response', previousResponse)
+                .on('next-response', nextResponse);
+        },
+
+        /**
+         * Called during the runner's render phase
+         */
+        render: function render() {
+            var $container = this.getAreaBroker().getToolboxArea();
+            $container.append(this.$button);
+        },
+
+        /**
+         * Called during the runner's destroy phase
+         */
+        destroy: function destroy() {
+            shortcut.remove('.' + pluginName);
+        }
+    });
+});

--- a/views/js/runner/plugins/content/accessibility/responsesAccess.js
+++ b/views/js/runner/plugins/content/accessibility/responsesAccess.js
@@ -130,7 +130,9 @@ define([
 
                     responses = $(':input', $content).toArray();
                     responses.sort(function (a, b) {
-                        return parseInt(a.tabIndex, 10) - parseInt(b.tabIndex, 10);
+                        var aIndex = a.tabIndex || 1;
+                        var bIndex = b.tabIndex || 1;
+                        return parseInt(aIndex, 10) - parseInt(bIndex, 10);
                     });
                     count = responses.length || 1;
                     cursor = 0;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3251

Requires: https://github.com/oat-sa/extension-tao-itemqti/pull/839

Allow to navigate through the item responses by using the tab key.
The plugin only scopes the actual item responses, thus it also prevents to reach outside controls, like the address bar.