### PR TITLE
plugin tester

### DIFF
--- a/views/js/test/runner/plugins/pluginTester.js
+++ b/views/js/test/runner/plugins/pluginTester.js
@@ -1,0 +1,288 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Christophe Noël <christophe@taotesting.com>
+ */
+define([
+    'lodash',
+    'helpers',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock'
+], function(_, helpers, runnerFactory, providerMock) {
+    'use strict';
+
+    var providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    return function pluginTesterFactory(config) {
+        var QUnit = config.QUnit,
+            pluginName = config.pluginName,
+            pluginFactory = config.pluginFactory;
+
+        var pluginTester;
+
+        pluginTester = {
+            testModule: function testModule() {
+                QUnit.module(pluginName + ': pluginFactory');
+
+                QUnit.test('module', function(assert) {
+                    var runner = runnerFactory(providerName);
+
+                    assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
+                    assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
+                    assert.notStrictEqual(pluginFactory(runner), pluginFactory(runner), 'The plugin factory provides a different instance on each call');
+                });
+            },
+
+            testApi: function testApi() {
+                var pluginApi = [
+                    { name : 'init',            title : 'init' },
+                    { name : 'render',          title : 'render' },
+                    { name : 'finish',          title : 'finish' },
+                    { name : 'destroy',         title : 'destroy' },
+                    { name : 'trigger',         title : 'trigger' },
+                    { name : 'getTestRunner',   title : 'getTestRunner' },
+                    { name : 'getAreaBroker',   title : 'getAreaBroker' },
+                    { name : 'getConfig',       title : 'getConfig' },
+                    { name : 'setConfig',       title : 'setConfig' },
+                    { name : 'getState',        title : 'getState' },
+                    { name : 'setState',        title : 'setState' },
+                    { name : 'show',            title : 'show' },
+                    { name : 'hide',            title : 'hide' },
+                    { name : 'enable',          title : 'enable' },
+                    { name : 'disable',         title : 'disable' }
+                ];
+
+                QUnit.module(pluginName + ': plugin API test');
+
+                QUnit
+                    .cases(pluginApi)
+                    .test('plugin API ', function(data, assert) {
+                        var runner = runnerFactory(providerName);
+                        var plugin = pluginFactory(runner);
+                        QUnit.expect(1);
+                        assert.equal(typeof plugin[data.name], 'function', 'The pluginFactory instances expose a "' + data.name + '" function');
+                    });
+            },
+
+
+            testNavigationButton: function testNavigationButton(buttonName, buttonSelector) {
+                QUnit.asyncTest(pluginName + ', button ' + buttonName + ': render/enable/disable/destroy', function(assert) {
+                    var runner = runnerFactory(providerName),
+                        areaBroker = runner.getAreaBroker(),
+                        plugin = pluginFactory(runner, areaBroker),
+                        $container = areaBroker.getNavigationArea();
+
+                    QUnit.expect(11);
+
+                    plugin.init()
+                        .then(function() {
+                            assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
+
+                            // rendering
+                            return plugin.render().then(function() {
+                                var $button = $container.find(buttonSelector);
+
+                                assert.equal(plugin.getState('ready'), true, 'The plugin is ready');
+                                assert.equal($button.length, 1, 'The plugin button has been inserted in the right place');
+                                assert.equal($button.hasClass('disabled'), true, 'The button has been rendered disabled');
+
+                                // enabling
+                                return plugin.enable().then(function() {
+                                    assert.equal(plugin.getState('enabled'), true, 'The plugin is enabled');
+                                    assert.equal($button.hasClass('disabled'), false, 'The button is not disabled');
+
+                                    // disabling
+                                    return plugin.disable().then(function() {
+                                        assert.equal(plugin.getState('enabled'), false, 'The plugin is disabled');
+                                        assert.equal($button.hasClass('disabled'), true, 'The button is disabled');
+                                        assert.equal($button.hasClass('active'), false, 'The button is turned off');
+
+                                        // destroying
+                                        return plugin.destroy().then(function() {
+                                            $button = $container.find(plugin.$button);
+
+                                            assert.equal(plugin.getState('init'), false, 'The plugin is destroyed');
+                                            assert.equal($button.length, 0, 'The button has been removed');
+                                            QUnit.start();
+                                        });
+                                    });
+                                });
+                            });
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'Unexpected failure : ' + err.message);
+                            QUnit.start();
+                        });
+                });
+
+                QUnit.asyncTest(pluginName + ', button ' + buttonName + ': show/hide', function(assert) {
+                    var runner = runnerFactory(providerName),
+                        areaBroker = runner.getAreaBroker(),
+                        plugin = pluginFactory(runner, areaBroker),
+                        $container = areaBroker.getNavigationArea();
+
+                    QUnit.expect(7);
+
+                    plugin.init()
+                        .then(function() {
+                            return plugin.render().then(function() {
+                                var $button = $container.find(buttonSelector);
+
+                                plugin.setState('visible', true);
+
+                                assert.equal(plugin.getState('ready'), true, 'The plugin is ready');
+                                assert.equal($button.length, 1, 'The plugin button has been inserted in the right place');
+                                assert.equal(plugin.getState('visible'), true, 'The plugin is visible');
+
+                                // hiding
+                                return plugin.hide().then(function() {
+                                    assert.equal(plugin.getState('visible'), false, 'The plugin is not visible');
+                                    assert.equal($button.css('display'), 'none', 'The plugin element is hidden');
+
+                                    // showing
+                                    return plugin.show().then(function() {
+                                        assert.equal(plugin.getState('visible'), true, 'The plugin is visible');
+                                        assert.notEqual($button.css('display'), 'none', 'The plugin element is visible');
+
+                                        QUnit.start();
+                                    });
+                                });
+                            });
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'Unexpected failure : ' + err.message);
+                            QUnit.start();
+                        });
+                });
+            },
+
+
+            testToolboxButton: function testToolboxButton(buttonName, buttonSelector) {
+                QUnit.asyncTest(pluginName + ', button ' + buttonName + ': render/enable/disable/destroy', function (assert) {
+                    var runner      = runnerFactory(providerName),
+                        areaBroker  = runner.getAreaBroker(),
+                        plugin      = pluginFactory(runner, areaBroker),
+                        toolbox     = areaBroker.getToolbox(),
+                        $container  = areaBroker.getToolboxArea(),
+                        $button;
+
+                    QUnit.expect(12);
+
+                    plugin.init()
+                        .then(function () {
+                            assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
+
+                            // toolbox rendering
+                            toolbox.render($container);
+
+                            $button = $container.find(buttonSelector);
+
+                            assert.equal($button.length, 1, 'The plugin button has been inserted in the right place');
+                            assert.equal($button.hasClass('disabled'), true, 'The button has been rendered disabled');
+
+                            // Plugin rendering
+                            return plugin.render().then(function () {
+                                assert.equal(plugin.getState('ready'), true, 'The plugin is ready');
+
+                                // enabling
+                                return plugin.enable().then(function () {
+                                    assert.equal(plugin.getState('enabled'), true, 'The plugin is enabled');
+                                    assert.equal($button.hasClass('disabled'), false, 'The button is not disabled');
+
+                                    // disabling
+                                    return plugin.disable().then(function () {
+                                        assert.equal(plugin.getState('enabled'), false, 'The plugin is disabled');
+                                        assert.equal($button.hasClass('disabled'), true, 'The button is disabled');
+                                        assert.equal($button.hasClass('active'), false, 'The button is turned off');
+
+                                        // plugin destroying
+                                        return plugin.destroy().then(function () {
+                                            $button = $container.find(buttonSelector);
+
+                                            assert.equal(plugin.getState('init'), false, 'The plugin is destroyed');
+                                            assert.equal($button.length, 1, 'The plugin button has not been destroyed by the plugin');
+
+                                            // toolbox destroying
+                                            toolbox.destroy();
+
+                                            $button = $container.find(buttonSelector);
+
+                                            assert.equal($button.length, 0, 'The button has been removed');
+                                            QUnit.start();
+                                        });
+                                    });
+                                });
+                            });
+                        })
+                        .catch(function (err) {
+                            assert.ok(false, 'Unexpected failure : ' + err.message);
+                            QUnit.start();
+                        });
+                });
+
+                QUnit.asyncTest(pluginName + ', button ' + buttonName + ': show/hide', function (assert) {
+                    var runner      = runnerFactory(providerName),
+                        areaBroker  = runner.getAreaBroker(),
+                        plugin      = pluginFactory(runner, areaBroker),
+                        toolbox     = areaBroker.getToolbox(),
+                        $container  = areaBroker.getToolboxArea(),
+                        $button;
+
+                    QUnit.expect(7);
+
+                    plugin.init()
+                        .then(function () {
+                            assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
+
+                            // toolbox rendering
+                            toolbox.render($container);
+
+                            $button = $container.find(buttonSelector);
+
+                            plugin.setState('visible', true);
+
+                            assert.equal($button.length, 1, 'The plugin button has been inserted in the right place');
+                            assert.equal(plugin.getState('visible'), true, 'The plugin is visible');
+
+                            // hiding
+                            return plugin.hide().then(function () {
+                                assert.equal(plugin.getState('visible'), false, 'The plugin is not visible');
+                                assert.equal($button.css('display'), 'none', 'The plugin element is hidden');
+
+                                // showing
+                                return plugin.show().then(function () {
+                                    assert.equal(plugin.getState('visible'), true, 'The plugin is visible');
+                                    assert.notEqual($button.css('display'), 'none', 'The plugin element is visible');
+
+                                    QUnit.start();
+                                });
+                            });
+                        })
+                        .catch(function (err) {
+                            assert.ok(false, 'Unexpected failure : ' + err.message);
+                            QUnit.start();
+                        });
+                });
+            }
+
+        };
+
+        return pluginTester;
+    };
+});

