### PR TITLE
Fix/tao 3350 tab key issue

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -391,7 +391,7 @@ return array(
         ],
         'dialog' => [
             'accept' => 'Enter',
-            'reject' => 'X'
+            'reject' => 'Esc'
         ]
     ],
 );

--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -388,6 +388,10 @@ return array(
         ],
         'previous' => [
             'trigger' => 'K'
+        ],
+        'dialog' => [
+            'accept' => 'Enter',
+            'reject' => 'X'
         ]
     ],
 );

--- a/manifest.php
+++ b/manifest.php
@@ -34,12 +34,12 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.46.2',
+    'version' => '5.47.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',
         'taoQtiItem' => '>=5.14.0',
-        'tao'        => '>=7.35.0'
+        'tao'        => '>=7.38.0'
     ),
 	'models' => array(
 		'http://www.tao.lu/Ontologies/TAOTest.rdf'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -932,7 +932,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $config['shortcuts']['dialog'] = [
                 'accept' => 'Enter',
-                'reject' => 'X'
+                'reject' => 'Esc'
             ];
 
             $extension->setConfig('testRunner', $config);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -924,5 +924,20 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
         
         $this->skip('5.45.0', '5.46.2');
+
+        if ($this->isVersion('5.46.2')) {
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+
+            $config = $extension->getConfig('testRunner');
+
+            $config['shortcuts']['dialog'] = [
+                'accept' => 'Enter',
+                'reject' => 'X'
+            ];
+
+            $extension->setConfig('testRunner', $config);
+
+            $this->setVersion('5.47.0');
+        }
     }
 }

