### PR TITLE
Fix/tao 3545 total cut score

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.55.1',
+    'version' => '5.55.2',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1002,6 +1002,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.50.1');
         }
 
-        $this->skip('5.50.1', '5.55.1');
+        $this->skip('5.50.1', '5.55.2');
     }
 }

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -56,29 +56,21 @@ define([
             key: 'total',
             label: __('Total score'),
             outcome: 'SCORE_TOTAL',
-            type: baseTypeHelper.FLOAT,
-            description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed, the result will take place in the SCORE_TOTAL outcome.')
-        },
-        category: {
-            key: 'category',
-            label: __('Category score'),
             prefix: 'SCORE_',
             type: baseTypeHelper.FLOAT,
-            description: __('The score will be processed per categories. A sum of all SCORE outcomes will be computed for each defined categories, the result will take place in the SCORE_xxx outcome, where xxx is the name of the category.')
+            description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed, the result will take place in the SCORE_TOTAL outcome.')
+                         + ' ' +
+                         __('If the category option is set, the score will also be processed per categories, and each results will take place in the SCORE_xxx outcome, where xxx is the name of the category.')
         },
         cut: {
             key: 'cut',
             label: __('Cut score'),
             outcome: 'PASS_TOTAL',
-            type: baseTypeHelper.BOOLEAN,
-            description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed, the result will be compared to the cut score, then the PASS_TOTAL outcome will be set accordingly.')
-        },
-        categorycut: {
-            key: 'categorycut',
-            label: __('Category cut score'),
             prefix: 'PASS_',
             type: baseTypeHelper.BOOLEAN,
-            description: __('The score will be processed per categories. An average of all SCORE outcomes will be computed for each defined categories, the result will be compared to the cut score, then the PASS_xxx outcome will be set accordingly, where xxx is the name of the category.')
+            description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed, the result will be compared to the cut score, then the PASS_TOTAL outcome will be set accordingly.')
+                         + ' ' +
+                         __('If the category option is set, the score will also be processed per categories, and each results will take place in the PASS_xxx outcome, where xxx is the name of the category.')
         }
     };
 