--- a/views/js/test/runner/plugins/sample/plugin.js
+++ b/views/js/test/runner/plugins/sample/plugin.js
@@ -1,0 +1,158 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Sample test runner plugin
+ *
+ * @author Christophe Noël <christophe@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'i18n',
+    'taoTests/runner/plugin',
+    'ui/hider',
+    'tpl!taoQtiTest/runner/plugins/templates/button'
+], function ($, _, __, pluginFactory, hider, buttonTpl) {
+    'use strict';
+
+    /**
+     * Returns the configured plugin
+     */
+    return pluginFactory({
+
+        name: 'pluginSample',
+
+        /**
+         * Initialize the plugin (called during runner's init)
+         */
+        init: function init() {
+            var self = this;
+
+            var testRunner = this.getTestRunner();
+            var testData = testRunner.getTestData() || {};
+            var testConfig = testData.config || {};
+            var pluginsConfig = testConfig.plugins || {};
+            // var config = _.defaults(pluginsConfig.formula || {}, defaults);
+            var areaBroker = testRunner.getAreaBroker();
+
+            /**
+             * Checks if the plugin is currently available
+             * activate with category: x-tao-option-formula
+             * @returns {Boolean}
+             */
+            function isEnabled() {
+                var context = testRunner.getTestContext();
+                return context && context.options && !!context.options.formula;
+            }
+
+            /**
+             * Is plugin activated ? if not, then we hide the plugin
+             */
+            function togglePlugin() {
+                if (isEnabled()) {
+                    self.show();
+                } else {
+                    self.hide();
+                }
+            }
+
+            // build navigation button (detached)
+            this.$navButton = $(buttonTpl({
+                control : 'navButton',
+                title : __('Navigation button'),
+                text : __('Navigation button')
+            }));
+
+            // build toolbox entry
+            this.toolboxButton = areaBroker.getToolbox().createEntry({
+                control : 'toolboxButton',
+                title : __('Toolbox button'),
+                text : __('Toolbox button')
+            });
+
+            // start disabled
+            togglePlugin();
+            this.disable();
+
+            // update plugin state based on changes
+            testRunner
+                .on('loaditem', togglePlugin)
+                .on('enabletools renderitem', function () {
+                    self.enable();
+                })
+                .on('disabletools unloaditem', function () {
+                    self.disable();
+                });
+        },
+
+        /**
+         * Called during the runner's render phase
+         */
+        render: function render() {
+            var $container = this.getAreaBroker().getNavigationArea();
+            $container.append(this.$navButton);
+        },
+
+        /**
+         * Called during the runner's destroy phase
+         */
+        destroy: function destroy() {
+            this.$navButton.remove();
+        },
+
+        /**
+         * Enable the button
+         */
+        enable: function enable() {
+            this.$navButton
+                .removeProp('disabled')
+                .removeClass('disabled');
+
+            this.toolboxButton.enable();
+        },
+
+        /**
+         * Disable the button
+         */
+        disable: function disable() {
+            this.$navButton
+                .prop('disabled', true)
+                .addClass('disabled');
+
+            this.toolboxButton.disable();
+        },
+
+        /**
+         * Show the button
+         */
+        show: function show() {
+            hider.show(this.$navButton);
+
+            this.toolboxButton.show();
+        },
+
+        /**
+         * Hide the button
+         */
+        hide: function hide() {
+            hider.hide(this.$navButton);
+
+            this.toolboxButton.hide();
+        }
+    });
+});

