### PR TITLE
Fix/tao 3630 dialog escape

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '5.55.2',
+    'version' => '5.55.3',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1002,6 +1002,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.50.1');
         }
 
-        $this->skip('5.50.1', '5.55.2');
+        $this->skip('5.50.1', '5.55.3');
     }
 }

--- a/views/js/test/runner/plugins/content/dialog/test.js
+++ b/views/js/test/runner/plugins/content/dialog/test.js
@@ -119,7 +119,9 @@ define([
         dialogAlert.on('create', function(message, dlg) {
             assert.ok(true, 'A dialog has been created');
             assert.equal(message, expectedMessage, 'The expected message has been displayed');
-            dlg.hide();
+            _.defer(function() {
+                dlg.hide();
+            });
         });
 
         dialogAlert.on('close', function() {
@@ -153,7 +155,9 @@ define([
         dialogAlert.on('create', function(message, dlg) {
             assert.ok(true, 'A dialog has been created');
             assert.equal(message, expectedMessage, 'The expected message has been displayed');
-            dlg.hide();
+            _.defer(function() {
+                dlg.hide();
+            });
         });
 
         dialogAlert.on('close', function() {
@@ -270,7 +274,9 @@ define([
         dialogConfirm.on('create', function(message, dlg) {
             assert.ok(true, 'A dialog has been created');
             assert.equal(message, expectedMessage, 'The expected message has been displayed');
-            dlg.hide();
+            _.defer(function() {
+                dlg.hide();
+            });
         });
 
         dialogConfirm.on('close', function() {
@@ -306,7 +312,9 @@ define([
         dialogConfirm.on('create', function(message, dlg) {
             assert.ok(true, 'A dialog has been created');
             assert.equal(message, expectedMessage, 'The expected message has been displayed');
-            dlg.hide();
+            _.defer(function() {
+                dlg.hide();
+            });
         });
 
         dialogConfirm.on('close', function() {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3630

Fix the issue that allows to cancel a dialog box with a wrong reason.
Previously, the alert and confirms dialogs triggered by the Test Runner directly called the callbacks and provided the reason of the close. Since the close action can be triggered by shortcut, the provided reason is not accurate (said `api` when closed by shortcut). 
Due do that issue, the dialog consumer cannot be informed if the dialog has been close using the `ESC` key, and depending on browser that can lead to behaviour issue. 
For instance, in Firefox the `ESC` key is always related to cancel, so we cannot go in full screen mode after a dialog alert, unless the user hit other shortcut to acknowledge or click a button, as the `requestFullscreen` API will fail.
Thanks to the reason knowledge, the dialog consumer can adapt its behaviour.