--- a/views/js/runner/plugins/content/dialog/dialog.js
+++ b/views/js/runner/plugins/content/dialog/dialog.js
@@ -27,35 +27,117 @@ define([
     'i18n',
     'taoTests/runner/plugin',
     'ui/dialog/alert',
-    'ui/dialog/confirm'
-], function ($, _, __, pluginFactory, dialogAlert, dialogConfirm){
+    'ui/dialog/confirm',
+    'util/shortcut/registry',
+    'util/shortcut',
+    'util/namespace'
+], function ($, _, __, pluginFactory, dialogAlert, dialogConfirm, shortcutRegistry, shortcut, namespaceHelper){
     'use strict';
+
+    /**
+     * The public name of the plugin
+     * @type {String}
+     */
+    var pluginName = 'dialog';
+
+    /**
+     * The prefix of actions triggered through the event loop
+     * @type {String}
+     */
+    var actionPrefix = 'tool-' + pluginName + '-';
 
     /**
      * Returns the configured plugin
      */
     return pluginFactory({
-        name : 'dialog',
+        name : pluginName,
 
         /**
          * Initialize the plugin (called during runner's init)
          */
         init : function init(){
             var testRunner = this.getTestRunner();
+            var testData = testRunner.getTestData() || {};
+            var testConfig = testData.config || {};
+            var pluginShortcuts = (testConfig.shortcuts || {})[pluginName] || {};
             var alerts = [];
             var confirms = [];
+            var opened = [];
+            var dialogShortcut = shortcutRegistry($('body'), {
+                propagate: false,
+                prevent: true
+            });
 
+            /**
+             * Closes a dialog with accept
+             * @param {dialog} dialog - The instance of the dialog
+             */
+            function closeAccept(dialog) {
+                // TODO: improve the dialog implementation in order to provide a better API
+                dialog.trigger('okbtn.modal').hide();
+            }
+
+            /**
+             * Closes a dialog with rejection
+             * @param {dialog} dialog - The instance of the dialog
+             */
+            function closeReject(dialog) {
+                dialog.hide();
+            }
+
+            /**
+             * Closes the last opened dialog
+             * @param {Boolean} accept Whether the dialog should be accepted or not
+             */
+            function closeLast(accept) {
+                var handle = opened.length && opened[opened.length - 1];
+                if (handle) {
+                    if (accept) {
+                        closeAccept(handle.dialog);
+                    } else {
+                        closeReject(handle.dialog);
+                    }
+                }
+            }
+
+            /**
+             * Add dialog on top of the provided stack
+             * @param {String} namespace - The event namespace that scope the dialog
+             * @param {Array} stack - The dialogs stack on which push the new instance
+             * @param {dialog} dialog - The instance of the dialog
+             */
             function addHandle(namespace, stack, dialog) {
-                stack.push({
+                var handle = {
                     context: namespace,
                     dialog: dialog
-                });
+                };
+
+                // prevents all registered shortcuts to be triggered
+                // and brings back the dialog shortcuts
+                shortcut.disable();
+                dialogShortcut.enable();
+
+                stack.push(handle);
+                opened.push(handle);
 
                 dialog.on('closed.modal', function() {
                     removeHandle(stack, dialog);
+                    removeHandle(opened, dialog);
+
+                    // if all dialogs have been closed allows all registered shortcuts to be triggered
+                    // also disables the dialog shortcuts
+                    if (!opened.length) {
+                        shortcut.enable();
+                        dialogShortcut.disable();
+                    }
                 });
             }
 
+            /**
+             * Remove a dialog from the provided stack
+             * @param {Array} stack - The dialogs stack from which remove the dialog instance
+             * @param {dialog} dialog - The instance of the dialog
+             */
             function removeHandle(stack, dialog) {
                 if (dialog) {
                     _.remove(stack, function(handle) {
@@ -66,21 +148,40 @@ define([
                 }
             }
 
+            /**
+             * Closes all dialogs within the provided stack
+             * @param {String} namespace - The event namespace that scope the dialogs to close
+             * @param {Boolean} accept - Whether (`true`) or not (`false`) to close the dialogs with accept
+             * @param {Array} stack - The dialogs stack in which close the dialogs
+             */
             function closeDialogs(namespace, accept, stack) {
                 if (stack) {
                     _.forEach(stack, function(handle) {
                         if (handle && (namespace === '@' || namespace === handle.context)) {
                             if (accept) {
-                                // TODO: improve the dialog implementation in order to provide a better API
-                                handle.dialog.trigger('okbtn.modal');
+                                closeAccept(handle.dialog);
+                            } else {
+                                closeReject(handle.dialog);
                             }
-                            handle.dialog.hide();
                         }
                     });
                 } else {
                     closeDialogs(namespace, accept, alerts);
                     closeDialogs(namespace, accept, confirms);
                 }
+            }
+
+            // starts with shortcuts disabled, prevents the TAB key to be used to move outside the dialog box
+            dialogShortcut.disable().set('Tab Shift+Tab');
+
+            // handle the plugin's shortcuts
+            if (testConfig.allowShortcuts) {
+                _.forEach(pluginShortcuts, function(command, key) {
+                    dialogShortcut.add(namespaceHelper.namespaceAll(command, pluginName, true), function() {
+                        // just fire the action using the event loop
+                        testRunner.trigger(actionPrefix + key);
+                    });
+                });
             }
 
             //change plugin state
@@ -94,8 +195,17 @@ define([
                 .before('closedialog.*', function(e, accept) {
                     closeDialogs(e.namespace, accept);
                 })
+                .on(actionPrefix + 'accept', function() {
+                    closeLast(true);
+                })
+                .on(actionPrefix + 'reject', function() {
+                    closeLast(false);
+                })
                 .on('destroy', function() {
                     closeDialogs('.@');
+
+                    dialogShortcut.clear();
+                    dialogShortcut = null;
                 });
         }
     });

--- a/views/js/runner/plugins/content/dialog/dialog.js
+++ b/views/js/runner/plugins/content/dialog/dialog.js
@@ -31,7 +31,7 @@ define([
     'util/shortcut/registry',
     'util/shortcut',
     'util/namespace'
-], function ($, _, __, pluginFactory, dialogAlert, dialogConfirm, shortcutRegistry, shortcut, namespaceHelper){
+], function ($, _, __, pluginFactory, dialogAlert, dialogConfirm, shortcutRegistry, globalShortcut, namespaceHelper){
     'use strict';
 
     /**
@@ -114,7 +114,7 @@ define([
 
                 // prevents all registered shortcuts to be triggered
                 // and brings back the dialog shortcuts
-                shortcut.disable();
+                globalShortcut.disable();
                 dialogShortcut.enable();
 
                 stack.push(handle);
@@ -127,7 +127,7 @@ define([
                     // if all dialogs have been closed allows all registered shortcuts to be triggered
                     // also disables the dialog shortcuts
                     if (!opened.length) {
-                        shortcut.enable();
+                        globalShortcut.enable();
                         dialogShortcut.disable();
                     }
                 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3350

Requires: https://github.com/oat-sa/tao-core/pull/1098

Fix the shortcuts issue happening with the modal dialogs:
- the TAB key should not focus outside of the dialog anymore
- when cancelling a dialog, the remaining dialogs should stay
- the dialogs now are controlled using these shortcuts (by default): `X` to cancel, `Enter` to validate