### PR TITLE
Test Runner Timer target

### DIFF
--- a/config/default/QtiRunnerConfig.conf.php
+++ b/config/default/QtiRunnerConfig.conf.php
@@ -1,0 +1,21 @@
+<?php
+/**  
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * 
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ *               
+ * 
+ */  
+return new oat\taoQtiTest\models\runner\config\QtiRunnerConfig();

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '6.4.2',
+    'version' => '6.5.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -124,27 +124,6 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         $serviceContext->setServiceManager($this->getServiceManager());
         $serviceContext->setTestConfig($this->getTestConfig());
 
-        $testSession = $serviceContext->getTestSession();
-        if ($testSession instanceof TestSession) {
-
-            $config = $this->getTestConfig()->getConfigValue('timer');
-
-            // sets the target from which computes the durations.
-            if (isset($config['target'])) {
-                switch (strtolower($config['target'])) {
-                    case 'client':
-                        $target = TimePoint::TARGET_CLIENT;
-                        break;
-
-                    case 'server':
-                    default:
-                        $target = TimePoint::TARGET_SERVER;
-                }
-
-                $testSession->setTimerTarget($target);
-            }
-        }
-
         if ($check) {
             // will throw exception if the test session is not valid
             $this->check($serviceContext);
@@ -215,7 +194,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     public function getTestConfig()
     {
         if (is_null($this->testConfig)) {
-            $this->testConfig = new QtiRunnerConfig();
+            $this->testConfig = $this->getServiceLocator()->get(QtiRunnerConfig::SERVICE_ID);
         }
         return $this->testConfig;
     }
@@ -402,7 +381,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $response['numberRubrics'] = count($route->current()->getRubricBlockRefs());
 
                 // append dynamic options
-                $response['options'] = $config->getOptions($context);
+                $response['options'] = $config->getTestOptions($context);
             }
 
         } else {

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -22,14 +22,17 @@
 
 namespace oat\taoQtiTest\models\runner\config;
 
+use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 
 /**
  * Class QtiRunnerOptions
  * @package oat\taoQtiTest\models\runner\options
  */
-class QtiRunnerConfig implements RunnerConfig
+class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
 {
+    const SERVICE_ID = 'taoQtiTest/QtiRunnerConfig';
+    
     /**
      * The test runner config
      * @var array
@@ -48,7 +51,7 @@ class QtiRunnerConfig implements RunnerConfig
      */
     protected function buildConfig() {
         // get the raw server config, using the old notation
-        $rawConfig = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        $rawConfig = $this->getServiceManager()->get('taoQtiTest/testRunner');
 
         // build the test config using the new notation
         return [
@@ -155,7 +158,7 @@ class QtiRunnerConfig implements RunnerConfig
      * @param RunnerServiceContext $context The test context
      * @return mixed
      */
-    public function getOptions(RunnerServiceContext $context)
+    public function getTestOptions(RunnerServiceContext $context)
     {
         if (is_null($this->options)) {
             // build the test config using the new notation

--- a/models/classes/runner/config/RunnerConfig.php
+++ b/models/classes/runner/config/RunnerConfig.php
@@ -48,5 +48,5 @@ interface RunnerConfig
      * @param RunnerServiceContext $context The test context
      * @return mixed
      */
-    public function getOptions(RunnerServiceContext $context);
+    public function getTestOptions(RunnerServiceContext $context);
 }

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -20,6 +20,7 @@
 
 namespace oat\taoQtiTest\models\runner\session;
 
+use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
 use oat\taoQtiTest\models\runner\time\QtiTimeConstraint;
 use oat\taoQtiTest\models\runner\time\QtiTimer;
 use oat\taoQtiTest\models\runner\time\QtiTimeStorage;
@@ -51,7 +52,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
      * The target from which compute the durations
      * @var int
      */
-    protected $timerTarget = TimePoint::TARGET_SERVER;
+    protected $timerTarget;
 
     /**
      * A temporary cache for computed durations
@@ -111,6 +112,21 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
      */
     public function getTimerTarget()
     {
+        if (is_null($this->timerTarget)) {
+            $testConfig = $this->getServiceLocator()->get(QtiRunnerConfig::SERVICE_ID);
+            $config = $testConfig->getConfigValue('timer');
+            switch (strtolower($config['target'])) {
+                case 'client':
+                    $target = TimePoint::TARGET_CLIENT;
+                    break;
+
+                case 'server':
+                default:
+                    $target = TimePoint::TARGET_SERVER;
+            }
+
+            $this->setTimerTarget($target);
+        }
         return $this->timerTarget;
     }
 
@@ -228,7 +244,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     public function getTimerDuration($identifier, $target = 0)
     {
         if (!$target) {
-            $target = $this->timerTarget;
+            $target = $this->getTimerTarget();
         }
 
         $durationKey = $target . '-';

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -22,6 +22,7 @@ namespace oat\taoQtiTest\scripts\update;
 use oat\oatbox\service\ServiceNotFoundException;
 use oat\taoQtiTest\models\export\metadata\TestExporter;
 use oat\taoQtiTest\models\export\metadata\TestMetadataExporter;
+use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
 use oat\taoQtiTest\models\SessionStateService;
 use oat\taoQtiTest\models\TestModelService;
 use oat\taoQtiTest\models\TestCategoryRulesService;
@@ -1053,5 +1054,13 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('6.3.1', '6.4.2');
+        
+        if ($this->isVersion('6.4.2')) {
+            $service = new QtiRunnerConfig();
+            $service->setServiceManager($this->getServiceManager());
+            $this->getServiceManager()->register(QtiRunnerConfig::SERVICE_ID, $service);
+
+            $this->setVersion('6.5.0');
+        }
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3788

Make the class QtiRunnerConfig a service.

Load the timer target from the config when needed.