### PR TITLE
Feature/tao 3545 score authoring

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.53.0',
+    'version' => '5.54.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1002,6 +1002,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.50.1');
         }
 
-        $this->skip('5.50.1', '5.53.0');
+        $this->skip('5.50.1', '5.54.0');
     }
 }

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -35,6 +35,7 @@ define([
     'taoQtiTest/controller/creator/encoders/dom2qti',
     'taoQtiTest/controller/creator/templates/index',
     'taoQtiTest/controller/creator/helpers/qtiTest',
+    'taoQtiTest/controller/creator/helpers/scoring',
     'core/validator/validators',
     'core/promise'
 ], function(
@@ -53,6 +54,7 @@ define([
     Dom2QtiEncoder,
     templates,
     qtiTestHelper,
+    scoringHelper,
     validators,
     Promise
     ){
@@ -161,6 +163,9 @@ define([
                 },
                 templates : templates,
                 beforeSave : function(model){
+                    //generate the outcomes that define the scoring
+                    scoringHelper.write(model);
+
                     //ensure the qti-type is present
                     qtiTestHelper.addMissingQtiType(model);
 
@@ -174,6 +179,8 @@ define([
             binder = DataBindController
                 .takeControl($container, binderOptions)
                 .get(function(model){
+                    //detect the scoring mode
+                    scoringHelper.read(model);
 
                     //extract ids
                     self.identifiers = qtiTestHelper.extractIdentifiers(model);

--- a/views/js/controller/creator/helpers/baseType.js
+++ b/views/js/controller/creator/helpers/baseType.js
@@ -1,0 +1,333 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * The BaseType enumeration (port of \qtism\common\enums\BaseType).
+ *
+ * From IMS QTI:
+ *
+ * A base-type is simply a description of a set of atomic values (atomic to this specification).
+ * Note that several of the baseTypes used to define the runtime data model have identical
+ * definitions to those of the basic data types used to define the values for attributes
+ * in the specification itself. The use of an enumeration to define the set of baseTypes
+ * used in the runtime model, as opposed to the use of classes with similar names, is
+ * designed to help distinguish between these two distinct levels of modelling.
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash'
+], function (_) {
+    'use strict';
+
+    /**
+     * The list of QTI base types
+     * @type {Object}
+     */
+    var baseTypeEnum = {
+        /**
+         * From IMS QTI:
+         *
+         * The set of identifier values is the same as the set of values
+         * defined by the identifier class.
+         *
+         * @type {Number}
+         */
+        IDENTIFIER: 0,
+
+        /**
+         * From IMS QTI:
+         *
+         * The set of boolean values is the same as the set of values defined
+         * by the boolean class.
+         *
+         * @type {Number}
+         */
+        BOOLEAN: 1,
+
+        /**
+         * From IMS QTI:
+         *
+         * The set of integer values is the same as the set of values defined
+         * by the integer class.
+         *
+         * @type {Number}
+         */
+        INTEGER: 2,
+
+        /**
+         * From IMS QTI:
+         *
+         * The set of float values is the same as the set of values defined by the
+         * float class.
+         *
+         * @type {Number}
+         */
+        FLOAT: 3,
+
+        /**
+         * From IMS QTI:
+         *
+         * The set of string values is the same as the set of values defined by the
+         * string class.
+         *
+         * @type {Number}
+         */
+        STRING: 4,
+
+        /**
+         * From IMS QTI:
+         *
+         * A point value represents an integer tuple corresponding to a graphic point.
+         * The two integers correspond to the horizontal (x-axis) and vertical (y-axis)
+         * positions respectively. The up/down and left/right senses of the axes are
+         * context dependent.
+         *
+         * @type {Number}
+         */
+        POINT: 5,
+
+        /**
+         * From IMS QTI:
+         *
+         * A pair value represents a pair of identifiers corresponding to an association
+         * between two objects. The association is undirected so (A,B) and (B,A) are equivalent.
+         *
+         * @type {Number}
+         */
+        PAIR: 6,
+
+        /**
+         * From IMS QTI:
+         *
+         * A directedPair value represents a pair of identifiers corresponding to a directed
+         * association between two objects. The two identifiers correspond to the source
+         * and destination objects.
+         *
+         * @type {Number}
+         */
+        DIRECTED_PAIR: 7,
+
+        /**
+         * From IMS QTI:
+         *
+         * A duration value specifies a distance (in time) between two time points.
+         * In other words, a time period as defined by [ISO8601], but represented as
+         * a single float that records time in seconds. Durations may have a fractional
+         * part. Durations are represented using the xsd:double datatype rather than
+         * xsd:dateTime for convenience and backward compatibility.
+         *
+         * @type {Number}
+         */
+        DURATION: 8,
+
+        /**
+         * From IMS QTI:
+         *
+         * A file value is any sequence of octets (bytes) qualified by a content-type and an
+         * optional filename given to the file (for example, by the candidate when uploading
+         * it as part of an interaction). The content type of the file is one of the MIME
+         * types defined by [RFC2045].
+         *
+         * @type {Number}
+         */
+        FILE: 9,
+
+        /**
+         * From IMS QTI:
+         *
+         * A URI value is a Uniform Resource Identifier as defined by [URI].
+         *
+         * @type {Number}
+         */
+        URI: 10,
+
+        /**
+         * From IMS QTI:
+         *
+         * An intOrIdentifier value is the union of the integer baseType and
+         * the identifier baseType.
+         *
+         * @type {Number}
+         */
+        INT_OR_IDENTIFIER: 11,
+
+        /**
+         * In qtism, we consider an extra 'coords' baseType.
+         *
+         * @type {Number}
+         */
+        COORDS: 12
+    };
+
+    var baseTypeHelper = _({
+        /**
+         * Gets the the list of QTI base types
+         * @returns {Object}
+         */
+        asArray: function asArray() {
+            return baseTypeEnum;
+        },
+
+        /**
+         * Gets a valid type or the default
+         * @param {String|Number} type
+         * @param {String|Number} [defaultType]
+         * @returns {*}
+         */
+        validOrDefault: function validOrDefault(type, defaultType) {
+            if (_.isFinite(type)) {
+                if (!baseTypeHelper.getNameByConstant(type)) {
+                    type = false;
+                }
+            } else {
+                type = baseTypeHelper.getConstantByName(type);
+            }
+
+            if (false === type) {
+                if (!_.isUndefined(defaultType) && defaultType !== -1) {
+                    type = baseTypeHelper.validOrDefault(defaultType, -1);
+                } else {
+                    type = -1;
+                }
+            }
+
+            return type;
+        },
+
+        /**
+         * Get a constant value from the BaseType enumeration by baseType name.
+         *
+         * * 'identifier' -> baseTypes.IDENTIFIER
+         * * 'boolean' -> baseTypes.BOOLEAN
+         * * 'integer' -> baseTypes.INTEGER
+         * * 'float' -> baseTypes.FLOAT
+         * * 'string' -> baseTypes.STRING
+         * * 'point' -> baseTypes.POINT
+         * * 'pair' -> baseTypes.PAIR
+         * * 'directedPair' -> baseTypes.DIRECTED_PAIR
+         * * 'duration' -> baseTypes.DURATION
+         * * 'file' -> baseTypes.FILE
+         * * 'uri' -> baseTypes.URI
+         * * 'intOrIdentifier' -> baseTypes.INT_OR_IDENTIFIER
+         * * extra 'coords' -> baseTypes.COORDS
+         *
+         * @param {String} name The baseType name.
+         * @return {Number|Boolean} The related enumeration value or `false` if the name could not be resolved.
+         */
+        getConstantByName: function getConstantByName(name) {
+            switch (String(name).trim().toLowerCase()) {
+                case 'identifier':
+                    return baseTypeEnum.IDENTIFIER;
+
+                case 'boolean':
+                    return baseTypeEnum.BOOLEAN;
+
+                case 'integer':
+                    return baseTypeEnum.INTEGER;
+
+                case 'float':
+                    return baseTypeEnum.FLOAT;
+
+                case 'string':
+                    return baseTypeEnum.STRING;
+
+                case 'point':
+                    return baseTypeEnum.POINT;
+
+                case 'pair':
+                    return baseTypeEnum.PAIR;
+
+                case 'directedpair':
+                    return baseTypeEnum.DIRECTED_PAIR;
+
+                case 'duration':
+                    return baseTypeEnum.DURATION;
+
+                case 'file':
+                    return baseTypeEnum.FILE;
+
+                case 'uri':
+                    return baseTypeEnum.URI;
+
+                case 'intoridentifier':
+                    return baseTypeEnum.INT_OR_IDENTIFIER;
+
+                case 'coords':
+                    return baseTypeEnum.COORDS;
+
+                default:
+                    return false;
+            }
+        },
+
+        /**
+         * Get the QTI name of a BaseType.
+         *
+         * @param {Number} constant A constant value from the BaseType enumeration.
+         * @return {String|Boolean} The QTI name or false if not match.
+         */
+        getNameByConstant: function getNameByConstant(constant) {
+            switch (constant) {
+                case baseTypeEnum.IDENTIFIER:
+                    return 'identifier';
+
+                case baseTypeEnum.BOOLEAN:
+                    return 'boolean';
+
+                case baseTypeEnum.INTEGER:
+                    return 'integer';
+
+                case baseTypeEnum.FLOAT:
+                    return 'float';
+
+                case baseTypeEnum.STRING:
+                    return 'string';
+
+                case baseTypeEnum.POINT:
+                    return 'point';
+
+                case baseTypeEnum.PAIR:
+                    return 'pair';
+
+                case baseTypeEnum.DIRECTED_PAIR:
+                    return 'directedPair';
+
+                case baseTypeEnum.DURATION:
+                    return 'duration';
+
+                case baseTypeEnum.FILE:
+                    return 'file';
+
+                case baseTypeEnum.URI:
+                    return 'uri';
+
+                case baseTypeEnum.INT_OR_IDENTIFIER:
+                    return 'intOrIdentifier';
+
+                case baseTypeEnum.COORDS:
+                    return 'coords';
+
+                default:
+                    return false;
+            }
+        }
+    }).assign(baseTypeEnum).value();
+
+    return baseTypeHelper;
+});

--- a/views/js/controller/creator/helpers/baseType.js
+++ b/views/js/controller/creator/helpers/baseType.js
@@ -190,7 +190,7 @@ define([
          * @param {String|Number} [defaultType]
          * @returns {*}
          */
-        validOrDefault: function validOrDefault(type, defaultType) {
+        getValid: function getValid(type, defaultType) {
             if (_.isFinite(type)) {
                 if (!baseTypeHelper.getNameByConstant(type)) {
                     type = false;
@@ -201,7 +201,7 @@ define([
 
             if (false === type) {
                 if (!_.isUndefined(defaultType) && defaultType !== -1) {
-                    type = baseTypeHelper.validOrDefault(defaultType, -1);
+                    type = baseTypeHelper.getValid(defaultType, -1);
                 } else {
                     type = -1;
                 }

--- a/views/js/controller/creator/helpers/cardinality.js
+++ b/views/js/controller/creator/helpers/cardinality.js
@@ -92,29 +92,29 @@ define([
         },
 
         /**
-         * Gets a valid type or the default
-         * @param {String|Number} type
-         * @param {String|Number} [defaultType]
+         * Gets a valid cardinality or the default
+         * @param {String|Number} cardinality
+         * @param {String|Number} [defaultCardinality]
          * @returns {*}
          */
-        getValid: function getValid(type, defaultType) {
-            if (_.isFinite(type)) {
-                if (!cardinalityHelper.getNameByConstant(type)) {
-                    type = false;
+        getValid: function getValid(cardinality, defaultCardinality) {
+            if (_.isFinite(cardinality)) {
+                if (!cardinalityHelper.getNameByConstant(cardinality)) {
+                    cardinality = false;
                 }
             } else {
-                type = cardinalityHelper.getConstantByName(type);
+                cardinality = cardinalityHelper.getConstantByName(cardinality);
             }
 
-            if (false === type) {
-                if (!_.isUndefined(defaultType) && defaultType !== -1) {
-                    type = cardinalityHelper.getValid(defaultType, -1);
+            if (false === cardinality) {
+                if (!_.isUndefined(defaultCardinality) && defaultCardinality !== cardinalityEnum.SINGLE) {
+                    cardinality = cardinalityHelper.getValid(defaultCardinality, cardinalityEnum.SINGLE);
                 } else {
-                    type = -1;
+                    cardinality = cardinalityEnum.SINGLE;
                 }
             }
 
-            return type;
+            return cardinality;
         },
 
         /**

--- a/views/js/controller/creator/helpers/cardinality.js
+++ b/views/js/controller/creator/helpers/cardinality.js
@@ -1,0 +1,172 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * The Cardinality enumeration (port of \qtism\common\enums\Cardinality).
+ *
+ * From IMS QTI:
+ *
+ * An expression or itemVariable can either be single-valued or multi-valued. A multi-valued
+ * expression (or variable) is called a container. A container contains a list of values,
+ * this list may be empty in which case it is treated as NULL. All the values in a multiple
+ * or ordered container are drawn from the same value set, however, containers may contain
+ * multiple occurrences of the same value. In other words, [A,B,B,C] is an acceptable value
+ * for a container. A container with cardinality multiple and value [A,B,C] is equivalent
+ * to a similar one with value [C,B,A] whereas these two values would be considered distinct
+ * for containers with cardinality ordered. When used as the value of a response variable
+ * this distinction is typified by the difference between selecting choices in a multi-response
+ * multi-choice task and ranking choices in an order objects task. In the language of [ISO11404]
+ * a container with multiple cardinality is a "bag-type", a container with ordered cardinality
+ * is a "sequence-type" and a container with record cardinality is a "record-type".
+ *
+ * The record container type is a special container that contains a set of independent values
+ * each identified by its own identifier and having its own base-type. This specification
+ * does not make use of the record type directly however it is provided to enable
+ * customInteractions to manipulate more complex responses and customOperators to
+ * return more complex values, in addition to the use for detailed information about
+ * numeric responses described in the stringInteraction abstract class.
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash'
+], function (_) {
+    'use strict';
+
+    /**
+     * The list of QTI cardinalities
+     * @type {Object}
+     */
+    var cardinalityEnum = {
+        /**
+         * Single term cardinality
+         *
+         * @type {Number}
+         */
+        SINGLE: 0,
+
+        /**
+         * Multiple terms cardinality
+         *
+         * @type {Number}
+         */
+        MULTIPLE: 1,
+
+        /**
+         * Ordered terms cardinality
+         *
+         * @type {Number}
+         */
+        ORDERED: 2,
+
+        /**
+         * Record term cardinality
+         *
+         * @type {Number}
+         */
+        RECORD: 3
+    };
+
+    var cardinalityHelper = _({
+        /**
+         * Gets the the list of QTI cardinalities
+         * @returns {Object}
+         */
+        asArray: function asArray() {
+            return cardinalityEnum;
+        },
+
+        /**
+         * Gets a valid type or the default
+         * @param {String|Number} type
+         * @param {String|Number} [defaultType]
+         * @returns {*}
+         */
+        getValid: function getValid(type, defaultType) {
+            if (_.isFinite(type)) {
+                if (!cardinalityHelper.getNameByConstant(type)) {
+                    type = false;
+                }
+            } else {
+                type = cardinalityHelper.getConstantByName(type);
+            }
+
+            if (false === type) {
+                if (!_.isUndefined(defaultType) && defaultType !== -1) {
+                    type = cardinalityHelper.getValid(defaultType, -1);
+                } else {
+                    type = -1;
+                }
+            }
+
+            return type;
+        },
+
+        /**
+         * Get a constant value from its name.
+         *
+         * @param {String} name The name of the constant, as per QTI spec.
+         * @return {Number|Boolean} The constant value or `false` if not found.
+         */
+        getConstantByName: function getConstantByName(name) {
+            switch (String(name).trim().toLowerCase()) {
+                case 'single':
+                    return cardinalityEnum.SINGLE;
+
+                case 'multiple':
+                    return cardinalityEnum.MULTIPLE;
+
+                case 'ordered':
+                    return cardinalityEnum.ORDERED;
+
+                case 'record':
+                    return cardinalityEnum.RECORD;
+
+                default:
+                    return false;
+            }
+        },
+
+        /**
+         * Get the name of a constant from its value.
+         *
+         * @param {Number} constant The constant value to search the name for.
+         * @return {String|Boolean} The name of the constant or false if not found.
+         */
+        getNameByConstant: function getNameByConstant(constant) {
+            switch (constant) {
+                case cardinalityEnum.SINGLE:
+                    return 'single';
+
+                case cardinalityEnum.MULTIPLE:
+                    return 'multiple';
+
+                case cardinalityEnum.ORDERED:
+                    return 'ordered';
+
+                case cardinalityEnum.RECORD:
+                    return 'record';
+
+                default:
+                    return false;
+            }
+        }
+    }).assign(cardinalityEnum).value();
+
+    return cardinalityHelper;
+});

--- a/views/js/controller/creator/helpers/category.js
+++ b/views/js/controller/creator/helpers/category.js
@@ -1,0 +1,97 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Helper that provides a way to browse all categories attached to a test model at the item level.
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash'
+], function (_) {
+    'use strict';
+
+    /**
+     * Checks if a category is an option
+     *
+     * @param {String} category
+     * @returns {Boolean}
+     */
+    function isCategoryOption(category) {
+        return category && category.indexOf('x-tao-') === 0;
+    }
+
+    /**
+     * Calls a function for each category in the test model
+     * @param {Object} testModel
+     * @param {Function} cb
+     */
+    function eachCategories(testModel, cb) {
+        _.forEach(testModel.testParts, function (testPart) {
+            _.forEach(testPart.assessmentSections, function (assessmentSection) {
+                _.forEach(assessmentSection.sectionParts, function (itemRef) {
+                    _.forEach(itemRef.categories, function(category) {
+                        cb(category, itemRef);
+                    });
+                });
+            });
+        });
+    }
+
+    return {
+        /**
+         * Calls a function for each category in the test model
+         * @function eachCategories
+         * @param {Object} testModel
+         * @param {Function} cb
+         */
+        eachCategories: eachCategories,
+
+        /**
+         * Gets the list of categories assigned to the items.
+         * Discards special purpose categories like 'x-tao-...'
+         *
+         * @param {Object} testModel
+         * @returns {Array}
+         */
+        listCategories: function listCategories(testModel) {
+            var categories = {};
+            eachCategories(testModel, function(category) {
+                if (!isCategoryOption(category)) {
+                    categories[category] = true;
+                }
+            });
+            return _.keys(categories);
+        },
+
+        /**
+         * Gets the list of options assigned to the items (special purpose categories like 'x-tao-...').
+         *
+         * @param {Object} testModel
+         * @returns {Array}
+         */
+        listOptions: function listOptions(testModel) {
+            var options = {};
+            eachCategories(testModel, function(category) {
+                if (isCategoryOption(category)) {
+                    options[category] = true;
+                }
+            });
+            return _.keys(options);
+        }
+    };
+});

--- a/views/js/controller/creator/helpers/outcome.js
+++ b/views/js/controller/creator/helpers/outcome.js
@@ -1,0 +1,292 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Basic helper that is intended to manage outcomes inside a test model.
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/baseType'
+], function (_, baseType) {
+    'use strict';
+
+    var outcomeHelper = {
+        /**
+         * Finds a QTI element in an expression, by its type.
+         * An expression is either an object or a list of objects.
+         * Does not browse any sub-expressions.
+         * @param {Array|Object} expression
+         * @param {String} type
+         * @returns {Object}
+         */
+        findQtiType: function findQtiType(expression, type) {
+            var found = null;
+
+            function checkType(qti) {
+                if (qti['qti-type'] === type) {
+                    found = qti;
+                    return false;
+                }
+            }
+
+            if (_.isArray(expression)) {
+                _.forEach(expression, checkType);
+            } else if (expression) {
+                checkType(expression);
+            }
+
+            return found;
+        },
+
+        /**
+         * Gets a property from an outcome rule expression.
+         * The path to the property is based on QTI types.
+         * @param {Object} outcomeRule - The outcome rule from which get the property
+         * @param {String|String[]} path - The path to the property, with QTI types separated by dot, like: "setOutcomeValue.gte.baseValue"
+         * @returns {*}
+         */
+        getProcessingRuleExpression: function getProcessingRuleProperty(outcomeRule, path) {
+            var steps = _.isArray(path) ? path : path.split('.');
+            var len = steps.length;
+            var expression = outcomeRule;
+            var i = 0;
+
+            while (expression && i < len) {
+                expression = outcomeHelper.findQtiType(expression, steps[i++]);
+                if (expression && i < len) {
+                    expression = expression.expression || expression.expressions;
+                }
+            }
+
+            return expression || null;
+        },
+
+        /**
+         * Gets a property from an outcome rule expression.
+         * The path to the property is based on QTI types.
+         * @param {Object} outcomeRule - The outcome rule from which get the property
+         * @param {String|String[]} path - The path to the property, with QTI types separated by dot, like: "setOutcomeValue.gte.baseValue.value"
+         * @returns {*}
+         */
+        getProcessingRuleProperty: function getProcessingRuleProperty(outcomeRule, path) {
+            var result = null;
+            var steps = _.isArray(path) ? path : path.split('.');
+            var property = steps.pop();
+            var expression = outcomeHelper.getProcessingRuleExpression(outcomeRule, steps);
+
+            if (expression && expression[property]) {
+                result = expression[property];
+            }
+
+            return result;
+        },
+
+        /**
+         * Gets the identifier of an outcome
+         * @param {Object|String} outcome
+         * @returns {String}
+         */
+        getOutcomeIdentifier: function getOutcomeIdentifier(outcome) {
+            return String(_.isObject(outcome) ? outcome.identifier : outcome);
+        },
+
+        /**
+         * Gets the list of outcome declarations
+         * @param {Object} testModel
+         * @returns {Array}
+         */
+        getOutcomeDeclarations: function getOutcomeDeclarations(testModel) {
+            return testModel && testModel.outcomeDeclarations;
+        },
+
+        /**
+         * Gets the list of outcome processing rules
+         * @param {Object} testModel
+         * @returns {Array}
+         */
+        getOutcomeProcessingRules: function getOutcomeProcessingRules(testModel) {
+            return testModel && testModel.outcomeProcessing && testModel.outcomeProcessing.outcomeRules;
+        },
+
+        /**
+         * Applies a function on each outcome declarations
+         * @param {Object} testModel
+         * @param {Function} cb
+         */
+        eachOutcomeDeclarations: function eachOutcomeDeclarations(testModel, cb) {
+            _.forEach(outcomeHelper.getOutcomeDeclarations(testModel), cb);
+        },
+
+        /**
+         * Applies a function on each outcome processing rules
+         * @param {Object} testModel
+         * @param {Function} cb
+         */
+        eachOutcomeProcessingRules: function eachOutcomeProcessingRules(testModel, cb) {
+            _.forEach(outcomeHelper.getOutcomeProcessingRules(testModel), cb);
+        },
+
+        /**
+         * Lists all outcomes identifiers. An optional callback allows to filter the list
+         * @param {Object} testModel
+         * @param {Function} [cb]
+         * @returns {Array}
+         */
+        listOutcomes: function listOutcomes(testModel, cb) {
+            var outcomes = [];
+            if (!_.isFunction(cb)) {
+                cb = null;
+            }
+            outcomeHelper.eachOutcomeDeclarations(testModel, function (outcome) {
+                if (!cb || cb(outcome)) {
+                    outcomes.push(outcomeHelper.getOutcomeIdentifier(outcome));
+                }
+            });
+            return outcomes;
+        },
+
+        /**
+         * Removes the spefified outcomes from the provided test model
+         * @param {Object} testModel
+         * @param {String[]} outcomes
+         */
+        removeOutcomes: function removeOutcomes(testModel, outcomes) {
+            var declarations = outcomeHelper.getOutcomeDeclarations(testModel);
+            var rules = outcomeHelper.getOutcomeProcessingRules(testModel);
+
+            outcomes = _.indexBy(_.isArray(outcomes) ? outcomes : [outcomes], function (outcome) {
+                return outcome;
+            });
+
+            if (declarations) {
+                _.remove(declarations, function (outcomeDeclaration) {
+                    return !!outcomes[outcomeHelper.getOutcomeIdentifier(outcomeDeclaration)];
+                });
+            }
+
+            if (rules) {
+                _.remove(rules, function (outcomeRule) {
+                    return !!outcomes[outcomeHelper.getOutcomeIdentifier(outcomeRule)];
+                });
+            }
+        },
+
+        /**
+         * Creates an outcome declaration
+         * @param {String} identifier
+         * @param {String|Number|Boolean} [type] - The data type of the outcome, FLOAT by default
+         * @param {Number} [cardinality] - The variable cardinality, default 0
+         * @returns {Object}
+         * @throws {TypeError} if the identifier is empty or is not a string
+         */
+        createOutcome: function createOutcome(identifier, type, cardinality) {
+
+            if (!validateIdentifier(identifier)) {
+                throw new TypeError('You must provide a valid identifier!');
+            }
+
+            return {
+                'qti-type': 'outcomeDeclaration',
+                views: [],
+                interpretation: '',
+                longInterpretation: '',
+                normalMaximum: false,
+                normalMinimum: false,
+                masteryValue: false,
+                identifier: identifier,
+                cardinality: parseInt(cardinality, 10) || 0,
+                baseType: baseType.validOrDefault(type, baseType.FLOAT)
+            };
+        },
+
+        /**
+         * Adds a processing rule into the test model
+         *
+         * @param {Object} testModel
+         * @param {Object} processingRule
+         * @returns {Object}
+         * @throws {TypeError} if the processing rule is not valid
+         */
+        addOutcomeProcessing: function createOutcomeProcessing(testModel, processingRule) {
+            var outcomeProcessing = testModel.outcomeProcessing;
+
+            if (!processingRule || !processingRule['qti-type'] || !_.isString(processingRule['qti-type'])) {
+                throw new TypeError('You must provide a valid outcome processing rule!');
+            }
+
+            if (!outcomeProcessing) {
+                outcomeProcessing = {
+                    'qti-type': 'outcomeProcessing',
+                    outcomeRules: []
+                };
+                testModel.outcomeProcessing = outcomeProcessing;
+            } else if (!outcomeProcessing.outcomeRules) {
+                outcomeProcessing.outcomeRules = [];
+            }
+
+            outcomeProcessing.outcomeRules.push(processingRule);
+            return processingRule;
+        },
+
+        /**
+         * Creates an outcome and adds it to the declarations
+         * @param {Object} testModel
+         * @param {Object} outcome - The outcome to add
+         * @param {Object} [processingRule] - The processing rule attached to the outcome
+         * @returns {Object}
+         * @throws {TypeError} if one of the outcome or the processing rule is not valid
+         */
+        addOutcome: function addOutcome(testModel, outcome, processingRule) {
+            var declarations = testModel.outcomeDeclarations;
+
+            if (!outcome || outcome['qti-type'] !== 'outcomeDeclaration' || !validateIdentifier(outcome.identifier)) {
+                throw new TypeError('You must provide a valid outcome!');
+            }
+
+            if (processingRule) {
+                if (!validateIdentifier(processingRule.identifier) || processingRule.identifier !== outcome.identifier) {
+                    throw new TypeError('You must provide a valid outcome processing rule!');
+                }
+
+                outcomeHelper.addOutcomeProcessing(testModel, processingRule);
+            }
+
+            if (!declarations) {
+                declarations = [];
+                testModel.outcomeDeclarations = declarations;
+            }
+
+            declarations.push(outcome);
+            return outcome;
+        }
+    };
+
+    var identifierValidator = /^[a-zA-Z_][a-zA-Z0-9_\.-]*$/;
+
+    /**
+     * Checks the validity of an identifier
+     * @param {String} identifier
+     * @returns {Boolean}
+     */
+    function validateIdentifier(identifier) {
+        return identifier && _.isString(identifier) && identifierValidator.test(identifier);
+    }
+
+    return outcomeHelper;
+});

--- a/views/js/controller/creator/helpers/outcome.js
+++ b/views/js/controller/creator/helpers/outcome.js
@@ -134,12 +134,35 @@ define([
         },
 
         /**
-         * Applies a function on each outcome processing rules
+         * Applies a function on each outcome processing rules. Does not take care of sub-expressions.
          * @param {Object} testModel
          * @param {Function} cb
          */
         eachOutcomeProcessingRules: function eachOutcomeProcessingRules(testModel, cb) {
             _.forEach(outcomeHelper.getOutcomeProcessingRules(testModel), cb);
+        },
+
+        /**
+         * Applies a function on each outcome processing rules, take care of each sub expression.
+         * @param {Object} testModel
+         * @param {Function} cb
+         */
+        eachOutcomeProcessingRuleExpressions: function eachOutcomeProcessingRuleExpressions(testModel, cb) {
+            function browseExpressions(processingRule) {
+                if (_.isArray(processingRule)) {
+                    _.forEach(processingRule, browseExpressions);
+                } else if (processingRule) {
+                    cb(processingRule);
+
+                    if (processingRule.expression) {
+                        browseExpressions(processingRule.expression);
+                    } else if (processingRule.expressions) {
+                        browseExpressions(processingRule.expressions);
+                    }
+                }
+            }
+
+            browseExpressions(outcomeHelper.getOutcomeProcessingRules(testModel));
         },
 
         /**

--- a/views/js/controller/creator/helpers/outcome.js
+++ b/views/js/controller/creator/helpers/outcome.js
@@ -61,7 +61,7 @@ define([
          * @param {String|String[]} path - The path to the property, with QTI types separated by dot, like: "setOutcomeValue.gte.baseValue"
          * @returns {*}
          */
-        getProcessingRuleExpression: function getProcessingRuleProperty(outcomeRule, path) {
+        getProcessingRuleExpression: function getProcessingRuleExpression(outcomeRule, path) {
             var steps = _.isArray(path) ? path : path.split('.');
             var len = steps.length;
             var expression = outcomeRule;

--- a/views/js/controller/creator/helpers/outcome.js
+++ b/views/js/controller/creator/helpers/outcome.js
@@ -22,8 +22,9 @@
  */
 define([
     'lodash',
-    'taoQtiTest/controller/creator/helpers/baseType'
-], function (_, baseType) {
+    'taoQtiTest/controller/creator/helpers/baseType',
+    'taoQtiTest/controller/creator/helpers/cardinality'
+], function (_, baseTypeHelper, cardinalityHelper) {
     'use strict';
 
     var outcomeHelper = {
@@ -233,8 +234,8 @@ define([
                 normalMinimum: false,
                 masteryValue: false,
                 identifier: identifier,
-                cardinality: parseInt(cardinality, 10) || 0,
-                baseType: baseType.validOrDefault(type, baseType.FLOAT)
+                cardinality: cardinalityHelper.getValid(cardinality, cardinalityHelper.SINGLE),
+                baseType: baseTypeHelper.getValid(type, baseTypeHelper.FLOAT)
             };
         },
 

--- a/views/js/controller/creator/helpers/processingRule.js
+++ b/views/js/controller/creator/helpers/processingRule.js
@@ -161,7 +161,7 @@ define([
             processingRule.minOperands = 1;
             processingRule.maxOperands = -1;
             processingRule.acceptedCardinalities = [0, 1, 2];
-            processingRule.acceptedBaseTypes = [2, 3];
+            processingRule.acceptedBaseTypes = [baseType.INTEGER, baseType.FLOAT];
 
             return processingRule;
         },
@@ -259,7 +259,7 @@ define([
         processingRule.minOperands = 2;
         processingRule.maxOperands = 2;
         processingRule.acceptedCardinalities = [0];
-        processingRule.acceptedBaseTypes = [2, 3];
+        processingRule.acceptedBaseTypes = [baseType.INTEGER, baseType.FLOAT];
 
         return processingRule;
     }

--- a/views/js/controller/creator/helpers/processingRule.js
+++ b/views/js/controller/creator/helpers/processingRule.js
@@ -22,8 +22,9 @@
  */
 define([
     'lodash',
-    'taoQtiTest/controller/creator/helpers/baseType'
-], function (_, baseType) {
+    'taoQtiTest/controller/creator/helpers/baseType',
+    'taoQtiTest/controller/creator/helpers/cardinality'
+], function (_, baseTypeHelper, cardinalityHelper) {
     'use strict';
 
     var processingRuleHelper = {
@@ -160,8 +161,8 @@ define([
 
             processingRule.minOperands = 1;
             processingRule.maxOperands = -1;
-            processingRule.acceptedCardinalities = [0, 1, 2];
-            processingRule.acceptedBaseTypes = [baseType.INTEGER, baseType.FLOAT];
+            processingRule.acceptedCardinalities = [cardinalityHelper.SINGLE, cardinalityHelper.MULTIPLE, cardinalityHelper.ORDERED];
+            processingRule.acceptedBaseTypes = [baseTypeHelper.INTEGER, baseTypeHelper.FLOAT];
 
             return processingRule;
         },
@@ -193,7 +194,7 @@ define([
                 processingRule.weightIdentifier = '';
             }
 
-            processingRule.baseType = baseType.validOrDefault(type);
+            processingRule.baseType = baseTypeHelper.getValid(type);
             processingRule.sectionIdentifier = '';
             processingRule.includeCategories = forceArray(includeCategories);
             processingRule.excludeCategories = forceArray(excludeCategories);
@@ -226,7 +227,7 @@ define([
         baseValue: function baseValue(value, type) {
             var processingRule = processingRuleHelper.create('baseValue');
 
-            processingRule.baseType = baseType.validOrDefault(type, baseType.FLOAT);
+            processingRule.baseType = baseTypeHelper.getValid(type, baseTypeHelper.FLOAT);
             processingRule.value = parseFloat(value) || 0;
 
             return processingRule;
@@ -258,8 +259,8 @@ define([
 
         processingRule.minOperands = 2;
         processingRule.maxOperands = 2;
-        processingRule.acceptedCardinalities = [0];
-        processingRule.acceptedBaseTypes = [baseType.INTEGER, baseType.FLOAT];
+        processingRule.acceptedCardinalities = [cardinalityHelper.SINGLE];
+        processingRule.acceptedBaseTypes = [baseTypeHelper.INTEGER, baseTypeHelper.FLOAT];
 
         return processingRule;
     }

--- a/views/js/controller/creator/helpers/processingRule.js
+++ b/views/js/controller/creator/helpers/processingRule.js
@@ -1,0 +1,283 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Basic helper that is intended to generate outcomes processing rules for a test model.
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/baseType'
+], function (_, baseType) {
+    'use strict';
+
+    var processingRuleHelper = {
+        /**
+         * Creates a basic processing rule
+         * @param {String} type
+         * @param {String} [identifier]
+         * @param {Array|Object} [expression]
+         * @returns {Object}
+         * @throws {TypeError} if the type is empty or is not a string
+         * @throws {TypeError} if the identifier is not a string
+         */
+        create: function create(type, identifier, expression) {
+            var processingRule = {
+                'qti-type': type
+            };
+
+            if (!type || !_.isString(type)) {
+                throw new TypeError('You must provide a valid processing type!');
+            }
+
+            if (identifier) {
+                if (!validateIdentifier(identifier)) {
+                    throw new TypeError('You must provide a valid identifier!');
+                }
+                processingRule.identifier = identifier;
+            }
+
+            if (expression) {
+                processingRuleHelper.setExpression(processingRule, expression);
+            }
+
+            return processingRule;
+        },
+
+        /**
+         * Sets an expression to a processing rule
+         * @param {Object} processingRule
+         * @param {Object|Array} expression
+         */
+        setExpression: function setExpression(processingRule, expression) {
+            if (processingRule) {
+                if (_.isArray(expression)) {
+                    if (processingRule.expression) {
+                        processingRule.expression = null;
+                    }
+                    processingRule.expressions = expression;
+                } else {
+                    if (processingRule.expressions) {
+                        processingRule.expressions = null;
+                    }
+                    if (expression) {
+                        processingRule.expression = expression;
+                    }
+                }
+            }
+        },
+
+        /**
+         * Adds an expression to a processing rule
+         * @param {Object} processingRule
+         * @param {Object|Array} expression
+         */
+        addExpression: function addExpression(processingRule, expression) {
+            if (processingRule && expression) {
+                if (processingRule.expression) {
+                    processingRule.expressions = forceArray(processingRule.expression);
+                    processingRule.expression = null;
+                }
+
+                if (_.isArray(expression)) {
+                    processingRule.expressions = forceArray(processingRule.expressions).concat(expression);
+                } else {
+                    if (processingRule.expressions) {
+                        processingRule.expressions.push(expression);
+                    } else {
+                        processingRule.expression = expression;
+                    }
+                }
+            }
+        },
+
+        /**
+         * Creates a `setOutcomeValue` rule
+         * @param {String} identifier
+         * @param {Object|Array} [expression]
+         * @returns {Object}
+         * @throws {TypeError} if the identifier is empty or is not a string
+         */
+        setOutcomeValue: function setOutcomeValue(identifier, expression) {
+            if (!validateIdentifier(identifier)) {
+                throw new TypeError('You must provide a valid identifier!');
+            }
+            return processingRuleHelper.create('setOutcomeValue', identifier, expression);
+        },
+
+        /**
+         * Creates a `gte` rule
+         * @param {Object|Array} left - the left operand
+         * @param {Object|Array} right - the right operand
+         * @returns {Object}
+         */
+        gte: function gte(left, right) {
+            return binaryOperator('gte', left, right);
+        },
+
+        /**
+         * Creates a `lte` rule
+         * @param {Object|Array} left - the left operand
+         * @param {Object|Array} right - the right operand
+         * @returns {Object}
+         */
+        lte: function lte(left, right) {
+            return binaryOperator('lte', left, right);
+        },
+
+        /**
+         * Creates a `divide` rule
+         * @param {Object|Array} left - the left operand
+         * @param {Object|Array} right - the right operand
+         * @returns {Object}
+         */
+        divide: function divide(left, right) {
+            return binaryOperator('divide', left, right);
+        },
+
+        /**
+         * Creates a `sum` rule
+         * @param {Object|Array} terms
+         * @returns {Object}
+         */
+        sum: function sum(terms) {
+            var processingRule = processingRuleHelper.create('sum', null, forceArray(terms));
+
+            processingRule.minOperands = 1;
+            processingRule.maxOperands = -1;
+            processingRule.acceptedCardinalities = [0, 1, 2];
+            processingRule.acceptedBaseTypes = [2, 3];
+
+            return processingRule;
+        },
+
+        /**
+         * Creates a `testVariables` rule
+         * @param {String} identifier
+         * @param {String|Number} [type]
+         * @param {String} weight
+         * @param {String|String[]} [includeCategories]
+         * @param {String|String[]} [excludeCategories]
+         * @returns {Object}
+         * @throws {TypeError} if the identifier is empty or is not a string
+         */
+        testVariables: function testVariables(identifier, type, weight, includeCategories, excludeCategories) {
+            var processingRule = processingRuleHelper.create('testVariables');
+
+            if (!validateIdentifier(identifier)) {
+                throw new TypeError('You must provide a valid identifier!');
+            }
+            processingRule.variableIdentifier = identifier;
+
+            if (weight) {
+                if (!validateIdentifier(weight)) {
+                    throw new TypeError('You must provide a valid weight identifier!');
+                }
+                processingRule.weightIdentifier = weight;
+            } else {
+                processingRule.weightIdentifier = '';
+            }
+
+            processingRule.baseType = baseType.validOrDefault(type);
+            processingRule.sectionIdentifier = '';
+            processingRule.includeCategories = forceArray(includeCategories);
+            processingRule.excludeCategories = forceArray(excludeCategories);
+
+            return processingRule;
+        },
+
+        /**
+         * Creates a `numberPresented` rule
+         * @param {String|String[]} [includeCategories]
+         * @param {String|String[]} [excludeCategories]
+         * @returns {Object}
+         */
+        numberPresented: function numberPresented(includeCategories, excludeCategories) {
+            var processingRule = processingRuleHelper.create('numberPresented');
+
+            processingRule.sectionIdentifier = '';
+            processingRule.includeCategories = forceArray(includeCategories);
+            processingRule.excludeCategories = forceArray(excludeCategories);
+
+            return processingRule;
+        },
+
+        /**
+         * Creates a `baseValue` rule
+         * @param {*} [value]
+         * @param {String|Number} [type]
+         * @returns {Object}
+         */
+        baseValue: function baseValue(value, type) {
+            var processingRule = processingRuleHelper.create('baseValue');
+
+            processingRule.baseType = baseType.validOrDefault(type, baseType.FLOAT);
+            processingRule.value = parseFloat(value) || 0;
+
+            return processingRule;
+        }
+
+    };
+
+    var identifierValidator = /^[a-zA-Z_][a-zA-Z0-9_\.-]*$/;
+
+    /**
+     * Checks the validity of an identifier
+     * @param {String} identifier
+     * @returns {Boolean}
+     */
+    function validateIdentifier(identifier) {
+        return identifier &&_.isString(identifier) && identifierValidator.test(identifier);
+    }
+
+    /**
+     * Creates a binary operator rule
+     * @param {String} type - The rule type
+     * @param {Object|Array} left - The left operand
+     * @param {Object|Array} right - The right operand
+     * @returns {Object}
+     * @throws {TypeError} if the type is empty or is not a string
+     */
+    function binaryOperator(type, left, right) {
+        var processingRule = processingRuleHelper.create(type, null, [left, right]);
+
+        processingRule.minOperands = 2;
+        processingRule.maxOperands = 2;
+        processingRule.acceptedCardinalities = [0];
+        processingRule.acceptedBaseTypes = [2, 3];
+
+        return processingRule;
+    }
+
+    /**
+     * Ensures a value is an array
+     * @param {*} value
+     * @returns {Array}
+     */
+    function forceArray(value) {
+        if (!value) {
+            value = [];
+        }
+        if (!_.isArray(value)) {
+            value = [value];
+        }
+        return value;
+    }
+
+    return processingRuleHelper;
+});

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -1,0 +1,338 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Basic helper that is intended to manage the score processing declaration in a test model.
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'i18n',
+    'taoQtiTest/controller/creator/helpers/baseType',
+    'taoQtiTest/controller/creator/helpers/outcome',
+    'taoQtiTest/controller/creator/helpers/processingRule',
+    'taoQtiTest/controller/creator/helpers/category'
+], function (_, __, baseType, outcomeHelper, processingRuleHelper, categoryHelper) {
+    'use strict';
+
+    /**
+     * The identifier of the custom processing mode.
+     * Nothing will be do, the existing rules will be kept without changes.
+     * @type {String}
+     */
+    var PROCESSING_CUSTOM = 'custom';
+
+    /**
+     * The identifier of the no score processing mode.
+     * If applied on existing score processing, will remove all the related rules
+     * @type {String}
+     */
+    var PROCESSING_NONE = 'none';
+
+    /**
+     * The identifier of the total score processing mode.
+     * Set an outcome variable that will contains the overall score.
+     * @type {String}
+     */
+    var PROCESSING_TOTAL = 'total';
+
+    /**
+     * The identifier of the category score processing mode.
+     * Set an outcome variable per category that will contains the score of the category.
+     * @type {String}
+     */
+    var PROCESSING_CATEGORY = 'category';
+
+    /**
+     * The identifier of the cut score processing mode.
+     * Set an outcome variable per category that will tell if the score is above the provided threshold.
+     * @type {String}
+     */
+    var PROCESSING_CUT = 'cut';
+
+    /**
+     * The list of supported processing modes, indexed by mode identifier
+     * @type {Object}
+     */
+    var processingModes = _([{
+        key: PROCESSING_NONE,
+        label: __('None')
+    }, {
+        key: PROCESSING_CUSTOM,
+        label: __('Custom')
+    }, {
+        key: PROCESSING_TOTAL,
+        label: __('Total score'),
+        outcome: 'SCORE_TOTAL',
+        type: baseType.FLOAT
+    }, {
+        key: PROCESSING_CATEGORY,
+        label: __('Category score'),
+        prefix: 'SCORE_',
+        type: baseType.FLOAT
+    }, {
+        key: PROCESSING_CUT,
+        label: __('Cut score'),
+        prefix: 'PASS_',
+        type: baseType.BOOLEAN
+    }]).indexBy(function (mode) {
+        return mode.key;
+    }).value();
+
+    /**
+     * List of writers that provides the outcomes for each score processing modes.
+     * The writers are separated from the list of supported modes, as this list is forwarded to the UI templates,
+     * and only data must be provided to templates.
+     * @type {Object}
+     */
+    var processingModeWriters = _([{
+        key: PROCESSING_NONE,
+        writer: function(model) {
+            // as no rules must be defined, just erase existing ones
+            removeScoring(model);
+        }
+    }, {
+        key: PROCESSING_CUSTOM,
+        writer: function() {
+            // just does nothing as we only need to keep intact the existing rules, if any
+        }
+    }, {
+        key: PROCESSING_TOTAL,
+        writer: function(model) {
+            var processingMode = processingModes[PROCESSING_TOTAL];
+            var outcome, processingRule;
+
+            // erase the existing rules, they will be replaced by those that are defined here
+            removeScoring(model);
+
+            // create the outcome and the rule that process the overall score
+            outcome = outcomeHelper.createOutcome(processingMode.outcome, processingMode.type);
+            processingRule = processingRuleHelper.setOutcomeValue(processingMode.outcome,
+                processingRuleHelper.sum(
+                    processingRuleHelper.testVariables(model.scoring.scoreIdentifier, -1, model.scoring.weightIdentifier)
+                )
+            );
+
+            outcomeHelper.addOutcome(model, outcome, processingRule);
+        }
+    }, {
+        key: PROCESSING_CATEGORY,
+        writer: function(model) {
+            var processingMode = processingModes[PROCESSING_CATEGORY];
+
+            // erase the existing rules, they will be replaced by those that are defined here
+            removeScoring(model);
+
+            // create an outcome per category
+            _.forEach(categoryHelper.listCategories(model), function(category) {
+                var outcome, processingRule;
+                var identifier = processingMode.prefix + category.toUpperCase();
+
+                // create the outcome and the rule that process the category score
+                outcome = outcomeHelper.createOutcome(identifier, processingMode.type);
+                processingRule = processingRuleHelper.setOutcomeValue(identifier,
+                    processingRuleHelper.sum(
+                        processingRuleHelper.testVariables(model.scoring.scoreIdentifier, -1, model.scoring.weightIdentifier, category)
+                    )
+                );
+
+                outcomeHelper.addOutcome(model, outcome, processingRule);
+            });
+        }
+    }, {
+        key: PROCESSING_CUT,
+        writer: function(model) {
+            var processingMode = processingModes[PROCESSING_CUT];
+
+            // erase the existing rules, they will be replaced by those that are defined here
+            removeScoring(model);
+
+            // create an outcome per category
+            _.forEach(categoryHelper.listCategories(model), function(category) {
+                var outcome, processingRule;
+                var identifier = processingMode.prefix + category.toUpperCase();
+
+                // create the outcome and the rule that process the category score
+                outcome = outcomeHelper.createOutcome(identifier, processingMode.type);
+                processingRule = processingRuleHelper.setOutcomeValue(identifier,
+                    processingRuleHelper.gte(
+                        processingRuleHelper.divide(
+                            processingRuleHelper.sum(
+                                processingRuleHelper.testVariables(model.scoring.scoreIdentifier, -1, model.scoring.weightIdentifier, category)
+                            ),
+                            processingRuleHelper.numberPresented(category)
+                        ),
+                        processingRuleHelper.baseValue(model.scoring.cutScore, baseType.FLOAT)
+                    )
+                );
+
+                outcomeHelper.addOutcome(model, outcome, processingRule);
+            });
+        }
+    }]).indexBy(function (mode) {
+        return mode.key;
+    }).value();
+
+    /**
+     * Checks if an outcome is related to the outcome processing,
+     * then returns the processing mode descriptor.
+     * @param {Object|String} outcome
+     * @returns {Object}
+     */
+    function getScoringMode(outcome) {
+        var identifier = outcomeHelper.getOutcomeIdentifier(outcome);
+        var mode = null;
+        _.forEach(processingModes, function (processingMode) {
+            if (processingMode.outcome === identifier || identifier.indexOf(processingMode.prefix) === 0) {
+                mode = processingMode;
+                return false;
+            }
+        });
+        return mode;
+    }
+
+    /**
+     * Checks if an outcome is related to the outcome processing
+     * @param {Object|String} outcome
+     * @returns {Boolean}
+     */
+    function isScoringOutcome(outcome) {
+        return !!getScoringMode(outcome);
+    }
+
+    /**
+     * Gets the score processing modes from a list of outcomes
+     * @param {Array} outcomes
+     * @returns {Array}
+     */
+    function listScoringModes(outcomes) {
+        var modes = {};
+        _.forEach(outcomes, function (outcomeDeclaration) {
+            var mode = getScoringMode(outcomeDeclaration);
+            if (mode) {
+                modes[mode.key] = true;
+            }
+        });
+        return _.keys(modes);
+    }
+
+    /**
+     * Gets the defined cut score from the outcome rules
+     * @param {Array|Object} outcomeRules
+     * @returns {Number}
+     */
+    function getCutScore(outcomeRules) {
+        var values = _.map(outcomeRules, function(outcome) {
+            return outcomeHelper.getProcessingRuleProperty(outcome, 'setOutcomeValue.gte.baseValue.value');
+        });
+        return Math.max(0, _.max(values));
+    }
+
+    /**
+     * Detects the outcome processing mode of the scoring
+     * @param {Object} model
+     */
+    function detectScoring(model) {
+        var outcomeDeclarations = outcomeHelper.getOutcomeDeclarations(model);
+        var outcomeRules = outcomeHelper.getOutcomeProcessingRules(model);
+
+        // walk through each outcome declaration, and tries to identify the score processing mode
+        var declarations = listScoringModes(outcomeDeclarations);
+        var processing = listScoringModes(outcomeRules);
+        var diff = _.difference(declarations, processing);
+        var count = _.size(declarations);
+
+        // default fallback, applied when several modes are detected at the same time
+        var outcomeProcessing = PROCESSING_CUSTOM;
+
+        // set the score processing mode with respect to the found outcomes
+        if (count === _.size(processing)) {
+            if (!count) {
+                // no mode detected, set the mode to none
+                outcomeProcessing = PROCESSING_NONE;
+            } else if (count === 1 && _.isEmpty(diff)) {
+                // single mode detected, keep the last got key
+                outcomeProcessing = processing[0];
+            }
+        }
+
+        model.scoring = {
+            modes: processingModes,
+            scoreIdentifier: 'SCORE',
+            weightIdentifier: '',
+            cutScore: getCutScore(outcomeRules),
+            outcomeProcessing: outcomeProcessing
+        };
+    }
+
+    /**
+     * Removes all outcome processing outcome variables
+     * @param {Object} model
+     */
+    function removeScoring(model) {
+        var scoringOutcomes = outcomeHelper.listOutcomes(model, isScoringOutcome);
+        outcomeHelper.removeOutcomes(model, scoringOutcomes);
+    }
+
+    /**
+     * Set the outcome processing outcome variables according to the chosen score processing mode
+     * @param {Object} model
+     */
+    function setScoring(model) {
+        var processingMode;
+
+        // write the outcomes only if the mode has been set
+        if (model.scoring) {
+            processingMode = processingModeWriters[model.scoring.outcomeProcessing];
+
+            if (processingMode) {
+                processingMode.writer(model);
+            } else {
+                throw new Error('Unknown score processing mode: ' + model.scoring.outcomeProcessing);
+            }
+        }
+    }
+
+    return {
+        /**
+         * Checks the test model against outcome processing mode.
+         * Initializes the scoring property accordingly.
+         *
+         * @param {Object} model
+         */
+        read: function read(model) {
+            // detect the score processing mode and build the descriptor used to manage the UI
+            detectScoring(model);
+
+            console.log('read', model);
+        },
+
+        /**
+         * If the processing mode has been set, generates the outcomes that define the scoring.
+         *
+         * @param {Object} model
+         */
+        write: function write(model) {
+//            model = _.cloneDeep(model);
+            // write the score processing mode by generating the outcomes variables
+            setScoring(model);
+
+            console.log('write', model);
+        }
+    };
+});

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -71,25 +71,30 @@ define([
      */
     var processingModes = _([{
         key: PROCESSING_NONE,
-        label: __('None')
+        label: __('None'),
+        description: __('No outcome processing. Erase the existing rules, if any.')
     }, {
         key: PROCESSING_CUSTOM,
-        label: __('Custom')
+        label: __('Custom'),
+        description: __('Custom outcome processing. No changes will be made to the existing rules.')
     }, {
         key: PROCESSING_TOTAL,
         label: __('Total score'),
         outcome: 'SCORE_TOTAL',
-        type: baseType.FLOAT
+        type: baseType.FLOAT,
+        description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed, the result will take place in the SCORE_TOTAL outcome.')
     }, {
         key: PROCESSING_CATEGORY,
         label: __('Category score'),
         prefix: 'SCORE_',
-        type: baseType.FLOAT
+        type: baseType.FLOAT,
+        description: __('The score will be processed per categories. A sum of all SCORE outcomes will be computed for each defined categories, the result will take place in the SCORE_xxx outcome, where xxx is the name of the category.')
     }, {
         key: PROCESSING_CUT,
         label: __('Cut score'),
         prefix: 'PASS_',
-        type: baseType.BOOLEAN
+        type: baseType.BOOLEAN,
+        description: __('The score will be processed per categories. An average of all SCORE outcomes will be computed for each defined categories, the result will be compared to the cut score, then the PASS_xxx outcome will be set accordingly, where xxx is the name of the category.')
     }]).indexBy(function (mode) {
         return mode.key;
     }).value();

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -31,6 +31,13 @@ define([
     'use strict';
 
     /**
+     * The default cut score
+     * @todo Move this to a config file
+     * @type {Number}
+     */
+    var defaultCutScore = 70;
+
+    /**
      * The identifier of the custom processing mode.
      * Nothing will be do, the existing rules will be kept without changes.
      * @type {String}
@@ -242,9 +249,12 @@ define([
      * @returns {Number}
      */
     function getCutScore(model) {
-        var values = _.map(outcomeHelper.getOutcomeProcessingRules(model), function(outcome) {
+        var values = _(outcomeHelper.getOutcomeProcessingRules(model)).map(function(outcome) {
             return outcomeHelper.getProcessingRuleProperty(outcome, 'setOutcomeValue.gte.baseValue.value');
-        });
+        }).compact().uniq().value();
+        if (_.isEmpty(values)) {
+            values = [defaultCutScore];
+        }
         return Math.max(0, _.max(values));
     }
 

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -27,7 +27,7 @@ define([
     'taoQtiTest/controller/creator/helpers/outcome',
     'taoQtiTest/controller/creator/helpers/processingRule',
     'taoQtiTest/controller/creator/helpers/category'
-], function (_, __, baseType, outcomeHelper, processingRuleHelper, categoryHelper) {
+], function (_, __, baseTypeHelper, outcomeHelper, processingRuleHelper, categoryHelper) {
     'use strict';
 
     /**
@@ -56,21 +56,21 @@ define([
             key: 'total',
             label: __('Total score'),
             outcome: 'SCORE_TOTAL',
-            type: baseType.FLOAT,
+            type: baseTypeHelper.FLOAT,
             description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed, the result will take place in the SCORE_TOTAL outcome.')
         },
         category: {
             key: 'category',
             label: __('Category score'),
             prefix: 'SCORE_',
-            type: baseType.FLOAT,
+            type: baseTypeHelper.FLOAT,
             description: __('The score will be processed per categories. A sum of all SCORE outcomes will be computed for each defined categories, the result will take place in the SCORE_xxx outcome, where xxx is the name of the category.')
         },
         cut: {
             key: 'cut',
             label: __('Cut score'),
             prefix: 'PASS_',
-            type: baseType.BOOLEAN,
+            type: baseTypeHelper.BOOLEAN,
             description: __('The score will be processed per categories. An average of all SCORE outcomes will be computed for each defined categories, the result will be compared to the cut score, then the PASS_xxx outcome will be set accordingly, where xxx is the name of the category.')
         }
     };
@@ -173,7 +173,7 @@ define([
                             ),
                             processingRuleHelper.numberPresented(category)
                         ),
-                        processingRuleHelper.baseValue(model.scoring.cutScore, baseType.FLOAT)
+                        processingRuleHelper.baseValue(model.scoring.cutScore, baseTypeHelper.FLOAT)
                     )
                 );
 

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -35,7 +35,7 @@ define([
      * @todo Move this to a config file
      * @type {Number}
      */
-    var defaultCutScore = 70;
+    var defaultCutScore = 0.5;
 
     /**
      * The list of supported processing modes, indexed by mode identifier

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -135,6 +135,22 @@
                 </div>
             </div>
         </div>
+
+<!-- assessmentTest/scoring/weightIdentifier -->
+        <div class="grid-row test-weight-identifier">
+            <div class="col-5">
+                <label for="test-weight-identifier">{{__ 'Weight'}}</label>
+            </div>
+            <div class="col-6">
+                <input type="text" name="test-weight-identifier" value="0" data-bind="scoring.weightIdentifier" data-bind-encoder="string" />
+            </div>
+            <div class="col-1 help">
+                <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
+                <div class="tooltip-content">
+                    {{__ "Set the weight identifier used to process the score"}}
+                </div>
+            </div>
+        </div>
     </div>
 {{/with}}
 </div>

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -126,7 +126,7 @@
                 <label for="test-cut-score">{{__ 'Cut score'}}</label>
             </div>
             <div class="col-6">
-                <input type="text" name="test-cut-score" value="0" data-bind="scoring.cutScore" data-bind-encoder="number" data-validate="$numeric;" />
+                <input type="text" name="test-cut-score" value="0" data-bind="scoring.cutScore" data-bind-encoder="float" data-validate="$numeric;" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -94,4 +94,47 @@
         </div>
     </div>
 
+    <h4 class="toggler closed" data-toggle="~ .test-scoring">{{__ "Scoring"}}</h4>
+
+<!-- assessmentTest/scoring -->
+{{#with scoring}}
+    <div class="test-scoring toggled">
+
+<!-- assessmentTest/scoring/outcomeProcessing -->
+        <div class="grid-row">
+            <div class="col-5">
+                <label for="test-outcome-processing">{{__ 'Outcome processing'}}</label>
+            </div>
+            <div class="col-6">
+                <select name="test-outcome-processing" class="select2" data-bind="scoring.outcomeProcessing" data-bind-encoder="string" data-has-search="false">
+                {{#each modes}}
+                    <option value="{{key}}" {{#if selected}}selected="selected"{{/if}}>{{label}}</option>
+                {{/each}}
+                </select>
+            </div>
+            <div class="col-1 help">
+                <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
+                <div class="tooltip-content">
+                    {{__ "Select the way the responses of your test should be processed"}}
+                </div>
+            </div>
+        </div>
+
+<!-- assessmentTest/scoring/cutScore -->
+        <div class="grid-row test-cut-score">
+            <div class="col-5">
+                <label for="test-cut-score">{{__ 'Cut score'}}</label>
+            </div>
+            <div class="col-6">
+                <input type="text" name="test-cut-score" value="0" data-bind="scoring.cutScore" data-bind-encoder="number" />
+            </div>
+            <div class="col-1 help">
+                <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
+                <div class="tooltip-content">
+                    {{__ "Set the cut score associated to the test"}}
+                </div>
+            </div>
+        </div>
+    </div>
+{{/with}}
 </div>

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -151,6 +151,18 @@
                 </div>
             </div>
         </div>
+
+<!-- assessmentTest/scoring/description -->
+        <div class="grid-row">
+            <div class="col-12">
+                {{#each modes}}
+                <div class="feedback-info test-outcome-processing-description" data-key="{{key}}">
+                    <span class="icon-info"></span>
+                    {{description}}
+                </div>
+                {{/each}}
+            </div>
+        </div>
     </div>
 {{/with}}
 </div>

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -126,7 +126,7 @@
                 <label for="test-cut-score">{{__ 'Cut score'}}</label>
             </div>
             <div class="col-6">
-                <input type="text" name="test-cut-score" value="0" data-bind="scoring.cutScore" data-bind-encoder="number" />
+                <input type="text" name="test-cut-score" value="0" data-bind="scoring.cutScore" data-bind-encoder="number" data-validate="$numeric;" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -142,7 +142,7 @@
                 <label for="test-weight-identifier">{{__ 'Weight'}}</label>
             </div>
             <div class="col-6">
-                <input type="text" name="test-weight-identifier" value="0" data-bind="scoring.weightIdentifier" data-bind-encoder="string" />
+                <input type="text" name="test-weight-identifier" data-bind="scoring.weightIdentifier" data-validate="$pattern(pattern=^([a-zA-Z_][a-zA-Z0-9_\.-]*)?$);" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -70,10 +70,12 @@ function($, _, hider, actions, testPartView, templates, qtiTestHelper){
 
             var $view = propView.getView();
             var $cutScoreLine = $('.test-cut-score', $view);
+            var $weightIdentifierLine = $('.test-weight-identifier', $view);
             var $title = $('.test-creator-test > h1 [data-bind=title]');
 
             function changeScoring(scoring) {
                 hider.toggle($cutScoreLine, !!scoring && scoring.outcomeProcessing === 'cut');
+                hider.toggle($weightIdentifierLine, !!scoring && ['none', 'custom'].indexOf(scoring.outcomeProcessing) === -1);
             }
 
             $view.on('change.binder', function (e, model) {

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -71,11 +71,14 @@ function($, _, hider, actions, testPartView, templates, qtiTestHelper){
             var $view = propView.getView();
             var $cutScoreLine = $('.test-cut-score', $view);
             var $weightIdentifierLine = $('.test-weight-identifier', $view);
+            var $descriptions = $('.test-outcome-processing-description', $view);
             var $title = $('.test-creator-test > h1 [data-bind=title]');
 
             function changeScoring(scoring) {
                 hider.toggle($cutScoreLine, !!scoring && scoring.outcomeProcessing === 'cut');
                 hider.toggle($weightIdentifierLine, !!scoring && ['none', 'custom'].indexOf(scoring.outcomeProcessing) === -1);
+                hider.hide($descriptions);
+                hider.show($descriptions.filter('[data-key="' + scoring.outcomeProcessing + '"]'));
             }
 
             $view.on('change.binder', function (e, model) {

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -19,25 +19,25 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-'jquery', 'lodash',
-'taoQtiTest/controller/creator/views/actions', 
+'jquery', 'lodash', 'ui/hider',
+'taoQtiTest/controller/creator/views/actions',
 'taoQtiTest/controller/creator/views/testpart',
 'taoQtiTest/controller/creator/templates/index',
 'taoQtiTest/controller/creator/helpers/qtiTest'
-], 
-function($, _, actions, testPartView, templates, qtiTestHelper){
+],
+function($, _, hider, actions, testPartView, templates, qtiTestHelper){
     'use strict';
- 
+
    /**
      * The TestView setup test related components and beahvior
-     * 
+     *
      * @exports taoQtiTest/controller/creator/views/test
      * @param {Object} model - the data model to bind to the test
      * @param {Object} [data] - additionnal data used by the setup
      * @param {Array} [data.identifiers] - the locked identifiers
      */
    var testView = function testView (model, data) {
-       
+
         actions.properties($('.test-creator-test > h1'), 'test', model, propHandler);
         testParts();
         addTestPart();
@@ -49,7 +49,7 @@ function($, _, actions, testPartView, templates, qtiTestHelper){
         function testParts () {
             if(!model.testParts){
                 model.testParts = [];
-            }                   
+            }
             $('.testpart').each(function(){
                 var $testPart = $(this);
                 var index = $testPart.data('bind-index');
@@ -60,23 +60,31 @@ function($, _, actions, testPartView, templates, qtiTestHelper){
                 testPartView.setUp($testPart, model.testParts[index], data);
             });
         }
-        
+
         /**
          * Perform some binding once the property view is created
          * @private
          * @param {propView} propView - the view object
          */
-        function propHandler (propView) {
-            
-           var $view = propView.getView();
+        function propHandler(propView) {
 
-            //listen for databinder change to update the test part title
-           var $title =  $('.test-creator-test > h1 [data-bind=title]');
-           $view.on('change.binder', function(e, model){
-                if(e.namespace === 'binder' && model['qti-type'] === 'assessmentTest'){
+            var $view = propView.getView();
+            var $cutScoreLine = $('.test-cut-score', $view);
+            var $title = $('.test-creator-test > h1 [data-bind=title]');
+
+            function changeScoring(scoring) {
+                hider.toggle($cutScoreLine, !!scoring && scoring.outcomeProcessing === 'cut');
+            }
+
+            $view.on('change.binder', function (e, model) {
+                if (e.namespace === 'binder' && model['qti-type'] === 'assessmentTest') {
+                    changeScoring(model.scoring);
+
+                    //update the test part title when the databinder has changed it
                     $title.text(model.title);
                 }
             });
+            changeScoring(model.scoring);
         }
 
         /**
@@ -103,12 +111,12 @@ function($, _, actions, testPartView, templates, qtiTestHelper){
                             identifier : qtiTestHelper.getIdentifier('assessmentSection',  data.identifiers),
                             title : 'Section 1',
                             index : 0,
-                            sectionParts : []             
+                            sectionParts : []
                         }]
                     });
                 }
             });
-            
+
             //we listen the event not from the adder but  from the data binder to be sure the model is up to date
             $(document)
               .off('add.binder', '.testparts')

--- a/views/js/test/creator/helpers/baseType/test.html
+++ b/views/js/test/creator/helpers/baseType/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Authoring - baseType Helper</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/baseType.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiTest/test/creator/helpers/baseType/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/creator/helpers/baseType/test.js
+++ b/views/js/test/creator/helpers/baseType/test.js
@@ -21,12 +21,12 @@
 define([
     'lodash',
     'taoQtiTest/controller/creator/helpers/baseType'
-], function (_, baseType) {
+], function (_, baseTypeHelper) {
     'use strict';
 
     var baseTypeApi = [
         {title: 'asArray'},
-        {title: 'validOrDefault'},
+        {title: 'getValid'},
         {title: 'getConstantByName'},
         {title: 'getNameByConstant'}
     ];
@@ -53,7 +53,7 @@ define([
 
     QUnit.test('module', function (assert) {
         QUnit.expect(1);
-        assert.equal(typeof baseType, 'object', "The baseType helper module exposes an object");
+        assert.equal(typeof baseTypeHelper, 'object', "The baseType helper module exposes an object");
     });
 
 
@@ -61,16 +61,16 @@ define([
         .cases(baseTypeApi)
         .test('helpers/baseType API ', function (data, assert) {
             QUnit.expect(1);
-            assert.equal(typeof baseType[data.title], 'function', 'The baseType helper exposes a "' + data.title + '" function');
+            assert.equal(typeof baseTypeHelper[data.title], 'function', 'The baseType helper exposes a "' + data.title + '" function');
         });
 
 
     QUnit.test('helpers/baseType.asArray()', function (assert) {
         QUnit.expect(3);
 
-        assert.equal(typeof baseType.asArray(), 'object', 'The baseType helper asArray() provides a list');
-        assert.equal(_.size(baseType.asArray()), 13, 'The baseType helper asArray() provides a list of base types');
-        assert.deepEqual(_.values(baseType.asArray()), _.range(0, 13), 'The baseType helper asArray() provides the base types as a list of index');
+        assert.equal(typeof baseTypeHelper.asArray(), 'object', 'The baseType helper asArray() provides a list');
+        assert.equal(_.size(baseTypeHelper.asArray()), 13, 'The baseType helper asArray() provides a list of base types');
+        assert.deepEqual(_.values(baseTypeHelper.asArray()), _.range(0, 13), 'The baseType helper asArray() provides the base types as a list of index');
     });
 
 
@@ -78,19 +78,19 @@ define([
         .cases(baseTypeList)
         .test('helpers/baseType.asArray() ', function (data, assert) {
             QUnit.expect(1);
-            assert.equal(baseType.asArray()[data.key], data.value, 'The type ' + data.title + ' has index ' + data.value);
+            assert.equal(baseTypeHelper.asArray()[data.key], data.value, 'The type ' + data.title + ' has index ' + data.value);
         });
 
-    QUnit.test('helpers/baseType.validOrDefault()', function (assert) {
+    QUnit.test('helpers/baseType.getValid()', function (assert) {
         QUnit.expect(7);
 
-        assert.equal(baseType.validOrDefault(100), -1, 'The baseType helper validOrDefault() provides a default type');
-        assert.equal(baseType.validOrDefault(1), 1, 'The baseType helper validOrDefault() provides the type if valid');
-        assert.equal(baseType.validOrDefault('float'), 3, 'The baseType helper validOrDefault() provides the type if valid');
-        assert.equal(baseType.validOrDefault('foo', 2), 2, 'The baseType helper validOrDefault() provides the default type');
-        assert.equal(baseType.validOrDefault('foo', 'integer'), 2, 'The baseType helper validOrDefault() provides the default type');
-        assert.equal(baseType.validOrDefault('foo', 'bar'), -1, 'The baseType helper validOrDefault() provides a default type');
-        assert.equal(baseType.validOrDefault('foo', 100), -1, 'The baseType helper validOrDefault() provides a default type');
+        assert.equal(baseTypeHelper.getValid(100), -1, 'The baseType helper getValid() provides a default type');
+        assert.equal(baseTypeHelper.getValid(1), 1, 'The baseType helper getValid() provides the type if valid');
+        assert.equal(baseTypeHelper.getValid('float'), 3, 'The baseType helper getValid() provides the type if valid');
+        assert.equal(baseTypeHelper.getValid('foo', 2), 2, 'The baseType helper getValid() provides the default type');
+        assert.equal(baseTypeHelper.getValid('foo', 'integer'), 2, 'The baseType helper getValid() provides the default type');
+        assert.equal(baseTypeHelper.getValid('foo', 'bar'), -1, 'The baseType helper getValid() provides a default type');
+        assert.equal(baseTypeHelper.getValid('foo', 100), -1, 'The baseType helper getValid() provides a default type');
     });
 
 
@@ -98,7 +98,7 @@ define([
         .cases(baseTypeList)
         .test('helpers/baseType.getConstantByName() ', function (data, assert) {
             QUnit.expect(1);
-            assert.equal(baseType.getConstantByName(data.title.toLowerCase()), data.value, 'The type ' + data.title + ' has index ' + data.value);
+            assert.equal(baseTypeHelper.getConstantByName(data.title.toLowerCase()), data.value, 'The type ' + data.title + ' has index ' + data.value);
         });
 
 
@@ -106,18 +106,18 @@ define([
         .cases(baseTypeList)
         .test('helpers/baseType.getNameByConstant() ', function (data, assert) {
             QUnit.expect(1);
-            assert.equal(baseType.getNameByConstant(data.value), data.title, 'The constant ' + data.value + ' refers to type ' + data.title);
+            assert.equal(baseTypeHelper.getNameByConstant(data.value), data.title, 'The constant ' + data.value + ' refers to type ' + data.title);
         });
 
 
     QUnit.test('helpers/baseType.getConstantByName(unknown)', function (assert) {
         QUnit.expect(1);
-        assert.equal(baseType.getConstantByName('foo'), false, 'An unknown type has not index');
+        assert.equal(baseTypeHelper.getConstantByName('foo'), false, 'An unknown type has not index');
     });
 
 
     QUnit.test('helpers/baseType.getNameByConstant(100)', function (assert) {
         QUnit.expect(1);
-        assert.equal(baseType.getNameByConstant(100), false, 'A constant out the type range does not mean anything');
+        assert.equal(baseTypeHelper.getNameByConstant(100), false, 'A constant out the type range does not mean anything');
     });
 });

--- a/views/js/test/creator/helpers/baseType/test.js
+++ b/views/js/test/creator/helpers/baseType/test.js
@@ -1,0 +1,123 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/baseType'
+], function (_, baseType) {
+    'use strict';
+
+    var baseTypeApi = [
+        {title: 'asArray'},
+        {title: 'validOrDefault'},
+        {title: 'getConstantByName'},
+        {title: 'getNameByConstant'}
+    ];
+
+    var baseTypeList = [
+        {title: 'identifier', key: 'IDENTIFIER', value: 0},
+        {title: 'boolean', key: 'BOOLEAN', value: 1},
+        {title: 'integer', key: 'INTEGER', value: 2},
+        {title: 'float', key: 'FLOAT', value: 3},
+        {title: 'string', key: 'STRING', value: 4},
+        {title: 'point', key: 'POINT', value: 5},
+        {title: 'pair', key: 'PAIR', value: 6},
+        {title: 'directedPair', key: 'DIRECTED_PAIR', value: 7},
+        {title: 'duration', key: 'DURATION', value: 8},
+        {title: 'file', key: 'FILE', value: 9},
+        {title: 'uri', key: 'URI', value: 10},
+        {title: 'intOrIdentifier', key: 'INT_OR_IDENTIFIER', value: 11},
+        {title: 'coords', key: 'COORDS', value: 12}
+    ];
+
+
+    QUnit.module('helpers/baseType');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+        assert.equal(typeof baseType, 'object', "The baseType helper module exposes an object");
+    });
+
+
+    QUnit
+        .cases(baseTypeApi)
+        .test('helpers/baseType API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof baseType[data.title], 'function', 'The baseType helper exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit.test('helpers/baseType.asArray()', function (assert) {
+        QUnit.expect(3);
+
+        assert.equal(typeof baseType.asArray(), 'object', 'The baseType helper asArray() provides a list');
+        assert.equal(_.size(baseType.asArray()), 13, 'The baseType helper asArray() provides a list of base types');
+        assert.deepEqual(_.values(baseType.asArray()), _.range(0, 13), 'The baseType helper asArray() provides the base types as a list of index');
+    });
+
+
+    QUnit
+        .cases(baseTypeList)
+        .test('helpers/baseType.asArray() ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(baseType.asArray()[data.key], data.value, 'The type ' + data.title + ' has index ' + data.value);
+        });
+
+    QUnit.test('helpers/baseType.validOrDefault()', function (assert) {
+        QUnit.expect(7);
+
+        assert.equal(baseType.validOrDefault(100), -1, 'The baseType helper validOrDefault() provides a default type');
+        assert.equal(baseType.validOrDefault(1), 1, 'The baseType helper validOrDefault() provides the type if valid');
+        assert.equal(baseType.validOrDefault('float'), 3, 'The baseType helper validOrDefault() provides the type if valid');
+        assert.equal(baseType.validOrDefault('foo', 2), 2, 'The baseType helper validOrDefault() provides the default type');
+        assert.equal(baseType.validOrDefault('foo', 'integer'), 2, 'The baseType helper validOrDefault() provides the default type');
+        assert.equal(baseType.validOrDefault('foo', 'bar'), -1, 'The baseType helper validOrDefault() provides a default type');
+        assert.equal(baseType.validOrDefault('foo', 100), -1, 'The baseType helper validOrDefault() provides a default type');
+    });
+
+
+    QUnit
+        .cases(baseTypeList)
+        .test('helpers/baseType.getConstantByName() ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(baseType.getConstantByName(data.title.toLowerCase()), data.value, 'The type ' + data.title + ' has index ' + data.value);
+        });
+
+
+    QUnit
+        .cases(baseTypeList)
+        .test('helpers/baseType.getNameByConstant() ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(baseType.getNameByConstant(data.value), data.title, 'The constant ' + data.value + ' refers to type ' + data.title);
+        });
+
+
+    QUnit.test('helpers/baseType.getConstantByName(unknown)', function (assert) {
+        QUnit.expect(1);
+        assert.equal(baseType.getConstantByName('foo'), false, 'An unknown type has not index');
+    });
+
+
+    QUnit.test('helpers/baseType.getNameByConstant(100)', function (assert) {
+        QUnit.expect(1);
+        assert.equal(baseType.getNameByConstant(100), false, 'A constant out the type range does not mean anything');
+    });
+});

--- a/views/js/test/creator/helpers/cardinality/test.html
+++ b/views/js/test/creator/helpers/cardinality/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Authoring - cardinality Helper</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/cardinality.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiTest/test/creator/helpers/cardinality/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/creator/helpers/cardinality/test.js
+++ b/views/js/test/creator/helpers/cardinality/test.js
@@ -1,0 +1,114 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/cardinality'
+], function (_, cardinalityHelper) {
+    'use strict';
+
+    var cardinalityApi = [
+        {title: 'asArray'},
+        {title: 'getValid'},
+        {title: 'getConstantByName'},
+        {title: 'getNameByConstant'}
+    ];
+
+    var cardinalityList = [
+        {title: 'single', key: 'SINGLE', value: 0},
+        {title: 'multiple', key: 'MULTIPLE', value: 1},
+        {title: 'ordered', key: 'ORDERED', value: 2},
+        {title: 'record', key: 'RECORD', value: 3}
+    ];
+
+
+    QUnit.module('helpers/cardinality');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+        assert.equal(typeof cardinalityHelper, 'object', "The cardinality helper module exposes an object");
+    });
+
+
+    QUnit
+        .cases(cardinalityApi)
+        .test('helpers/cardinality API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof cardinalityHelper[data.title], 'function', 'The cardinality helper exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit.test('helpers/cardinality.asArray()', function (assert) {
+        QUnit.expect(3);
+
+        assert.equal(typeof cardinalityHelper.asArray(), 'object', 'The cardinality helper asArray() provides a list');
+        assert.equal(_.size(cardinalityHelper.asArray()), 4, 'The cardinality helper asArray() provides a list of base cardinalitys');
+        assert.deepEqual(_.values(cardinalityHelper.asArray()), _.range(0, 4), 'The cardinality helper asArray() provides the base cardinalitys as a list of index');
+    });
+
+
+    QUnit
+        .cases(cardinalityList)
+        .test('helpers/cardinality.asArray() ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(cardinalityHelper.asArray()[data.key], data.value, 'The cardinality ' + data.title + ' has index ' + data.value);
+        });
+
+    QUnit.test('helpers/cardinality.getValid()', function (assert) {
+        QUnit.expect(7);
+
+        assert.equal(cardinalityHelper.getValid(100), -1, 'The cardinality helper getValid() provides a default cardinality');
+        assert.equal(cardinalityHelper.getValid(1), 1, 'The cardinality helper getValid() provides the cardinality if valid');
+        assert.equal(cardinalityHelper.getValid('multiple'), 1, 'The cardinality helper getValid() provides the cardinality if valid');
+        assert.equal(cardinalityHelper.getValid('foo', 2), 2, 'The cardinality helper getValid() provides the default cardinality');
+        assert.equal(cardinalityHelper.getValid('foo', 'ordered'), 2, 'The cardinality helper getValid() provides the default cardinality');
+        assert.equal(cardinalityHelper.getValid('foo', 'bar'), -1, 'The cardinality helper getValid() provides a default cardinality');
+        assert.equal(cardinalityHelper.getValid('foo', 100), -1, 'The cardinality helper getValid() provides a default cardinality');
+    });
+
+
+    QUnit
+        .cases(cardinalityList)
+        .test('helpers/cardinality.getConstantByName() ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(cardinalityHelper.getConstantByName(data.title.toLowerCase()), data.value, 'The cardinality ' + data.title + ' has index ' + data.value);
+        });
+
+
+    QUnit
+        .cases(cardinalityList)
+        .test('helpers/cardinality.getNameByConstant() ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(cardinalityHelper.getNameByConstant(data.value), data.title, 'The constant ' + data.value + ' refers to cardinality ' + data.title);
+        });
+
+
+    QUnit.test('helpers/cardinality.getConstantByName(unknown)', function (assert) {
+        QUnit.expect(1);
+        assert.equal(cardinalityHelper.getConstantByName('foo'), false, 'An unknown cardinality has not index');
+    });
+
+
+    QUnit.test('helpers/cardinality.getNameByConstant(100)', function (assert) {
+        QUnit.expect(1);
+        assert.equal(cardinalityHelper.getNameByConstant(100), false, 'A constant out the cardinality range does not mean anything');
+    });
+});

--- a/views/js/test/creator/helpers/cardinality/test.js
+++ b/views/js/test/creator/helpers/cardinality/test.js
@@ -75,13 +75,13 @@ define([
     QUnit.test('helpers/cardinality.getValid()', function (assert) {
         QUnit.expect(7);
 
-        assert.equal(cardinalityHelper.getValid(100), -1, 'The cardinality helper getValid() provides a default cardinality');
+        assert.equal(cardinalityHelper.getValid(100), 0, 'The cardinality helper getValid() provides a default cardinality');
         assert.equal(cardinalityHelper.getValid(1), 1, 'The cardinality helper getValid() provides the cardinality if valid');
         assert.equal(cardinalityHelper.getValid('multiple'), 1, 'The cardinality helper getValid() provides the cardinality if valid');
         assert.equal(cardinalityHelper.getValid('foo', 2), 2, 'The cardinality helper getValid() provides the default cardinality');
         assert.equal(cardinalityHelper.getValid('foo', 'ordered'), 2, 'The cardinality helper getValid() provides the default cardinality');
-        assert.equal(cardinalityHelper.getValid('foo', 'bar'), -1, 'The cardinality helper getValid() provides a default cardinality');
-        assert.equal(cardinalityHelper.getValid('foo', 100), -1, 'The cardinality helper getValid() provides a default cardinality');
+        assert.equal(cardinalityHelper.getValid('foo', 'bar'), 0, 'The cardinality helper getValid() provides a default cardinality');
+        assert.equal(cardinalityHelper.getValid('foo', 100), 0, 'The cardinality helper getValid() provides a default cardinality');
     });
 
 

--- a/views/js/test/creator/helpers/category/categories.json
+++ b/views/js/test/creator/helpers/category/categories.json
@@ -1,0 +1,256 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history", "x-tao-option-reviewScreen"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math", "x-tao-option-reviewScreen"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math", "x-tao-option-reviewScreen", "x-tao-option-calculator"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "testFeedbacks": []
+}

--- a/views/js/test/creator/helpers/category/test.html
+++ b/views/js/test/creator/helpers/category/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Authoring - category Helper</title>
+    <base href="../../../../../../../tao/views/" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/category.js"></script>
+
+    <script  type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //load the test
+            require(['taoQtiTest/test/creator/helpers/category/test'], function(){
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/creator/helpers/category/test.js
+++ b/views/js/test/creator/helpers/category/test.js
@@ -1,0 +1,125 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/category',
+    'json!taoQtiTest/test/creator/helpers/category/categories.json'
+], function (_,
+             categoryHelper,
+             testModelSample) {
+    'use strict';
+
+    var categoryHelperApi = [
+        {title: 'eachCategories'},
+        {title: 'listCategories'},
+        {title: 'listOptions'}
+    ];
+
+
+    QUnit.module('helpers/category');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+        assert.equal(typeof categoryHelper, 'object', "The category helper module exposes an object");
+    });
+
+
+    QUnit
+        .cases(categoryHelperApi)
+        .test('helpers/category API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof categoryHelper[data.title], 'function', 'The category helper exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit.test('helpers/category.eachCategories()', function (assert) {
+        var path = [{
+            category: 'history',
+            item: 'item-1'
+        }, {
+            category: 'x-tao-option-reviewScreen',
+            item: 'item-1'
+        }, {
+            category: 'math',
+            item: 'item-3'
+        }, {
+            category: 'x-tao-option-reviewScreen',
+            item: 'item-3'
+        }, {
+            category: 'math',
+            item: 'item-2'
+        }, {
+            category: 'x-tao-option-reviewScreen',
+            item: 'item-2'
+        }, {
+            category: 'x-tao-option-calculator',
+            item: 'item-2'
+        }, {
+            category: 'history',
+            item: 'item-4'
+        }, {
+            category: 'history',
+            item: 'item-5'
+        }, {
+            category: 'math',
+            item: 'item-6'
+        }];
+        var pointer = 0;
+
+        categoryHelper.eachCategories(testModelSample, function(category, itemRef) {
+            assert.equal(category, path[pointer].category, 'The category helper loop over the right category');
+            assert.equal(itemRef.identifier, path[pointer].item, 'The category helper loop over the right item ref');
+            pointer ++;
+        });
+
+        QUnit.expect(1 + path.length * 2);
+
+        assert.equal(pointer, path.length, 'The category helper returns the right categories');
+    });
+
+
+    QUnit.test('helpers/category.listCategories()', function (assert) {
+        var expectedCategories = ['history', 'math'];
+        var categories = categoryHelper.listCategories(testModelSample);
+
+        categories.sort();
+        expectedCategories.sort();
+
+        QUnit.expect(1);
+
+        assert.deepEqual(categories, expectedCategories, 'The category helper returns the right categories');
+    });
+
+
+    QUnit.test('helpers/category.listOptions()', function (assert) {
+        var expectedOptions = ['x-tao-option-calculator', 'x-tao-option-reviewScreen'];
+        var options = categoryHelper.listOptions(testModelSample);
+
+        options.sort();
+        expectedOptions.sort();
+
+        QUnit.expect(1);
+
+        assert.deepEqual(options, expectedOptions, 'The category helper returns the right options');
+    });
+
+});

--- a/views/js/test/creator/helpers/outcome/outcomes.json
+++ b/views/js/test/creator/helpers/outcome/outcomes.json
@@ -1,0 +1,426 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [{
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_MATH",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_HISTORY",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_MATH",
+    "cardinality": 0,
+    "baseType": 1
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_HISTORY",
+    "cardinality": 0,
+    "baseType": 1
+  }],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_MATH",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["math"],
+          "excludeCategories": []
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_HISTORY",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["history"],
+          "excludeCategories": []
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_MATH",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "",
+              "sectionIdentifier": "",
+              "includeCategories": ["math"],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": ["math"],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 70
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_HISTORY",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "",
+              "sectionIdentifier": "",
+              "includeCategories": ["history"],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": ["math"],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 70
+        }]
+      }
+    }]
+  },
+  "testFeedbacks": []
+}

--- a/views/js/test/creator/helpers/outcome/test.html
+++ b/views/js/test/creator/helpers/outcome/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Authoring - outcome Helper</title>
+    <base href="../../../../../../../tao/views/" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/outcome.js"></script>
+
+    <script  type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //load the test
+            require(['taoQtiTest/test/creator/helpers/outcome/test'], function(){
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/creator/helpers/outcome/test.js
+++ b/views/js/test/creator/helpers/outcome/test.js
@@ -250,7 +250,7 @@ define([
     }, {
         title: 'cardinality',
         identifier: 'FOO_BAR',
-        cardinality: 5,
+        cardinality: 2,
         outcome: {
             'qti-type': 'outcomeDeclaration',
             views: [],
@@ -260,7 +260,7 @@ define([
             normalMinimum: false,
             masteryValue: false,
             identifier: 'FOO_BAR',
-            cardinality: 5,
+            cardinality: 2,
             baseType: 3
         }
     }, {

--- a/views/js/test/creator/helpers/outcome/test.js
+++ b/views/js/test/creator/helpers/outcome/test.js
@@ -38,6 +38,7 @@ define([
         {title: 'getOutcomeProcessingRules'},
         {title: 'eachOutcomeDeclarations'},
         {title: 'eachOutcomeProcessingRules'},
+        {title: 'eachOutcomeProcessingRuleExpressions'},
         {title: 'listOutcomes'},
         {title: 'removeOutcomes'},
         {title: 'createOutcome'},
@@ -137,6 +138,26 @@ define([
 
         outcomeHelper.eachOutcomeProcessingRules(testModelSample, function (outcome) {
             assert.equal(outcome.identifier, path[pointer], 'The outcome helper loop over the right rule');
+            pointer++;
+        });
+
+        QUnit.expect(1 + path.length);
+
+        assert.equal(pointer, path.length, 'The outcome helper returns the right rules');
+    });
+
+
+    QUnit.test('helpers/outcome.eachOutcomeProcessingRuleExpressions()', function (assert) {
+        var path = [
+            'setOutcomeValue', 'sum', 'testVariables',
+            'setOutcomeValue', 'sum', 'testVariables',
+            'setOutcomeValue', 'gte', 'divide', 'sum', 'testVariables', 'numberPresented', 'baseValue',
+            'setOutcomeValue', 'gte', 'divide', 'sum', 'testVariables', 'numberPresented', 'baseValue'
+        ];
+        var pointer = 0;
+
+        outcomeHelper.eachOutcomeProcessingRuleExpressions(testModelSample, function (outcome) {
+            assert.equal(outcome['qti-type'], path[pointer], 'The outcome helper loop over the right rule');
             pointer++;
         });
 

--- a/views/js/test/creator/helpers/outcome/test.js
+++ b/views/js/test/creator/helpers/outcome/test.js
@@ -1,0 +1,617 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/outcome',
+    'json!taoQtiTest/test/creator/helpers/outcome/outcomes.json'
+], function (_,
+             outcomeHelper,
+             testModelSample) {
+    'use strict';
+
+    var createOutcomeCases, createOutcomeErrorCases;
+    var addOutcomeProcessingCases, addOutcomeProcessingErrorCases;
+    var addOutcomeCases, addOutcomeErrorCases;
+    var outcomeHelperApi = [
+        {title: 'findQtiType'},
+        {title: 'getProcessingRuleExpression'},
+        {title: 'getProcessingRuleProperty'},
+        {title: 'getOutcomeDeclarations'},
+        {title: 'getOutcomeProcessingRules'},
+        {title: 'eachOutcomeDeclarations'},
+        {title: 'eachOutcomeProcessingRules'},
+        {title: 'listOutcomes'},
+        {title: 'removeOutcomes'},
+        {title: 'createOutcome'},
+        {title: 'addOutcomeProcessing'},
+        {title: 'addOutcome'}
+    ];
+
+
+    QUnit.module('helpers/outcome');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+        assert.equal(typeof outcomeHelper, 'object', "The outcome helper module exposes an object");
+    });
+
+
+    QUnit
+        .cases(outcomeHelperApi)
+        .test('helpers/outcome API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof outcomeHelper[data.title], 'function', 'The outcome helper exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit.test('helpers/outcome.findQtiType()', function (assert) {
+        var expression = [{
+            'qti-type': 'foo',
+            identifier: 'FOO'
+        }, {
+            'qti-type': 'bar',
+            identifier: 'BAR'
+        }];
+
+        QUnit.expect(5);
+        assert.equal(outcomeHelper.findQtiType(expression, 'foo'), expression[0], 'The outcome helper has found the right expression');
+        assert.equal(outcomeHelper.findQtiType(expression, 'bar'), expression[1], 'The outcome helper has found the right expression');
+        assert.equal(outcomeHelper.findQtiType(expression, 'baz'), null, 'The outcome helper has not found any expression');
+        assert.equal(outcomeHelper.findQtiType(expression[0], 'foo'), expression[0], 'The outcome helper has found the right expression');
+        assert.equal(outcomeHelper.findQtiType(expression[0], 'baz'), null, 'The outcome helper has not found any expression');
+    });
+
+
+    QUnit.test('helpers/outcome.getProcessingRuleExpression()', function (assert) {
+        QUnit.expect(4);
+        outcomeHelper.eachOutcomeProcessingRules(testModelSample, function (outcomeRule) {
+            var expression = outcomeHelper.getProcessingRuleExpression(outcomeRule, 'setOutcomeValue.gte.divide.sum.testVariables');
+            if (expression) {
+                assert.equal(typeof expression, 'object', 'An expression has been found from the outcome');
+                assert.equal(expression['qti-type'], 'testVariables', 'An expression has been found from the outcome');
+            }
+        });
+    });
+
+
+    QUnit.test('helpers/outcome.getProcessingRuleProperty()', function (assert) {
+        var expectedValues = [70, 70];
+        var values = _(outcomeHelper.getOutcomeProcessingRules(testModelSample)).map(function (outcomeRule) {
+            return outcomeHelper.getProcessingRuleProperty(outcomeRule, 'setOutcomeValue.gte.baseValue.value');
+        }).compact().value();
+
+        QUnit.expect(1);
+        assert.deepEqual(values, expectedValues, 'The outcome helper returns the right property value');
+    });
+
+
+    QUnit.test('helpers/outcome.getOutcomeDeclarations()', function (assert) {
+        QUnit.expect(1);
+        assert.equal(outcomeHelper.getOutcomeDeclarations(testModelSample), testModelSample.outcomeDeclarations, 'The outcome helper returns the right outcome declarations');
+    });
+
+
+    QUnit.test('helpers/outcome.getOutcomeProcessingRules()', function (assert) {
+        QUnit.expect(1);
+        assert.equal(outcomeHelper.getOutcomeProcessingRules(testModelSample), testModelSample.outcomeProcessing.outcomeRules, 'The outcome helper returns the right outcome processing rules');
+    });
+
+
+    QUnit.test('helpers/outcome.eachOutcomeDeclarations()', function (assert) {
+        var path = ['SCORE_MATH', 'SCORE_HISTORY', 'PASS_MATH', 'PASS_HISTORY'];
+        var pointer = 0;
+
+        outcomeHelper.eachOutcomeDeclarations(testModelSample, function (outcome) {
+            assert.equal(outcome.identifier, path[pointer], 'The outcome helper loop over the right declaration');
+            pointer++;
+        });
+
+        QUnit.expect(1 + path.length);
+
+        assert.equal(pointer, path.length, 'The outcome helper returns the right declarations');
+    });
+
+
+    QUnit.test('helpers/outcome.eachOutcomeProcessingRules()', function (assert) {
+        var path = ['SCORE_MATH', 'SCORE_HISTORY', 'PASS_MATH', 'PASS_HISTORY'];
+        var pointer = 0;
+
+        outcomeHelper.eachOutcomeProcessingRules(testModelSample, function (outcome) {
+            assert.equal(outcome.identifier, path[pointer], 'The outcome helper loop over the right rule');
+            pointer++;
+        });
+
+        QUnit.expect(1 + path.length);
+
+        assert.equal(pointer, path.length, 'The outcome helper returns the right rules');
+    });
+
+
+    QUnit.test('helpers/outcome.listOutcomes()', function (assert) {
+        var expectedOutcomes = ['SCORE_MATH', 'SCORE_HISTORY', 'PASS_MATH', 'PASS_HISTORY'];
+        var outcomes = outcomeHelper.listOutcomes(testModelSample);
+
+        outcomes.sort();
+        expectedOutcomes.sort();
+
+        QUnit.expect(1);
+
+        assert.deepEqual(outcomes, expectedOutcomes, 'The outcome helper returns the right outcomes');
+    });
+
+
+    QUnit.test('helpers/outcome.listOutcomes(callback)', function (assert) {
+        var expectedOutcomes = ['SCORE_MATH', 'SCORE_HISTORY'];
+        var outcomes = outcomeHelper.listOutcomes(testModelSample, function (outcome) {
+            return outcome.identifier.indexOf('SCORE_') === 0;
+        });
+
+        outcomes.sort();
+        expectedOutcomes.sort();
+
+        QUnit.expect(1);
+
+        assert.deepEqual(outcomes, expectedOutcomes, 'The outcome helper returns the right outcomes');
+    });
+
+
+    QUnit.test('helpers/outcome.removeOutcomes()', function (assert) {
+        var testModel = _.cloneDeep(testModelSample);
+        var outcomeToRemove = 'SCORE_MATH';
+        var countDeclarations = testModel.outcomeDeclarations.length;
+        var countRules = testModel.outcomeProcessing.outcomeRules.length;
+
+        QUnit.expect(6);
+
+        assert.equal(testModel.outcomeDeclarations[0].identifier, outcomeToRemove, 'There is an outcome declaration');
+        assert.equal(testModel.outcomeProcessing.outcomeRules[0].identifier, outcomeToRemove, 'There is an outcome rule');
+
+        outcomeHelper.removeOutcomes(testModel, 'SCORE_MATH');
+
+        assert.notEqual(testModel.outcomeDeclarations[0].identifier, outcomeToRemove, 'The outcome declaration has been removed');
+        assert.notEqual(testModel.outcomeProcessing.outcomeRules[0].identifier, outcomeToRemove, 'The outcome rule has been removed');
+
+        assert.equal(testModel.outcomeDeclarations.length, countDeclarations - 1, 'The number of outcomes declarations is accurate');
+        assert.equal(testModel.outcomeProcessing.outcomeRules.length, countRules - 1, 'The number of outcomes rules is accurate');
+    });
+
+
+    createOutcomeCases = [{
+        title: 'default',
+        identifier: 'FOO_BAR',
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            views: [],
+            interpretation: '',
+            longInterpretation: '',
+            normalMaximum: false,
+            normalMinimum: false,
+            masteryValue: false,
+            identifier: 'FOO_BAR',
+            cardinality: 0,
+            baseType: 3
+        }
+    }, {
+        title: 'integer',
+        identifier: 'FOO_BAR',
+        type: 'integer',
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            views: [],
+            interpretation: '',
+            longInterpretation: '',
+            normalMaximum: false,
+            normalMinimum: false,
+            masteryValue: false,
+            identifier: 'FOO_BAR',
+            cardinality: 0,
+            baseType: 2
+        }
+    }, {
+        title: 'cardinality',
+        identifier: 'FOO_BAR',
+        cardinality: 5,
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            views: [],
+            interpretation: '',
+            longInterpretation: '',
+            normalMaximum: false,
+            normalMinimum: false,
+            masteryValue: false,
+            identifier: 'FOO_BAR',
+            cardinality: 5,
+            baseType: 3
+        }
+    }, {
+        title: 'full',
+        identifier: 'FOO_BAR',
+        type: 1,
+        cardinality: 1,
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            views: [],
+            interpretation: '',
+            longInterpretation: '',
+            normalMaximum: false,
+            normalMinimum: false,
+            masteryValue: false,
+            identifier: 'FOO_BAR',
+            cardinality: 1,
+            baseType: 1
+        }
+    }, {
+        title: 'wrong type',
+        identifier: 'FOO_BAR',
+        type: 100,
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            views: [],
+            interpretation: '',
+            longInterpretation: '',
+            normalMaximum: false,
+            normalMinimum: false,
+            masteryValue: false,
+            identifier: 'FOO_BAR',
+            cardinality: 0,
+            baseType: 3
+        }
+    }, {
+        title: 'wrong type name',
+        identifier: 'FOO_BAR',
+        type: 'foo',
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            views: [],
+            interpretation: '',
+            longInterpretation: '',
+            normalMaximum: false,
+            normalMinimum: false,
+            masteryValue: false,
+            identifier: 'FOO_BAR',
+            cardinality: 0,
+            baseType: 3
+        }
+    }];
+
+    QUnit
+        .cases(createOutcomeCases)
+        .test('helpers/outcome.createOutcome() ', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(outcomeHelper.createOutcome(data.identifier, data.type, data.cardinality), data.outcome, 'The outcome helper has provided the expected outcome declaration');
+        });
+
+
+    createOutcomeErrorCases = [{
+        title: 'Missing identifier'
+    }, {
+        title: 'Empty identifier',
+        identifier: ''
+    }, {
+        title: 'Wrong identifier',
+        identifier: {foo: 'bar'}
+    }, {
+        title: 'Bad  identifier',
+        identifier: '12 foo bar'
+    }];
+
+    QUnit
+        .cases(createOutcomeErrorCases)
+        .test('helpers/outcome.createOutcome()#error', function (data, assert) {
+            QUnit.expect(1);
+            assert.throws(function () {
+                outcomeHelper.createOutcome(data.identifier);
+            }, 'An error must be thrown when the identifier is wrong');
+        });
+
+
+    addOutcomeProcessingCases = [{
+        title: 'Create the collection',
+        testModel: {},
+        processingRule: {
+            'qti-type': 'foo'
+        },
+        expected: {
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing',
+                outcomeRules: [{
+                    'qti-type': 'foo'
+                }]
+            }
+        }
+    }, {
+        title: 'Complete the collection',
+        testModel: {
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing'
+            }
+        },
+        processingRule: {
+            'qti-type': 'foo'
+        },
+        expected: {
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing',
+                outcomeRules: [{
+                    'qti-type': 'foo'
+                }]
+            }
+        }
+    }, {
+        title: 'Update the collection',
+        testModel: {
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing',
+                outcomeRules: [{
+                    'qti-type': 'foo'
+                }]
+            }
+        },
+        processingRule: {
+            'qti-type': 'bar'
+        },
+        expected: {
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing',
+                outcomeRules: [{
+                    'qti-type': 'foo'
+                }, {
+                    'qti-type': 'bar'
+                }]
+            }
+        }
+    }];
+
+    QUnit
+        .cases(addOutcomeProcessingCases)
+        .test('helpers/outcome.addOutcomeProcessing() ', function (data, assert) {
+            QUnit.expect(2);
+            assert.deepEqual(outcomeHelper.addOutcomeProcessing(data.testModel, data.processingRule), data.processingRule, 'The outcome helper has returned the outcome processing rule declaration');
+            assert.deepEqual(data.testModel, data.expected, 'The outcome helper has added the outcome processing rule declaration');
+        });
+
+
+    addOutcomeProcessingErrorCases = [{
+        title: 'Missing processing rule',
+        testModel: {}
+    }, {
+        title: 'Invalid processing rule',
+        testModel: {},
+        processingRule: {}
+    }, {
+        title: 'Invalid processing rule type (empty)',
+        testModel: {},
+        processingRule: {
+            'qti-type': ''
+        }
+    }, {
+        title: 'Invalid processing rule type (wrong)',
+        testModel: {},
+        processingRule: {
+            'qti-type': {foo: 'bar'}
+        }
+    }];
+
+    QUnit
+        .cases(addOutcomeProcessingErrorCases)
+        .test('helpers/outcome.addOutcomeProcessing()#error', function (data, assert) {
+            QUnit.expect(1);
+            assert.throws(function () {
+                outcomeHelper.addOutcomeProcessing(data.testModel, data.processingRule);
+            }, 'An error must be thrown when the input is wrong');
+        });
+
+
+    addOutcomeCases = [{
+        title: 'Create the collection',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'foo'
+        },
+        expected: {
+            outcomeDeclarations: [{
+                'qti-type': 'outcomeDeclaration',
+                identifier: 'foo'
+            }]
+        }
+    }, {
+        title: 'Update the collection',
+        testModel: {
+            outcomeDeclarations: [{
+                'qti-type': 'outcomeDeclaration',
+                identifier: 'foo'
+            }]
+        },
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'bar'
+        },
+        expected: {
+            outcomeDeclarations: [{
+                'qti-type': 'outcomeDeclaration',
+                identifier: 'foo'
+            }, {
+                'qti-type': 'outcomeDeclaration',
+                identifier: 'bar'
+            }]
+        }
+    }, {
+        title: 'Create the collection of processing rules',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'foo'
+        },
+        processingRule: {
+            'qti-type': 'foo',
+            identifier: 'foo'
+        },
+        expected: {
+            outcomeDeclarations: [{
+                'qti-type': 'outcomeDeclaration',
+                identifier: 'foo'
+            }],
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing',
+                outcomeRules: [{
+                    'qti-type': 'foo',
+                    identifier: 'foo'
+                }]
+            }
+        }
+    }, {
+        title: 'Update the collection of processing rules',
+        testModel: {
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing',
+                outcomeRules: [{
+                    'qti-type': 'foo'
+                }]
+            }
+        },
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'foo'
+        },
+        processingRule: {
+            'qti-type': 'bar',
+            identifier: 'foo'
+        },
+        expected: {
+            outcomeDeclarations: [{
+                'qti-type': 'outcomeDeclaration',
+                identifier: 'foo'
+            }],
+            outcomeProcessing: {
+                'qti-type': 'outcomeProcessing',
+                outcomeRules: [{
+                    'qti-type': 'foo'
+                }, {
+                    'qti-type': 'bar',
+                    identifier: 'foo'
+                }]
+            }
+        }
+    }];
+
+    QUnit
+        .cases(addOutcomeCases)
+        .test('helpers/outcome.addOutcome() ', function (data, assert) {
+            QUnit.expect(2);
+            assert.deepEqual(outcomeHelper.addOutcome(data.testModel, data.outcome, data.processingRule), data.outcome, 'The outcome helper has returned the outcome declaration');
+            assert.deepEqual(data.testModel, data.expected, 'The outcome helper has added the outcome declaration');
+        });
+
+
+    addOutcomeErrorCases = [{
+        title: 'Missing outcome',
+        testModel: {}
+    }, {
+        title: 'Invalid outcome',
+        testModel: {},
+        outcome: {}
+    }, {
+        title: 'Invalid outcome type (empty)',
+        testModel: {},
+        outcome: {
+            identifier: 'foo',
+            'qti-type': ''
+        }
+    }, {
+        title: 'Invalid outcome type (wrong)',
+        testModel: {},
+        outcome: {
+            identifier: 'foo',
+            'qti-type': 'outcome'
+        }
+    }, {
+        title: 'Missing outcome identifier',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration'
+        }
+    }, {
+        title: 'Invalid outcome identifier (empty)',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: ''
+        }
+    }, {
+        title: 'Invalid outcome identifier (wrong)',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: '12 foo bar'
+        }
+    }, {
+        title: 'Invalid processing rule',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'foo'
+        },
+        processingRule: {}
+    }, {
+        title: 'Invalid processing rule type (empty)',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'foo'
+        },
+        processingRule: {
+            'qti-type': ''
+        }
+    }, {
+        title: 'Invalid processing rule type (wrong)',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'foo'
+        },
+        processingRule: {
+            'qti-type': {foo: 'bar'}
+        }
+    }, {
+        title: 'Invalid processing rule (bad identifier)',
+        testModel: {},
+        outcome: {
+            'qti-type': 'outcomeDeclaration',
+            identifier: 'foo'
+        },
+        processingRule: {
+            'qti-type': 'type',
+            identifier: 'bar'
+        }
+    }];
+
+    QUnit
+        .cases(addOutcomeErrorCases)
+        .test('helpers/outcome.addOutcome()#error', function (data, assert) {
+            QUnit.expect(1);
+            assert.throws(function () {
+                outcomeHelper.addOutcome(data.testModel, data.outcome, data.processingRule);
+            }, 'An error must be thrown when the input is wrong');
+        });
+
+});

--- a/views/js/test/creator/helpers/processingRule/test.html
+++ b/views/js/test/creator/helpers/processingRule/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Authoring - processingRule Helper</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/processingRule.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiTest/test/creator/helpers/processingRule/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/creator/helpers/processingRule/test.js
+++ b/views/js/test/creator/helpers/processingRule/test.js
@@ -1,0 +1,901 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/processingRule'
+], function (_, processingRule) {
+    'use strict';
+
+    var createCases, createErrorCases;
+    var setExpressionCases;
+    var addExpressionCases;
+    var setOutcomeValueCases, setOutcomeValueErrorCases;
+    var gteCases;
+    var lteCases;
+    var divideCases;
+    var sumCases;
+    var testVariablesCases, testVariablesErrorCases;
+    var numberPresentedCases;
+    var baseValueCases;
+    var processingRuleApi = [
+        {title: 'create'},
+        {title: 'setExpression'},
+        {title: 'addExpression'},
+        {title: 'setOutcomeValue'},
+        {title: 'gte'},
+        {title: 'lte'},
+        {title: 'divide'},
+        {title: 'sum'},
+        {title: 'testVariables'},
+        {title: 'numberPresented'},
+        {title: 'baseValue'}
+    ];
+
+
+    QUnit.module('helpers/processingRule');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+        assert.equal(typeof processingRule, 'object', "The processingRule helper module exposes an object");
+    });
+
+
+    QUnit
+        .cases(processingRuleApi)
+        .test('helpers/processingRule API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof processingRule[data.title], 'function', 'The processingRule helper exposes a "' + data.title + '" function');
+        });
+
+
+    createCases = [{
+        title: 'only the type',
+        type: 'foo',
+        expected: {
+            'qti-type': 'foo'
+        }
+    }, {
+        title: 'type and identifier',
+        type: 'foo',
+        identifier: 'bar',
+        expected: {
+            'qti-type': 'foo',
+            identifier: 'bar'
+        }
+    }, {
+        title: 'type and expression',
+        type: 'foo',
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'expression'
+            }
+        }
+    }, {
+        title: 'type and array expression',
+        type: 'foo',
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression2'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression2'
+            }]
+        }
+    }, {
+        title: 'type, identifier, expression',
+        type: 'foo',
+        identifier: 'bar',
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            identifier: 'bar',
+            expression: {
+                'qti-type': 'expression'
+            }
+        }
+    }, {
+        title: 'type, identifier, array expression',
+        type: 'foo',
+        identifier: 'bar',
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression2'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            identifier: 'bar',
+            expressions: [{
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression2'
+            }]
+        }
+    }];
+
+    QUnit
+        .cases(createCases)
+        .test('helpers/processingRule.create()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.create(data.type, data.identifier, data.expression), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    createErrorCases = [{
+        title: 'Missing type',
+        identifier: 'foo'
+    }, {
+        title: 'Empty type',
+        type: '',
+        identifier: 'foo'
+    }, {
+        title: 'Wrong type',
+        type: {foo: 'bar'},
+        identifier: 'foo'
+    }, {
+        title: 'Wrong identifier',
+        type: 'foo',
+        identifier: {foo: 'bar'}
+    }, {
+        title: 'Bad identifier',
+        type: 'foo',
+        identifier: '12 foo bar'
+    }];
+
+    QUnit
+        .cases(createErrorCases)
+        .test('helpers/processingRule.create() #error', function (data, assert) {
+            QUnit.expect(1);
+            assert.throws(function () {
+                processingRule.create(data.type, data.identifier, data.expression);
+            }, 'The processingRule throws error when the input is wrong');
+        });
+
+
+    setExpressionCases = [{
+        title: 'Set expression',
+        processingRule: {
+            'qti-type': 'foo'
+        },
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'expression'
+            }
+        }
+    }, {
+        title: 'Set array expression',
+        processingRule: {
+            'qti-type': 'foo'
+        },
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression1'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression1'
+            }]
+        }
+    }, {
+        title: 'Replace expression',
+        processingRule: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'old'
+            }
+        },
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'expression'
+            }
+        }
+    }, {
+        title: 'Replace array expression',
+        processingRule: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'old1'
+            }]
+        },
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression1'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression1'
+            }]
+        }
+    }, {
+        title: 'Replace expression, existing array',
+        processingRule: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'old1'
+            }]
+        },
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            expressions: null,
+            expression: {
+                'qti-type': 'expression'
+            }
+        }
+    }, {
+        title: 'Replace array expression, existing single',
+        processingRule: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'old'
+            }
+        },
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression1'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            expression: null,
+            expressions: [{
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression1'
+            }]
+        }
+    }];
+
+    QUnit
+        .cases(setExpressionCases)
+        .test('helpers/processingRule.setExpression()', function (data, assert) {
+            QUnit.expect(1);
+            processingRule.setExpression(data.processingRule, data.expression);
+            assert.deepEqual(data.processingRule, data.expected, 'The processingRule helper has correctly updated the processing rule');
+        });
+
+
+    addExpressionCases = [{
+        title: 'Set expression',
+        processingRule: {
+            'qti-type': 'foo'
+        },
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'expression'
+            }
+        }
+    }, {
+        title: 'Set array expression',
+        processingRule: {
+            'qti-type': 'foo'
+        },
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression1'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression1'
+            }]
+        }
+    }, {
+        title: 'Add expression',
+        processingRule: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'old'
+            }
+        },
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            expression: null,
+            expressions: [{
+                'qti-type': 'old'
+            }, {
+                'qti-type': 'expression'
+            }]
+        }
+    }, {
+        title: 'Add array expression',
+        processingRule: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'old1'
+            }]
+        },
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression1'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression1'
+            }]
+        }
+    }, {
+        title: 'Add expression, existing array',
+        processingRule: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'old1'
+            }]
+        },
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'foo',
+            expressions: [{
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'old1'
+            }, {
+                'qti-type': 'expression'
+            }]
+        }
+    }, {
+        title: 'Add array expression, existing single',
+        processingRule: {
+            'qti-type': 'foo',
+            expression: {
+                'qti-type': 'old'
+            }
+        },
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression1'
+        }],
+        expected: {
+            'qti-type': 'foo',
+            expression: null,
+            expressions: [{
+                'qti-type': 'old'
+            }, {
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression1'
+            }]
+        }
+    }];
+
+    QUnit
+        .cases(addExpressionCases)
+        .test('helpers/processingRule.addExpression()', function (data, assert) {
+            QUnit.expect(1);
+            processingRule.addExpression(data.processingRule, data.expression);
+            assert.deepEqual(data.processingRule, data.expected, 'The processingRule helper has correctly updated the processing rule');
+        });
+
+
+    setOutcomeValueCases = [{
+        title: 'Identifier only',
+        identifier: 'foo',
+        expected: {
+            'qti-type': 'setOutcomeValue',
+            identifier: 'foo'
+        }
+    }, {
+        title: 'Identifier and expression',
+        identifier: 'foo',
+        expression: {
+            'qti-type': 'expression'
+        },
+        expected: {
+            'qti-type': 'setOutcomeValue',
+            identifier: 'foo',
+            expression: {
+                'qti-type': 'expression'
+            }
+        }
+    }, {
+        title: 'Identifier and array expression',
+        identifier: 'foo',
+        expression: [{
+            'qti-type': 'expression1'
+        }, {
+            'qti-type': 'expression2'
+        }],
+        expected: {
+            'qti-type': 'setOutcomeValue',
+            identifier: 'foo',
+            expressions: [{
+                'qti-type': 'expression1'
+            }, {
+                'qti-type': 'expression2'
+            }]
+        }
+    }];
+
+    QUnit
+        .cases(setOutcomeValueCases)
+        .test('helpers/processingRule.setOutcomeValue()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.setOutcomeValue(data.identifier, data.expression), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    setOutcomeValueErrorCases = [{
+        title: 'Missing identifier'
+    }, {
+        title: 'Empty identifier',
+        identifier: ''
+    }, {
+        title: 'Wrong identifier',
+        identifier: {foo: 'bar'}
+    }, {
+        title: 'Bad identifier',
+        type: 'foo',
+        identifier: '12 foo bar'
+    }];
+
+    QUnit
+        .cases(setOutcomeValueErrorCases)
+        .test('helpers/processingRule.setOutcomeValue() #error', function (data, assert) {
+            QUnit.expect(1);
+            assert.throws(function () {
+                processingRule.setOutcomeValue(data.identifier, data.expression);
+            }, 'The processingRule throws error when the input is wrong');
+        });
+
+
+    gteCases = [{
+        title: 'left and right',
+        left: {
+            'qti-type': 'left'
+        },
+        right: {
+            'qti-type': 'right'
+        },
+        expected: {
+            'qti-type': 'gte',
+            minOperands: 2,
+            maxOperands: 2,
+            acceptedCardinalities: [0],
+            acceptedBaseTypes: [2, 3],
+            expressions: [{
+                'qti-type': 'left'
+            }, {
+                'qti-type': 'right'
+            }]
+        }
+
+    }];
+
+    QUnit
+        .cases(gteCases)
+        .test('helpers/processingRule.gte()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.gte(data.left, data.right), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    lteCases = [{
+        title: 'left and right',
+        left: {
+            'qti-type': 'left'
+        },
+        right: {
+            'qti-type': 'right'
+        },
+        expected: {
+            'qti-type': 'lte',
+            minOperands: 2,
+            maxOperands: 2,
+            acceptedCardinalities: [0],
+            acceptedBaseTypes: [2, 3],
+            expressions: [{
+                'qti-type': 'left'
+            }, {
+                'qti-type': 'right'
+            }]
+        }
+
+    }];
+
+    QUnit
+        .cases(lteCases)
+        .test('helpers/processingRule.lte()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.lte(data.left, data.right), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    divideCases = [{
+        title: 'left and right',
+        left: {
+            'qti-type': 'left'
+        },
+        right: {
+            'qti-type': 'right'
+        },
+        expected: {
+            'qti-type': 'divide',
+            minOperands: 2,
+            maxOperands: 2,
+            acceptedCardinalities: [0],
+            acceptedBaseTypes: [2, 3],
+            expressions: [{
+                'qti-type': 'left'
+            }, {
+                'qti-type': 'right'
+            }]
+        }
+
+    }];
+
+    QUnit
+        .cases(divideCases)
+        .test('helpers/processingRule.divide()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.divide(data.left, data.right), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    sumCases = [{
+        title: 'single term',
+        terms: {
+            'qti-type': 'term1'
+        },
+        expected: {
+            'qti-type': 'sum',
+            minOperands: 1,
+            maxOperands: -1,
+            acceptedCardinalities: [0, 1, 2],
+            acceptedBaseTypes: [2, 3],
+            expressions: [{
+                'qti-type': 'term1'
+            }]
+        }
+    }, {
+        title: 'several terms',
+        terms: [{
+            'qti-type': 'term1'
+        }, {
+            'qti-type': 'term2'
+        }],
+        expected: {
+            'qti-type': 'sum',
+            minOperands: 1,
+            maxOperands: -1,
+            acceptedCardinalities: [0, 1, 2],
+            acceptedBaseTypes: [2, 3],
+            expressions: [{
+                'qti-type': 'term1'
+            }, {
+                'qti-type': 'term2'
+            }]
+        }
+    }];
+
+    QUnit
+        .cases(sumCases)
+        .test('helpers/processingRule.sum()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.sum(data.terms), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    testVariablesCases = [{
+        title: 'only identifier',
+        identifier: 'foo',
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: -1,
+            weightIdentifier: '',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: []
+        }
+    }, {
+        title: 'identifier and type as string',
+        identifier: 'foo',
+        type: 'integer',
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: 2,
+            weightIdentifier: '',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: []
+        }
+    }, {
+        title: 'identifier and type as constant',
+        identifier: 'foo',
+        type: 3,
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: 3,
+            weightIdentifier: '',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: []
+        }
+    }, {
+        title: 'identifier and weight',
+        identifier: 'foo',
+        weight: 'bar',
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: -1,
+            weightIdentifier: 'bar',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: []
+        }
+    }, {
+        title: 'identifier and one category to include as string',
+        identifier: 'foo',
+        includeCategories: 'bar',
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: -1,
+            weightIdentifier: '',
+            sectionIdentifier: '',
+            includeCategories: ['bar'],
+            excludeCategories: []
+        }
+    }, {
+        title: 'identifier and one category to include as array',
+        identifier: 'foo',
+        includeCategories: ['bar'],
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: -1,
+            weightIdentifier: '',
+            sectionIdentifier: '',
+            includeCategories: ['bar'],
+            excludeCategories: []
+        }
+    }, {
+        title: 'identifier and one category to exclude as string',
+        identifier: 'foo',
+        excludeCategories: 'bar',
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: -1,
+            weightIdentifier: '',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: ['bar']
+        }
+    }, {
+        title: 'identifier and one category to exclude as array',
+        identifier: 'foo',
+        excludeCategories: ['bar'],
+        expected: {
+            'qti-type': 'testVariables',
+            variableIdentifier: 'foo',
+            baseType: -1,
+            weightIdentifier: '',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: ['bar']
+        }
+    }];
+
+    QUnit
+        .cases(testVariablesCases)
+        .test('helpers/processingRule.testVariables()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.testVariables(data.identifier, data.type, data.weight, data.includeCategories, data.excludeCategories), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    testVariablesErrorCases = [{
+        title: 'Missing identifier'
+    }, {
+        title: 'Empty identifier',
+        identifier: ''
+    }, {
+        title: 'Wrong identifier',
+        identifier: {foo: 'bar'}
+    }, {
+        title: 'Wrong weight identifier',
+        identifier: 'foo',
+        weight: {foo: 'bar'}
+    }, {
+        title: 'Bad weight identifier',
+        identifier: 'foo',
+        weight: '12 foo bar'
+    }];
+
+    QUnit
+        .cases(testVariablesErrorCases)
+        .test('helpers/processingRule.testVariables() #error', function (data, assert) {
+            QUnit.expect(1);
+            assert.throws(function () {
+                processingRule.testVariables(data.identifier, data.type, data.weight, data.includeCategories, data.excludeCategories);
+            }, 'The processingRule throws error when the input is wrong');
+        });
+
+
+    numberPresentedCases = [{
+        title: 'no categories',
+        expected: {
+            'qti-type': 'numberPresented',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: []
+        }
+    }, {
+        title: 'category to include as string',
+        includeCategories: 'bar',
+        expected: {
+            'qti-type': 'numberPresented',
+            sectionIdentifier: '',
+            includeCategories: ['bar'],
+            excludeCategories: []
+        }
+    }, {
+        title: 'category to include as array',
+        includeCategories: ['bar'],
+        expected: {
+            'qti-type': 'numberPresented',
+            sectionIdentifier: '',
+            includeCategories: ['bar'],
+            excludeCategories: []
+        }
+    }, {
+        title: 'category to exclude as string',
+        excludeCategories: 'bar',
+        expected: {
+            'qti-type': 'numberPresented',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: ['bar']
+        }
+    }, {
+        title: 'category to exclude as array',
+        excludeCategories: ['bar'],
+        expected: {
+            'qti-type': 'numberPresented',
+            sectionIdentifier: '',
+            includeCategories: [],
+            excludeCategories: ['bar']
+        }
+    }];
+
+    QUnit
+        .cases(numberPresentedCases)
+        .test('helpers/processingRule.numberPresented()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.numberPresented(data.includeCategories, data.excludeCategories), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+
+    baseValueCases = [{
+        title: 'no input',
+        expected: {
+            'qti-type': 'baseValue',
+            baseType: 3,
+            value: 0
+        }
+    }, {
+        title: 'default type',
+        value: 50,
+        expected: {
+            'qti-type': 'baseValue',
+            baseType: 3,
+            value: 50
+        }
+    }, {
+        title: 'type (string) and value',
+        type: 'integer',
+        value: 50,
+        expected: {
+            'qti-type': 'baseValue',
+            baseType: 2,
+            value: 50
+        }
+    }, {
+        title: 'type (constant) and value',
+        type: 1,
+        value: 0,
+        expected: {
+            'qti-type': 'baseValue',
+            baseType: 1,
+            value: 0
+        }
+    }, {
+        title: 'type (wrong) and value',
+        type: 100,
+        value: 7,
+        expected: {
+            'qti-type': 'baseValue',
+            baseType: 3,
+            value: 7
+        }
+    }];
+
+    QUnit
+        .cases(baseValueCases)
+        .test('helpers/processingRule.baseValue()', function (data, assert) {
+            QUnit.expect(1);
+            assert.deepEqual(processingRule.baseValue(data.value, data.type), data.expected, 'The processingRule helper has created the expected processing rule');
+        });
+
+});

--- a/views/js/test/creator/helpers/scoring/scoringCategory.json
+++ b/views/js/test/creator/helpers/scoring/scoringCategory.json
@@ -1,0 +1,320 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [{
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_HISTORY",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_MATH",
+    "cardinality": 0,
+    "baseType": 3
+  }],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_HISTORY",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["history"],
+          "excludeCategories": []
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_MATH",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["math"],
+          "excludeCategories": []
+        }]
+      }
+    }]
+  },
+  "testFeedbacks": []
+}

--- a/views/js/test/creator/helpers/scoring/scoringCustom.json
+++ b/views/js/test/creator/helpers/scoring/scoringCustom.json
@@ -1,0 +1,426 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [{
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_MATH",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_HISTORY",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_MATH",
+    "cardinality": 0,
+    "baseType": 1
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_HISTORY",
+    "cardinality": 0,
+    "baseType": 1
+  }],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_MATH",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["math"],
+          "excludeCategories": []
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_HISTORY",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["history"],
+          "excludeCategories": []
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_MATH",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "",
+              "sectionIdentifier": "",
+              "includeCategories": ["math"],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": ["math"],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 70
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_HISTORY",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "",
+              "sectionIdentifier": "",
+              "includeCategories": ["history"],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": ["math"],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 70
+        }]
+      }
+    }]
+  },
+  "testFeedbacks": []
+}

--- a/views/js/test/creator/helpers/scoring/scoringCustom.json
+++ b/views/js/test/creator/helpers/scoring/scoringCustom.json
@@ -361,7 +361,7 @@
               "qti-type": "testVariables",
               "variableIdentifier": "SCORE",
               "baseType": -1,
-              "weightIdentifier": "",
+              "weightIdentifier": "WEIGHT",
               "sectionIdentifier": "",
               "includeCategories": ["math"],
               "excludeCategories": []
@@ -403,7 +403,7 @@
               "qti-type": "testVariables",
               "variableIdentifier": "SCORE",
               "baseType": -1,
-              "weightIdentifier": "",
+              "weightIdentifier": "WEIGHT",
               "sectionIdentifier": "",
               "includeCategories": ["history"],
               "excludeCategories": []

--- a/views/js/test/creator/helpers/scoring/scoringCustom.json
+++ b/views/js/test/creator/helpers/scoring/scoringCustom.json
@@ -375,7 +375,7 @@
         }, {
           "qti-type": "baseValue",
           "baseType": 3,
-          "value": 70
+          "value": 60
         }]
       }
     }, {
@@ -417,7 +417,7 @@
         }, {
           "qti-type": "baseValue",
           "baseType": 3,
-          "value": 70
+          "value": 60
         }]
       }
     }]

--- a/views/js/test/creator/helpers/scoring/scoringCut.json
+++ b/views/js/test/creator/helpers/scoring/scoringCut.json
@@ -301,7 +301,7 @@
               "qti-type": "testVariables",
               "variableIdentifier": "SCORE",
               "baseType": -1,
-              "weightIdentifier": "",
+              "weightIdentifier": "WEIGHT",
               "sectionIdentifier": "",
               "includeCategories": ["history"],
               "excludeCategories": []
@@ -343,7 +343,7 @@
               "qti-type": "testVariables",
               "variableIdentifier": "SCORE",
               "baseType": -1,
-              "weightIdentifier": "",
+              "weightIdentifier": "WEIGHT",
               "sectionIdentifier": "",
               "includeCategories": ["math"],
               "excludeCategories": []

--- a/views/js/test/creator/helpers/scoring/scoringCut.json
+++ b/views/js/test/creator/helpers/scoring/scoringCut.json
@@ -315,7 +315,7 @@
         }, {
           "qti-type": "baseValue",
           "baseType": 3,
-          "value": 70
+          "value": 60
         }]
       }
     }, {
@@ -357,7 +357,7 @@
         }, {
           "qti-type": "baseValue",
           "baseType": 3,
-          "value": 70
+          "value": 60
         }]
       }
     }]

--- a/views/js/test/creator/helpers/scoring/scoringCut.json
+++ b/views/js/test/creator/helpers/scoring/scoringCut.json
@@ -1,0 +1,366 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [{
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_HISTORY",
+    "cardinality": 0,
+    "baseType": 1
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_MATH",
+    "cardinality": 0,
+    "baseType": 1
+  }],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_HISTORY",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "",
+              "sectionIdentifier": "",
+              "includeCategories": ["history"],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": ["history"],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 70
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_MATH",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "",
+              "sectionIdentifier": "",
+              "includeCategories": ["math"],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": ["math"],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 70
+        }]
+      }
+    }]
+  },
+  "testFeedbacks": []
+}

--- a/views/js/test/creator/helpers/scoring/scoringNoOutcomes.json
+++ b/views/js/test/creator/helpers/scoring/scoringNoOutcomes.json
@@ -1,0 +1,261 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": []
+  },
+  "testFeedbacks": []
+}
+

--- a/views/js/test/creator/helpers/scoring/scoringNone.json
+++ b/views/js/test/creator/helpers/scoring/scoringNone.json
@@ -1,0 +1,321 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [{
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "OUTCOME_1",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "OUTCOME_2",
+    "cardinality": 0,
+    "baseType": 3
+  }],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "OUTCOME_1",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["math"],
+          "excludeCategories": []
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "OUTCOME_2",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": ["history"],
+          "excludeCategories": []
+        }]
+      }
+    }]
+  },
+  "testFeedbacks": []
+}
+

--- a/views/js/test/creator/helpers/scoring/scoringTotal.json
+++ b/views/js/test/creator/helpers/scoring/scoringTotal.json
@@ -1,0 +1,290 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "Test-1",
+  "title": "Test 1",
+  "outcomeDeclarations": [{
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_TOTAL",
+    "cardinality": 0,
+    "baseType": 3
+  }],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "testPart-1",
+    "navigationMode": 0,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": false
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section 1",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090611690885",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [{
+          "qti-type": "weight",
+          "identifier": "WEIGHT",
+          "value": 1
+        }],
+        "templateDefaults": {},
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090613110988",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090616225291",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 2",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i148309061819894",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 0
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i1483090620510297",
+        "categories": ["history"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://tao.dev/tao.rdf#i14830906232870100",
+        "categories": ["math"],
+        "variableMappings": {},
+        "weights": [],
+        "templateDefaults": {},
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 2
+      }],
+      "identifier": "assessmentSection-2",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_TOTAL",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": [],
+          "excludeCategories": []
+        }]
+      }
+    }]
+  },
+  "testFeedbacks": []
+}

--- a/views/js/test/creator/helpers/scoring/test.html
+++ b/views/js/test/creator/helpers/scoring/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Authoring - scoring Helper</title>
+    <base href="../../../../../../../tao/views/" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/scoring.js"></script>
+
+    <script  type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //load the test
+            require(['taoQtiTest/test/creator/helpers/scoring/test'], function(){
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/creator/helpers/scoring/test.js
+++ b/views/js/test/creator/helpers/scoring/test.js
@@ -43,11 +43,11 @@ define([
     ];
 
     var scoringReadCases = [
-        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 0},
-        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 70},
-        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 0},
-        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: 0},
-        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 70}
+        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 0, weightIdentifier: ''},
+        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 70, weightIdentifier: 'WEIGHT'},
+        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 0, weightIdentifier: ''},
+        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: 0, weightIdentifier: ''},
+        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 70, weightIdentifier: 'WEIGHT'}
     ];
 
     var scoringWriteCases = [
@@ -55,7 +55,7 @@ define([
         {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', expected: scoringCustomSample},
         {title: 'category', model: scoringCustomSample, outcomeProcessing: 'category', expected: scoringCategorySample},
         {title: 'total', model: scoringCustomSample, outcomeProcessing: 'total', expected: scoringTotalSample},
-        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 70, expected: scoringCutSample}
+        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 70, weightIdentifier: 'WEIGHT', expected: scoringCutSample}
     ];
 
 
@@ -81,13 +81,14 @@ define([
         .test('helpers/scoring.read() ', function (data, assert) {
             var model = _.cloneDeep(data.model);
 
-            QUnit.expect(3);
+            QUnit.expect(4);
 
             scoringHelper.read(model);
 
             assert.equal(typeof model.scoring, 'object', 'The scoring descriptor has been set');
             assert.equal(model.scoring.outcomeProcessing, data.outcomeProcessing, 'The right scoring processing mode has been detected');
             assert.equal(model.scoring.cutScore, data.cutScore, 'The right cutScore has been loaded');
+            assert.equal(model.scoring.weightIdentifier, data.weightIdentifier, 'The right weightIdentifier has been loaded');
         });
 
 
@@ -102,6 +103,7 @@ define([
 
             model.scoring.outcomeProcessing = data.outcomeProcessing;
             model.scoring.cutScore = data.cutScore;
+            model.scoring.weightIdentifier = data.weightIdentifier;
 
             scoringHelper.write(model);
 

--- a/views/js/test/creator/helpers/scoring/test.js
+++ b/views/js/test/creator/helpers/scoring/test.js
@@ -1,0 +1,128 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/scoring',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringNone.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringCustom.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringTotal.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringCategory.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringCut.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringNoOutcomes.json'
+], function (_,
+             scoringHelper,
+             scoringNoneSample,
+             scoringCustomSample,
+             scoringTotalSample,
+             scoringCategorySample,
+             scoringCutSample,
+             scoringNoOutcomesSample) {
+    'use strict';
+
+    var scoringHelperApi = [
+        {title: 'read'},
+        {title: 'write'}
+    ];
+
+    var scoringReadCases = [
+        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 0},
+        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 70},
+        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 0},
+        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: 0},
+        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 70}
+    ];
+
+    var scoringWriteCases = [
+        {title: 'none', model: scoringCustomSample, outcomeProcessing: 'none', expected: scoringNoOutcomesSample},
+        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', expected: scoringCustomSample},
+        {title: 'category', model: scoringCustomSample, outcomeProcessing: 'category', expected: scoringCategorySample},
+        {title: 'total', model: scoringCustomSample, outcomeProcessing: 'total', expected: scoringTotalSample},
+        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 70, expected: scoringCutSample}
+    ];
+
+
+    QUnit.module('helpers/scoring');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+        assert.equal(typeof scoringHelper, 'object', "The scoring helper module exposes an object");
+    });
+
+
+    QUnit
+        .cases(scoringHelperApi)
+        .test('helpers/scoring API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof scoringHelper[data.title], 'function', 'The scoring helper exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit
+        .cases(scoringReadCases)
+        .test('helpers/scoring.read() ', function (data, assert) {
+            var model = _.cloneDeep(data.model);
+
+            QUnit.expect(3);
+
+            scoringHelper.read(model);
+
+            assert.equal(typeof model.scoring, 'object', 'The scoring descriptor has been set');
+            assert.equal(model.scoring.outcomeProcessing, data.outcomeProcessing, 'The right scoring processing mode has been detected');
+            assert.equal(model.scoring.cutScore, data.cutScore, 'The right cutScore has been loaded');
+        });
+
+
+    QUnit
+        .cases(scoringWriteCases)
+        .test('helpers/scoring.write() ', function (data, assert) {
+            var model = _.cloneDeep(data.model);
+
+            QUnit.expect(1);
+
+            scoringHelper.read(model);
+
+            model.scoring.outcomeProcessing = data.outcomeProcessing;
+            model.scoring.cutScore = data.cutScore;
+
+            scoringHelper.write(model);
+
+            model = _.omit(model, 'scoring');
+
+            assert.deepEqual(model, data.expected, 'The score processing has been set');
+        });
+
+
+    QUnit.test('helpers/scoring.write() #error', function (assert) {
+        var model = {
+            scoring: {
+                outcomeProcessing: 'foo'
+            }
+        };
+
+        QUnit.expect(1);
+
+        assert.throws(function() {
+            scoringHelper.write(model);
+        }, 'The scoring helper should throw an error if the processing mode is unknown!');
+
+    });
+});

--- a/views/js/test/creator/helpers/scoring/test.js
+++ b/views/js/test/creator/helpers/scoring/test.js
@@ -43,11 +43,11 @@ define([
     ];
 
     var scoringReadCases = [
-        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 0, weightIdentifier: ''},
-        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 70, weightIdentifier: 'WEIGHT'},
-        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 0, weightIdentifier: ''},
-        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: 0, weightIdentifier: ''},
-        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 70, weightIdentifier: 'WEIGHT'}
+        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 70, weightIdentifier: ''},
+        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 60, weightIdentifier: 'WEIGHT'},
+        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 70, weightIdentifier: ''},
+        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: 70, weightIdentifier: ''},
+        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT'}
     ];
 
     var scoringWriteCases = [
@@ -55,7 +55,7 @@ define([
         {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', expected: scoringCustomSample},
         {title: 'category', model: scoringCustomSample, outcomeProcessing: 'category', expected: scoringCategorySample},
         {title: 'total', model: scoringCustomSample, outcomeProcessing: 'total', expected: scoringTotalSample},
-        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 70, weightIdentifier: 'WEIGHT', expected: scoringCutSample}
+        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT', expected: scoringCutSample}
     ];
 
 

--- a/views/js/test/creator/helpers/scoring/test.js
+++ b/views/js/test/creator/helpers/scoring/test.js
@@ -43,10 +43,10 @@ define([
     ];
 
     var scoringReadCases = [
-        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 70, weightIdentifier: ''},
+        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 0.5, weightIdentifier: ''},
         {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 60, weightIdentifier: 'WEIGHT'},
-        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 70, weightIdentifier: ''},
-        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: 70, weightIdentifier: ''},
+        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 0.50, weightIdentifier: ''},
+        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: .50, weightIdentifier: ''},
         {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT'}
     ];
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3545

Add authoring for the score processing.

Several modes are currently supported:
- `none`: no outcome processing.
- `custom`: a custom outcome processing is defined, it cannot be authored and the existing rules are just kept intact.
- `total`: an outcome and the related processing rules are added to compute a global score, set into the variable `SCORE_TOTAL`.
- `category`: an outcome is created for each categories (the special ones are discarded: `x-tao-*`), and the related processing rules are added to compute score per category basis. The result is stored in each `SCORE_xxx` outcome, where `xxx` is the category name.
- `cut`: a cut score must be provided, and an outcome is created for each categories (the special ones are discarded: `x-tao-*`). For each categories processing rules are added to compute score per category basis and compare it to the cut score. The boolean result is stored in each `PASS_xxx` outcome, where `xxx` is the category name.

To allow to manage the processing rules at client side, some helpers have been added, with very basic support. Not all processing rules are supported yet.