### PR TITLE
Fix/tao 3409 timeout fast forward

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.39.0',
+    'version' => '5.39.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -223,7 +223,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
             }
 
             $session->initItemTimer();
-            if (TestRunnerUtils::isTimeout($session) === false) {
+            if ($session->isTimeout() === false) {
                 TestRunnerUtils::beginCandidateInteraction($session);
             }
         } else {
@@ -1133,7 +1133,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         /* @var TestSession $session */
         $session = $context->getTestSession();
 
-        if ($session->isRunning() === true && TestRunnerUtils::isTimeout($session) === false) {
+        if ($session->isRunning() === true && $session->isTimeout() === false) {
             TestRunnerUtils::beginCandidateInteraction($session);
             $continue = true;
         }

--- a/models/classes/runner/time/QtiTimeConstraint.php
+++ b/models/classes/runner/time/QtiTimeConstraint.php
@@ -115,7 +115,8 @@ class QtiTimeConstraint extends TimeConstraint
                 // take care of the already consumed extra time under the current constraint
                 // and append the full remaining extra time
                 // the total must correspond to the already elapsed time plus the remaining time
-                $extraTime = $this->timer->getRemainingExtraTime() + $this->timer->getConsumedExtraTime($this->getSource()->getIdentifier());
+                $currentExtraTime = $this->timer->getRemainingExtraTime() + $this->timer->getConsumedExtraTime($this->getSource()->getIdentifier());
+                $extraTime = min($this->timer->getExtraTime(), $currentExtraTime);
                 $remaining->add(new QtiDuration('PT' . $extraTime . 'S'));
             }
             $remaining->sub($this->getDuration());

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -843,6 +843,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.38.2');
         }
 
-        $this->skip('5.38.2', '5.39.0');
+        $this->skip('5.38.2', '5.39.1');
     }
 }


### PR DESCRIPTION
Fix the issue related to the fast forward over timed out items when a timeout occurs.

The issue is due to the computation of the extra time when no extra time is set.