### PR TITLE
Fix/tao 3531 options with images navigation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.53.0',
+    'version' => '5.53.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -954,7 +954,7 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('5.48.0', '5.49.0');
-        
+
         if ($this->isVersion('5.49.0')) {
 
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
@@ -972,7 +972,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('5.49.1');
         }
-        
+
         if ($this->isVersion('5.49.1')) {
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
 
@@ -1002,6 +1002,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.50.1');
         }
 
-        $this->skip('5.50.1', '5.53.0');
+        $this->skip('5.50.1', '5.53.1');
     }
 }

--- a/views/css/plugins/key-navigation.css
+++ b/views/css/plugins/key-navigation.css
@@ -1,2 +1,2 @@
-.qti-item img.key-navigation-focusable{border:2px solid transparent}.qti-item img.key-navigation-focusable:focus{border-style:solid !important;border-color:#0e5d91 !important;outline:none}
+.qti-item div.key-navigation-focusable{padding:5px !important}.qti-item div.key-navigation-focusable,.qti-item img.key-navigation-focusable{border:2px solid transparent}.qti-item div.key-navigation-focusable:focus,.qti-item img.key-navigation-focusable:focus{border-style:solid !important;border-color:#0e5d91 !important;outline:none}
 /*# sourceMappingURL=key-navigation.css.map */

--- a/views/css/plugins/key-navigation.css.map
+++ b/views/css/plugins/key-navigation.css.map
@@ -1,6 +1,6 @@
 {
 "version": 3,
-"mappings": "AAEA,sCAAuC,CACnC,MAAM,CAAE,qBAAqB,CAC7B,4CAAQ,CAEJ,YAAY,CAAE,gBAAgB,CAC9B,YAAY,CAAE,kBAAgB,CAC9B,OAAO,CAAE,IAAI",
+"mappings": "AAEA,sCAAuC,CACnC,OAAO,CAAE,cAAc,CAG3B,6EACuC,CACnC,MAAM,CAAE,qBAAqB,CAC7B,yFAAQ,CAEJ,YAAY,CAAE,gBAAgB,CAC9B,YAAY,CAAE,kBAAgB,CAC9B,OAAO,CAAE,IAAI",
 "sources": ["../../scss/plugins/key-navigation.scss"],
 "names": [],
 "file": "key-navigation.css"

--- a/views/js/runner/plugins/content/accessibility/keyNavigation.js
+++ b/views/js/runner/plugins/content/accessibility/keyNavigation.js
@@ -151,12 +151,19 @@ define([
                     var $content = testRunner.getAreaBroker().getContentArea();
                     var index = 1;
 
-                    focusables = $(':input,img', $content).addClass('key-navigation-focusable').each(function(){
-                        var $this = $(this);
-                        //redistribute focus order
-                        $this.attr('tabindex', index);
-                        index++;
-                    }).toArray();
+                    focusables = $(':input,img', $content)
+                        .filter(function removeImagesInChoices() {
+                            var $this = $(this);
+                            return !($this.is('img') && $this.closest('.qti-choice', $content).length);
+                        })
+                        .addClass('key-navigation-focusable')
+                        .each(function(){
+                            var $this = $(this);
+                            //redistribute focus order
+                            $this.attr('tabindex', index);
+                            index++;
+                        })
+                        .toArray();
 
                     count = focusables.length || 1;
                     cursor = null;

--- a/views/js/runner/plugins/content/accessibility/keyNavigation.js
+++ b/views/js/runner/plugins/content/accessibility/keyNavigation.js
@@ -117,7 +117,7 @@ define([
                     cursor = 0;
                     //find the first input
                     _.forEach(focusables, function(focusable, index){
-                        if(focusable.nodeName !== 'IMG'){
+                        if ($(focusable).is(':input')) {
                             cursor = index;
                             focusable.focus();
                             return false;
@@ -151,7 +151,7 @@ define([
                     var $content = testRunner.getAreaBroker().getContentArea();
                     var index = 1;
 
-                    focusables = $(':input,img', $content)
+                    focusables = $(':input,img,.key-navigation-focusable', $content)
                         .filter(function removeImagesInChoices() {
                             var $this = $(this);
                             return !($this.is('img') && $this.closest('.qti-choice', $content).length);

--- a/views/scss/plugins/key-navigation.scss
+++ b/views/scss/plugins/key-navigation.scss
@@ -1,5 +1,10 @@
 @import "inc/bootstrap";
 
+.qti-item div.key-navigation-focusable {
+    padding: 5px !important;
+}
+
+.qti-item div.key-navigation-focusable,
 .qti-item img.key-navigation-focusable {
     border: 2px solid transparent;
     &:focus {


### PR DESCRIPTION
Create a choice interaction with images in some choices. With this fix, navigating through choices with Tab doesn't focus on images.

This also fixes https://oat-sa.atlassian.net/browse/TAO-3533. For this one, use the item in the JIRA ticket for testing, and you also need https://github.com/oat-sa/extension-tao-act/pull/439