### PR TITLE
Feature/tao 3238 test export

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.34.0',
+    'version' => '5.35.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.4.0',

--- a/models/classes/export/metadata/TestExporter.php
+++ b/models/classes/export/metadata/TestExporter.php
@@ -22,31 +22,150 @@
 namespace oat\taoQtiTest\models\export\metadata;
 
 use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\filesystem\File;
 use oat\oatbox\service\ConfigurableService;
-use oat\taoQtiItem\model\flyExporter\simpleExporter\ItemExporter;
+use oat\taoQtiItem\model\flyExporter\extractor\ExtractorException;
 use oat\taoQtiItem\model\flyExporter\simpleExporter\SimpleExporter;
+use qtism\data\AssessmentItemRef;
+use qtism\data\AssessmentSection;
+use qtism\data\TestPart;
 
 /**
- *
  * Class TestExporter
  */
 class TestExporter extends ConfigurableService implements TestMetadataExporter
 {
     use OntologyAwareTrait;
 
+    const TEST_PART    = 'testPart';
+    const TEST_SECTION = 'section';
+    const TEST_ITEM    = 'assessmentItemRef';
+    const ITEM_SHUFFLE = 'shuffle';
+    const ITEM_ORDER   = 'section-order';
+
+    /**
+     * Item exporter to handle each items
+     *
+     * @var SimpleExporter
+     */
+    protected $itemExporter;
+
+    /**
+     * Uri of assessment to export
+     *
+     * @var string
+     */
+    protected $assessmentUri;
+
+    /**
+     * Item data extracted from assessment
+     *
+     * @var array
+     */
+    protected $assessmentItemData = [];
+
     /**
      * Main action to launch export
      *
      * @param string $uri
-     * @return mixed
+     * @return File
      */
     public function export($uri)
     {
-        /** @var ItemExporter $itemExporter */
-        $itemExporter = $this->getServiceManager()->get(SimpleExporter::SERVICE_ID);
-        return $itemExporter->export(
-            \taoQtiTest_models_classes_QtiTestService::singleton()->getItems($this->getResource($uri)),
-            true
-        );
+        $this->assessmentUri = $uri;
+
+        $items = \taoQtiTest_models_classes_QtiTestService::singleton()->getItems($this->getResource($uri));
+
+        $data = [];
+        /** @var \core_kernel_classes_Resource $item */
+        foreach ($items as $item) {
+            try {
+                $itemData = $this->getItemExporter()->getDataByItem($item);
+                foreach ($itemData as &$column) {
+                    $column = array_merge($column, $this->getAdditionalData($item));
+                }
+                $data[] = $itemData;
+            } catch (ExtractorException $e) {
+                \common_Logger::e('ERROR on item ' . $item->getUri() . ' : ' . $e->getMessage());
+            }
+        }
+        $headers = array_merge($this->getItemExporter()->getHeaders(), $this->getHeaders());
+
+        return $this->getItemExporter()->save($headers, $data, true);
+    }
+
+    /**
+     * Get assessment data for an item
+     *
+     * @param \core_kernel_classes_Resource $item
+     * @return array
+     */
+    protected function getAdditionalData(\core_kernel_classes_Resource $item)
+    {
+        $data = $this->getAssessmentData();
+        $identifier = $item->getUri();
+
+        if (isset($data[$identifier])) {
+            return $data[$identifier];
+        } else {
+            return [];
+        }
+    }
+
+    /**
+     * Fetch assessment item data
+     *
+     * @return array
+     */
+    protected function getAssessmentData()
+    {
+        if (empty($this->assessmentItemData)) {
+            $xml = \taoQtiTest_models_classes_QtiTestService::singleton()->getDoc($this->getResource($this->assessmentUri));
+            $testPartCollection = $xml->getDocumentComponent()->getComponentsByClassName(self::TEST_PART);
+
+            /** @var TestPart $testPart */
+            foreach ($testPartCollection as $testPart) {
+                $sectionCollection = $testPart->getAssessmentSections();
+                /** @var AssessmentSection $section */
+                foreach ($sectionCollection as $section) {
+                    $itemCollection = $section->getComponentsByClassName(self::TEST_ITEM);
+                    $order = 1;
+                    /** @var AssessmentItemRef $item */
+                    foreach ($itemCollection as $item) {
+                        $this->assessmentItemData[$item->getHref()] = [
+                            self::TEST_PART    => $testPart->getIdentifier(),
+                            self::TEST_SECTION => $section->getIdentifier(),
+                            self::ITEM_SHUFFLE => is_null($section->getOrdering()) ? 0 : (int) $section->getOrdering()->getShuffle(),
+                            self::ITEM_ORDER   => $order,
+                        ];
+                        $order++;
+                    }
+                }
+            }
+        }
+        return $this->assessmentItemData;
+    }
+
+    /**
+     * Get headers of additional data for assessment items
+     *
+     * @return array
+     */
+    protected function getHeaders()
+    {
+        return [self::TEST_PART, self::TEST_SECTION, self::ITEM_SHUFFLE, self::ITEM_ORDER];
+    }
+
+    /**
+     * Get item exporter service
+     *
+     * @return SimpleExporter
+     */
+    protected function getItemExporter()
+    {
+        if (! $this->itemExporter) {
+            $this->itemExporter = $this->getServiceManager()->get(SimpleExporter::SERVICE_ID);
+        }
+        return $this->itemExporter;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -793,5 +793,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('5.34.0');
         }
+
+        $this->skip('5.34.0', '5.35.0');
     }
 }


### PR DESCRIPTION
Require https://github.com/oat-sa/extension-tao-itemqti/pull/842

Export metadata test has 4 news columns regarding item into a test (testPArt, section, shuffle, order)
The order is order on test part.

TO TEST : export test metadata & check column