--- a/views/js/test/runner/plugins/sample/test.html
+++ b/views/js/test/runner/plugins/sample/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Runner Plugin - Sample</title>
+    <link rel="stylesheet" type="text/css" href="/tao/views/js/lib/qunit/qunit.css">
+    <link rel="stylesheet" type="text/css" href="/tao/views/css/tao-main-style.css">
+    <script type="text/javascript" src="/tao/views/js/lib/require.js"></script>
+    <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="/tao/views/js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="test/views/js/runner/plugins/sample/plugin.js"></script>
+
+    <script  type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //load the test
+            require(['taoQtiTest/test/runner/plugins/sample/test'], function(){
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/runner/plugins/sample/test.js
+++ b/views/js/test/runner/plugins/sample/test.js
@@ -1,0 +1,48 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+/**
+ * Test the pluginTester with the a sample plugin
+ *
+ * @author Christophe Noël <christophe@taotesting.com>
+ */
+
+define([
+    'jquery',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/test/runner/plugins/sample/plugin',
+    'taoQtiTest/test/runner/plugins/pluginTester'
+], function($, runnerFactory, providerMockFactory, pluginFactory, pluginTesterFactory) {
+    'use strict';
+
+    var pluginTester = pluginTesterFactory({
+        QUnit: QUnit,
+        pluginName: 'Sample',
+        pluginFactory: pluginFactory
+    });
+
+    var providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMockFactory());
+
+    pluginTester.testModule();
+    pluginTester.testApi();
+    pluginTester.testNavigationButton('navButton', '[data-control="navButton"]');
+    pluginTester.testToolboxButton('toolboxButton', '[data-control="toolboxButton"]');
+
+
+});


### PR DESCRIPTION
**Rationale:**
While working on plugins refactoring the latest sprint I noticed that instead of encouraging refactoring, our test suite - in this specific area - actually made the process more painful than it should have been. Most of our plugin tests indeed suffer from [tests smells](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.19.5499&rep=rep1&type=pdf), and especially LOT of code duplication. While it can be justified sometimes in unit tests, I think this is not the case here.

That's why I propose this little helper to factor the tests that are not related to a specific plugin implementation, but rather concern the fact that the plugin is correctly implemented as a plugin.