@@ -112,48 +104,19 @@ define([
          */
         total: function processingModeWriterTotal(model) {
             var processingMode = processingModes.total;
-            var outcome, processingRule;
-            var identifier = getOutcomeIdentifier(processingMode);
 
             // erase the existing rules, they will be replaced by those that are defined here
             removeScoring(model);
 
             // create the outcome and the rule that process the overall score
-            outcome = outcomeHelper.createOutcome(identifier, processingMode.type);
-            processingRule = processingRuleHelper.setOutcomeValue(identifier,
-                processingRuleHelper.sum(
-                    processingRuleHelper.testVariables(model.scoring.scoreIdentifier, -1, model.scoring.weightIdentifier)
-                )
-            );
+            addTotalScoreOutcomes(model, getOutcomeIdentifier(processingMode), processingMode.type);
 
-            outcomeHelper.addOutcome(model, outcome, processingRule);
-        },
-
-        /**
-         * Writes the outcomes in the scoring mode "Category score"
-         * @param {Object} model
-         */
-        category: function processingModeWriterCategory(model) {
-            var processingMode = processingModes.category;
-
-            // erase the existing rules, they will be replaced by those that are defined here
-            removeScoring(model);
-
-            // create an outcome per category
-            _.forEach(categoryHelper.listCategories(model), function (category) {
-                var outcome, processingRule;
-                var identifier = getOutcomeIdentifier(processingMode, category);
-
-                // create the outcome and the rule that process the category score
-                outcome = outcomeHelper.createOutcome(identifier, processingMode.type);
-                processingRule = processingRuleHelper.setOutcomeValue(identifier,
-                    processingRuleHelper.sum(
-                        processingRuleHelper.testVariables(model.scoring.scoreIdentifier, -1, model.scoring.weightIdentifier, category)
-                    )
-                );
-
-                outcomeHelper.addOutcome(model, outcome, processingRule);
-            });
+            // create an outcome per categories
+            if (model.scoring.categoryScore) {
+                _.forEach(categoryHelper.listCategories(model), function (category) {
+                    addTotalScoreOutcomes(model, getOutcomeIdentifier(processingMode, category), processingMode.type, category);
+                });
+            }
         },
 
         /**
@@ -168,22 +131,13 @@ define([
 
             // create the outcome and the rule that process the overall score
             addCutScoreOutcomes(model, getOutcomeIdentifier(processingMode), processingMode.type);
-        },
-
-        /**
-         * Writes the outcomes in the scoring mode "Category cut score"
-         * @param {Object} model
-         */
-        categorycut: function processingModeWriterCut(model) {
-            var processingMode = processingModes.categorycut;
-
-            // erase the existing rules, they will be replaced by those that are defined here
-            removeScoring(model);
 
             // create an outcome per category
-            _.forEach(categoryHelper.listCategories(model), function (category) {
-                addCutScoreOutcomes(model, getOutcomeIdentifier(processingMode, category), processingMode.type, category);
-            });
+            if (model.scoring.categoryScore) {
+                _.forEach(categoryHelper.listCategories(model), function (category) {
+                    addCutScoreOutcomes(model, getOutcomeIdentifier(processingMode, category), processingMode.type, category);
+                });
+            }
         }
     };
 
@@ -201,7 +155,26 @@ define([
     }
 
     /**
-     * Creates an outcome and the rule that process the category score
+     * Creates an outcome and the rule that process the total score
+     *
+     * @param {Object} model
+     * @param {String} identifier
+     * @param {String|Number} type
+     * @param {String} [category]
+     */
+    function addTotalScoreOutcomes(model, identifier, type, category) {
+        var outcome = outcomeHelper.createOutcome(identifier, type);
+        var processingRule = processingRuleHelper.setOutcomeValue(identifier,
+            processingRuleHelper.sum(
+                processingRuleHelper.testVariables(model.scoring.scoreIdentifier, -1, model.scoring.weightIdentifier, category)
+            )
+        );
+
+        outcomeHelper.addOutcome(model, outcome, processingRule);
+    }
+
+    /**
+     * Creates an outcome and the rule that process the cut score
      *
      * @param {Object} model
      * @param {String} identifier
@@ -269,6 +242,25 @@ define([
     }
 
     /**
+     * Checks if the test model contains outcomes for categories
+     * @param {Object} model
+     * @returns {Boolean}
+     */
+    function hasCategoryOutcome(model) {
+        var categoryOutcomes = false;
+        _.forEach(outcomeHelper.getOutcomeDeclarations(model), function (outcomeDeclaration) {
+            var identifier = outcomeHelper.getOutcomeIdentifier(outcomeDeclaration);
+            _.forEach(processingModes, function (processingMode) {
+                if (processingMode.prefix && processingMode.outcome !== identifier && identifier.indexOf(processingMode.prefix) === 0) {
+                    categoryOutcomes = true;
+                    return false;
+                }
+            });
+        });
+        return categoryOutcomes;
+    }
+
+    /**
      * Gets the defined cut score from the outcome rules
      * @param {Object} model
      * @returns {Number}
@@ -301,10 +293,11 @@ define([
     }
 
     /**
-     * Detects the outcome processing mode of the scoring
+     * Detects the outcome processing mode for the scoring
      * @param {Object} model
+     * @returns {String}
      */
-    function detectScoring(model) {
+    function getOutcomeProcessing(model) {
         var outcomeDeclarations = outcomeHelper.getOutcomeDeclarations(model);
         var outcomeRules = outcomeHelper.getOutcomeProcessingRules(model);
 
@@ -328,13 +321,7 @@ define([
             }
         }
 
-        model.scoring = {
-            modes: processingModes,
-            scoreIdentifier: 'SCORE',
-            weightIdentifier: getWeightIdentifier(model),
-            cutScore: getCutScore(model),
-            outcomeProcessing: outcomeProcessing
-        };
+        return outcomeProcessing;
     }
 
     /**
@@ -346,26 +333,6 @@ define([
         outcomeHelper.removeOutcomes(model, scoringOutcomes);
     }
 
-    /**
-     * Set the outcome processing outcome variables according to the chosen score processing mode
-     * @param {Object} model
-     */
-    function setScoring(model) {
-        var processingModeWriter;
-        var scoring = model.scoring;
-
-        // write the outcomes only if the mode has been set
-        if (scoring) {
-            processingModeWriter = processingModeWriters[scoring.outcomeProcessing];
-
-            if (processingModeWriter) {
-                processingModeWriter(model);
-            } else {
-                throw new Error('Unknown score processing mode: ' + scoring.outcomeProcessing);
-            }
-        }
-    }
-
     return {
         /**
          * Checks the test model against outcome processing mode.
@@ -375,7 +342,14 @@ define([
          */
         read: function read(model) {
             // detect the score processing mode and build the descriptor used to manage the UI
-            detectScoring(model);
+            model.scoring = {
+                modes: processingModes,
+                scoreIdentifier: 'SCORE',
+                weightIdentifier: getWeightIdentifier(model),
+                cutScore: getCutScore(model),
+                categoryScore: hasCategoryOutcome(model),
+                outcomeProcessing: getOutcomeProcessing(model)
+            };
         },
 
         /**
@@ -384,8 +358,19 @@ define([
          * @param {Object} model
          */
         write: function write(model) {
-            // write the score processing mode by generating the outcomes variables
-            setScoring(model);
+            var processingModeWriter;
+            var scoring = model.scoring;
+
+            // write the score processing mode by generating the outcomes variables, but only if the mode has been set
+            if (scoring) {
+                processingModeWriter = processingModeWriters[scoring.outcomeProcessing];
+
+                if (processingModeWriter) {
+                    processingModeWriter(model);
+                } else {
+                    throw new Error('Unknown score processing mode: ' + scoring.outcomeProcessing);
+                }
+            }
         }
     };
 });

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -120,6 +120,25 @@
             </div>
         </div>
 
+<!-- assessmentTest/scoring/categoryScore -->
+        <div class="grid-row test-category-score">
+            <div class="col-5">
+                <label for="test-category-score">{{__ 'Category score'}}</label>
+            </div>
+            <div class="col-6">
+                <label>
+                    <input type="checkbox" name="test-category-score" value="true" data-bind="scoring.categoryScore" data-bind-encoder="boolean" />
+                    <span class="icon-checkbox"></span>
+                </label>
+            </div>
+            <div class="col-1 help">
+                <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
+                <div class="tooltip-content">
+                    {{__ "Also compute the score per categories"}}
+                </div>
+            </div>
+        </div>
+
 <!-- assessmentTest/scoring/cutScore -->
         <div class="grid-row test-cut-score">
             <div class="col-5">

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -43,7 +43,7 @@ function($, _, hider, actions, testPartView, templates, qtiTestHelper){
         addTestPart();
 
         /**
-         * set up the exisiting test part views
+         * set up the existing test part views
          * @private
          */
         function testParts () {
@@ -69,14 +69,17 @@ function($, _, hider, actions, testPartView, templates, qtiTestHelper){
         function propHandler(propView) {
 
             var $view = propView.getView();
+            var $categoryScoreLine = $('.test-category-score', $view);
             var $cutScoreLine = $('.test-cut-score', $view);
             var $weightIdentifierLine = $('.test-weight-identifier', $view);
             var $descriptions = $('.test-outcome-processing-description', $view);
             var $title = $('.test-creator-test > h1 [data-bind=title]');
 
             function changeScoring(scoring) {
+                var noOptions = !!scoring && ['none', 'custom'].indexOf(scoring.outcomeProcessing) === -1;
                 hider.toggle($cutScoreLine, !!scoring && scoring.outcomeProcessing === 'cut');
-                hider.toggle($weightIdentifierLine, !!scoring && ['none', 'custom'].indexOf(scoring.outcomeProcessing) === -1);
+                hider.toggle($categoryScoreLine, noOptions);
+                hider.toggle($weightIdentifierLine, noOptions);
                 hider.hide($descriptions);
                 hider.show($descriptions.filter('[data-key="' + scoring.outcomeProcessing + '"]'));
             }

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -81,6 +81,11 @@ function($, _, hider, actions, testPartView, templates, qtiTestHelper){
                 hider.show($descriptions.filter('[data-key="' + scoring.outcomeProcessing + '"]'));
             }
 
+            $('[name=test-outcome-processing]', $view).select2({
+                minimumResultsForSearch: -1,
+                width: '100%'
+            });
+
             $view.on('change.binder', function (e, model) {
                 if (e.namespace === 'binder' && model['qti-type'] === 'assessmentTest') {
                     changeScoring(model.scoring);

--- a/views/js/test/creator/helpers/scoring/scoringCategoryCut.json
+++ b/views/js/test/creator/helpers/scoring/scoringCategoryCut.json
@@ -10,7 +10,18 @@
     "normalMaximum": false,
     "normalMinimum": false,
     "masteryValue": false,
-    "identifier": "PASS_TOTAL",
+    "identifier": "PASS_HISTORY",
+    "cardinality": 0,
+    "baseType": 1
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_MATH",
     "cardinality": 0,
     "baseType": 1
   }],
@@ -267,7 +278,7 @@
     "qti-type": "outcomeProcessing",
     "outcomeRules": [{
       "qti-type": "setOutcomeValue",
-      "identifier": "PASS_TOTAL",
+      "identifier": "PASS_HISTORY",
       "expression": {
         "qti-type": "gte",
         "minOperands": 2,
@@ -292,13 +303,55 @@
               "baseType": -1,
               "weightIdentifier": "WEIGHT",
               "sectionIdentifier": "",
-              "includeCategories": [],
+              "includeCategories": ["history"],
               "excludeCategories": []
             }]
           }, {
             "qti-type": "numberPresented",
             "sectionIdentifier": "",
-            "includeCategories": [],
+            "includeCategories": ["history"],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 60
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_MATH",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "WEIGHT",
+              "sectionIdentifier": "",
+              "includeCategories": ["math"],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": ["math"],
             "excludeCategories": []
           }]
         }, {

--- a/views/js/test/creator/helpers/scoring/scoringCutCategory.json
+++ b/views/js/test/creator/helpers/scoring/scoringCutCategory.json
@@ -10,6 +10,17 @@
     "normalMaximum": false,
     "normalMinimum": false,
     "masteryValue": false,
+    "identifier": "PASS_TOTAL",
+    "cardinality": 0,
+    "baseType": 1
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
     "identifier": "PASS_HISTORY",
     "cardinality": 0,
     "baseType": 1
@@ -277,6 +288,48 @@
   "outcomeProcessing": {
     "qti-type": "outcomeProcessing",
     "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_TOTAL",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "divide",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [0],
+          "acceptedBaseTypes": [2, 3],
+          "expressions": [{
+            "qti-type": "sum",
+            "minOperands": 1,
+            "maxOperands": -1,
+            "acceptedCardinalities": [0, 1, 2],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "testVariables",
+              "variableIdentifier": "SCORE",
+              "baseType": -1,
+              "weightIdentifier": "WEIGHT",
+              "sectionIdentifier": "",
+              "includeCategories": [],
+              "excludeCategories": []
+            }]
+          }, {
+            "qti-type": "numberPresented",
+            "sectionIdentifier": "",
+            "includeCategories": [],
+            "excludeCategories": []
+          }]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 60
+        }]
+      }
+    }, {
       "qti-type": "setOutcomeValue",
       "identifier": "PASS_HISTORY",
       "expression": {

--- a/views/js/test/creator/helpers/scoring/scoringTotalCategory.json
+++ b/views/js/test/creator/helpers/scoring/scoringTotalCategory.json
@@ -10,6 +10,17 @@
     "normalMaximum": false,
     "normalMinimum": false,
     "masteryValue": false,
+    "identifier": "SCORE_TOTAL",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
     "identifier": "SCORE_HISTORY",
     "cardinality": 0,
     "baseType": 3
@@ -277,6 +288,25 @@
   "outcomeProcessing": {
     "qti-type": "outcomeProcessing",
     "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_TOTAL",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": [],
+          "excludeCategories": []
+        }]
+      }
+    }, {
       "qti-type": "setOutcomeValue",
       "identifier": "SCORE_HISTORY",
       "expression": {

--- a/views/js/test/creator/helpers/scoring/test.js
+++ b/views/js/test/creator/helpers/scoring/test.js
@@ -24,18 +24,18 @@ define([
     'json!taoQtiTest/test/creator/helpers/scoring/scoringNone.json',
     'json!taoQtiTest/test/creator/helpers/scoring/scoringCustom.json',
     'json!taoQtiTest/test/creator/helpers/scoring/scoringTotal.json',
-    'json!taoQtiTest/test/creator/helpers/scoring/scoringCategory.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringTotalCategory.json',
     'json!taoQtiTest/test/creator/helpers/scoring/scoringCut.json',
-    'json!taoQtiTest/test/creator/helpers/scoring/scoringCategoryCut.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringCutCategory.json',
     'json!taoQtiTest/test/creator/helpers/scoring/scoringNoOutcomes.json'
 ], function (_,
              scoringHelper,
              scoringNoneSample,
              scoringCustomSample,
              scoringTotalSample,
-             scoringCategorySample,
+             scoringTotalCategorySample,
              scoringCutSample,
-             scoringCategoryCutSample,
+             scoringCutCategorySample,
              scoringNoOutcomesSample) {
     'use strict';
 
@@ -45,21 +45,103 @@ define([
     ];
 
     var scoringReadCases = [
-        {title: 'none', model: scoringNoneSample, outcomeProcessing: 'none', cutScore: 0.5, weightIdentifier: ''},
-        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 60, weightIdentifier: 'WEIGHT'},
-        {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 0.50, weightIdentifier: ''},
-        {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: .50, weightIdentifier: ''},
-        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT'},
-        {title: 'categorycut', model: scoringCategoryCutSample, outcomeProcessing: 'categorycut', cutScore: 60, weightIdentifier: 'WEIGHT'}
+        {
+            title: 'none',
+            model: scoringNoneSample,
+            outcomeProcessing: 'none',
+            categoryScore: false,
+            cutScore: 0.5,
+            weightIdentifier: ''
+        },
+        {
+            title: 'custom',
+            model: scoringCustomSample,
+            outcomeProcessing: 'custom',
+            categoryScore: true,
+            cutScore: 60,
+            weightIdentifier: 'WEIGHT'
+        },
+        {
+            title: 'total',
+            model: scoringTotalSample,
+            outcomeProcessing: 'total',
+            categoryScore: false,
+            cutScore: .50,
+            weightIdentifier: ''
+        },
+        {
+            title: 'total&category',
+            model: scoringTotalCategorySample,
+            outcomeProcessing: 'total',
+            categoryScore: true,
+            cutScore: 0.50,
+            weightIdentifier: ''
+        },
+        {
+            title: 'cut',
+            model: scoringCutSample,
+            outcomeProcessing: 'cut',
+            categoryScore: false,
+            cutScore: 60,
+            weightIdentifier: 'WEIGHT'
+        },
+        {
+            title: 'cut&category',
+            model: scoringCutCategorySample,
+            outcomeProcessing: 'cut',
+            categoryScore: true,
+            cutScore: 60,
+            weightIdentifier: 'WEIGHT'
+        }
     ];
 
     var scoringWriteCases = [
-        {title: 'none', model: scoringCustomSample, outcomeProcessing: 'none', expected: scoringNoOutcomesSample},
-        {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', expected: scoringCustomSample},
-        {title: 'category', model: scoringCustomSample, outcomeProcessing: 'category', expected: scoringCategorySample},
-        {title: 'total', model: scoringCustomSample, outcomeProcessing: 'total', expected: scoringTotalSample},
-        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT', expected: scoringCutSample},
-        {title: 'categorycut', model: scoringCustomSample, outcomeProcessing: 'categorycut', cutScore: 60, weightIdentifier: 'WEIGHT', expected: scoringCategoryCutSample}
+        {
+            title: 'none',
+            model: scoringCustomSample,
+            categoryScore: false,
+            outcomeProcessing: 'none',
+            expected: scoringNoOutcomesSample
+        },
+        {
+            title: 'custom',
+            model: scoringCustomSample,
+            categoryScore: false,
+            outcomeProcessing: 'custom',
+            expected: scoringCustomSample
+        },
+        {
+            title: 'total',
+            model: scoringCustomSample,
+            categoryScore: false,
+            outcomeProcessing: 'total',
+            expected: scoringTotalSample
+        },
+        {
+            title: 'total&category',
+            model: scoringCustomSample,
+            categoryScore: true,
+            outcomeProcessing: 'total',
+            expected: scoringTotalCategorySample
+        },
+        {
+            title: 'cut',
+            model: scoringCustomSample,
+            categoryScore: false,
+            outcomeProcessing: 'cut',
+            cutScore: 60,
+            weightIdentifier: 'WEIGHT',
+            expected: scoringCutSample
+        },
+        {
+            title: 'cut&category',
+            model: scoringCustomSample,
+            categoryScore: true,
+            outcomeProcessing: 'cut',
+            cutScore: 60,
+            weightIdentifier: 'WEIGHT',
+            expected: scoringCutCategorySample
+        }
     ];
 
 
@@ -85,12 +167,13 @@ define([
         .test('helpers/scoring.read() ', function (data, assert) {
             var model = _.cloneDeep(data.model);
 
-            QUnit.expect(4);
+            QUnit.expect(5);
 
             scoringHelper.read(model);
 
             assert.equal(typeof model.scoring, 'object', 'The scoring descriptor has been set');
             assert.equal(model.scoring.outcomeProcessing, data.outcomeProcessing, 'The right scoring processing mode has been detected');
+            assert.equal(model.scoring.categoryScore, data.categoryScore, 'The right categoryScore option has been set');
             assert.equal(model.scoring.cutScore, data.cutScore, 'The right cutScore has been loaded');
             assert.equal(model.scoring.weightIdentifier, data.weightIdentifier, 'The right weightIdentifier has been loaded');
         });
@@ -106,6 +189,7 @@ define([
             scoringHelper.read(model);
 
             model.scoring.outcomeProcessing = data.outcomeProcessing;
+            model.scoring.categoryScore = data.categoryScore;
             model.scoring.cutScore = data.cutScore;
             model.scoring.weightIdentifier = data.weightIdentifier;
 
@@ -126,7 +210,7 @@ define([
 
         QUnit.expect(1);
 
-        assert.throws(function() {
+        assert.throws(function () {
             scoringHelper.write(model);
         }, 'The scoring helper should throw an error if the processing mode is unknown!');
 

--- a/views/js/test/creator/helpers/scoring/test.js
+++ b/views/js/test/creator/helpers/scoring/test.js
@@ -26,6 +26,7 @@ define([
     'json!taoQtiTest/test/creator/helpers/scoring/scoringTotal.json',
     'json!taoQtiTest/test/creator/helpers/scoring/scoringCategory.json',
     'json!taoQtiTest/test/creator/helpers/scoring/scoringCut.json',
+    'json!taoQtiTest/test/creator/helpers/scoring/scoringCategoryCut.json',
     'json!taoQtiTest/test/creator/helpers/scoring/scoringNoOutcomes.json'
 ], function (_,
              scoringHelper,
@@ -34,6 +35,7 @@ define([
              scoringTotalSample,
              scoringCategorySample,
              scoringCutSample,
+             scoringCategoryCutSample,
              scoringNoOutcomesSample) {
     'use strict';
 
@@ -47,7 +49,8 @@ define([
         {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', cutScore: 60, weightIdentifier: 'WEIGHT'},
         {title: 'category', model: scoringCategorySample, outcomeProcessing: 'category', cutScore: 0.50, weightIdentifier: ''},
         {title: 'total', model: scoringTotalSample, outcomeProcessing: 'total', cutScore: .50, weightIdentifier: ''},
-        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT'}
+        {title: 'cut', model: scoringCutSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT'},
+        {title: 'categorycut', model: scoringCategoryCutSample, outcomeProcessing: 'categorycut', cutScore: 60, weightIdentifier: 'WEIGHT'}
     ];
 
     var scoringWriteCases = [
@@ -55,7 +58,8 @@ define([
         {title: 'custom', model: scoringCustomSample, outcomeProcessing: 'custom', expected: scoringCustomSample},
         {title: 'category', model: scoringCustomSample, outcomeProcessing: 'category', expected: scoringCategorySample},
         {title: 'total', model: scoringCustomSample, outcomeProcessing: 'total', expected: scoringTotalSample},
-        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT', expected: scoringCutSample}
+        {title: 'cut', model: scoringCustomSample, outcomeProcessing: 'cut', cutScore: 60, weightIdentifier: 'WEIGHT', expected: scoringCutSample},
+        {title: 'categorycut', model: scoringCustomSample, outcomeProcessing: 'categorycut', cutScore: 60, weightIdentifier: 'WEIGHT', expected: scoringCategoryCutSample}
     ];
 
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3545

Change the way to author the score processing. Instead of having several exclusive modes to compute category score or total score, the UI now offers to choose between Total or Cut score, and then allows to add the categories score.