### PR TITLE
Fix/tao 3835 redirect session end

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '6.5.0',
+    'version' => '6.5.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1062,5 +1062,6 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('6.5.0');
         }
+        $this->skip('6.5.0', '6.5.1');
     }
 }

--- a/views/js/controller/runner/runner.js
+++ b/views/js/controller/runner/runner.js
@@ -18,6 +18,7 @@
 
 /**
  * Test runner controller entry
+ *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
@@ -48,60 +49,17 @@ define([
         'testDefinition',
         'testCompilation',
         'serviceCallId',
+        'bootstrap',
         'exitUrl',
         'plugins'
     ];
 
-
-
-    /*
-     *TODO provider registration should be loaded dynamically
+    /**
+     * TODO provider registration should be loaded dynamically
+     * the same way the proxy and the plugins are loaded
      */
     runner.registerProvider('qti', qtiProvider);
     communicator.registerProvider('poll', pollProvider);
-
-
-
-    /**
-     * Initializes and launches the test runner
-     * @param {Object} config
-     */
-    function initRunner(config) {
-        var plugins = pluginLoader.getPlugins();
-        var reason = '';
-
-        config = _.defaults(config, {
-            renderTo: $('.runner')
-        });
-
-        //instantiate the QtiTestRunner
-        runner('qti', plugins, config)
-            .on('error', onError)
-            .on('ready', function () {
-                _.defer(function () {
-                    $('.runner').removeClass('hidden');
-                });
-            })
-            .on('pause', function(data) {
-                if (data && data.reason) {
-                    // change exit Url
-                    reason = data.reason;
-                }
-            })
-            .after('destroy', function () {
-
-                // at the end, we are redirected to the exit URL
-                var url = config.exitUrl;
-                if (reason && reason.length) {
-                    url = urlUtil.build(url, {
-                        warning: reason
-                    });
-                }
-
-                window.location = url;
-            })
-            .init();
-    }
 
     /**
      * The runner controller
@@ -111,36 +69,64 @@ define([
         /**
          * Controller entry point
          *
-         * @param {Object} options - the testRunner options
-         * @param {String} options.testDefinition
-         * @param {String} options.testCompilation
-         * @param {String} options.serviceCallId
-         * @param {Object} options.bootstrap
-         * @param {String} options.exitUrl - the full URL where to return at the final end of the test
+         * @param {Object}   options - the testRunner options
+         * @param {String}   options.testDefinition - the test definition id
+         * @param {String}   options.testCompilation - the test compilation id
+         * @param {String}   options.serviceCallId - the service call id
+         * @param {Object}   options.bootstrap - contains the extension and the controller to call
+         * @param {String}   options.exitUrl - the full URL where to return at the final end of the test
+         * @param {Object[]} options.plugins - the collection of plugins to load
          */
         start: function start(options) {
 
-            var logger = loggerFactory('controller/runner', loggerFactory.levels.warn, options);
+            var exitReason;
+            var $container = $('.runner');
+            var logger     = loggerFactory('controller/runner', { runnerOptions : options });
 
+            /**
+             * Does the option exists ?
+             * @param {String} name - the option key
+             * @returns {Boolean}
+             */
             var hasOption = function hasOption(name){
                 return typeof options[name] !== 'undefined';
             };
 
             /**
-            * Catches errors
-            * @param {Object} err
-            */
-            var onError = function onError(err) {
-
-                loadingBar.stop();
-
-                feedback().error(err.message);
-
-                logger.error(err);
+             * Exit the test runner using the configured exitUrl
+             * @param {String} [reason] - to add a warning once left
+             */
+            var exit = function exit(reason){
+                var url = options.exitUrl;
+                if (reason) {
+                    url = urlUtil.build(url, {
+                        warning: reason
+                    });
+                }
+                window.location = url;
             };
 
+            /**
+             * Handles errors
+             * @param {Error} err - the thrown error
+             * @param {String} [displayMessage] - an alternate message to display
+             */
+            var onError = function onError(err, displayMessage) {
+                loadingBar.stop();
+                logger.error({ displayMessage : displayMessage }, err);
 
+                if(err.code === 403) {
+                    //we just leave if any 403 occurs
+                    return exit();
+                }
+                feedback().error(displayMessage || err.message, { timeout : -1 });
+            };
 
+            /**
+             * Load the plugins dynamically
+             * @param {Object[]} plugins - the collection of plugins to load
+             * @returns {Promise} resolves with the list of loaded plugins
+             */
             var loadPlugins = function loadPlugins(plugins){
                 var pluginLoader = pluginLoaderFactory();
 
@@ -154,6 +140,10 @@ define([
                         });
             };
 
+            /**
+             * Load the configured proxy provider
+             * @returns {Promise} resolves with the name of the proxy provider
+             */
             var loadProxy = function loadProxy(){
                 return proxyLoader();
             };
@@ -162,38 +152,48 @@ define([
 
             // verify required options
             if( ! _.every(requiredOptions, hasOption)) {
-                return onError({
-                    success: false,
-                    code: 0,
-                    type: 'error',
-                    message: __('Missing required option %s', name)
-                });
-
+                return onError(new TypeError(__('Missing required option %s', name)));
             }
 
+            //load the plugins and the proxy provider
+            Promise
+                .all([
+                    loadPlugins(options.plugins),
+                    loadProxy()
+                ])
+                .then(function (results) {
 
+                    var plugins = results[0];
+                    var proxyProviderName = results[1];
 
+                    var config = _.omit(options, 'plugins');
+                    config.proxyProvider = proxyProviderName;
+                    config.renderTo      = $container;
 
+                    logger.debug({ config: config, plugins: plugins}, 'Start test runner');
 
-                //load the plugins and the proxy provider
-                Promise
-                    .all([
-
-                        pluginLoader.load()
-                    ])
-                    .then(function () {
-
-                        //here we initialize the Test Runner
-                        initRunner(_.omit(startOptions, 'plugins'));
-                    })
-                    .catch(function () {
-                        onError({
-                            success: false,
-                            code: 0,
-                            type: 'error',
-                            message: __('Plugin dependency error!')
-                        });
-                    });
+                    //instantiate the QtiTestRunner
+                    runner('qti', plugins, config)
+                        .on('error', onError)
+                        .on('ready', function () {
+                            _.defer(function () {
+                                $container.removeClass('hidden');
+                            });
+                        })
+                        .on('pause', function(data) {
+                            if (data && data.reason) {
+                                exitReason = data.reason;
+                            }
+                        })
+                        .after('destroy', function () {
+                            // at the end, we are redirected to the exit URL
+                            exit(exitReason);
+                        })
+                        .init();
+                })
+                .catch(function(err){
+                    onError(err, __('An error occured during the test iniialization!'));
+                });
         }
     };
 });

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -79,12 +79,15 @@ define([
                         var headers = {};
                         var tokenHandler = self.getTokenHandler();
                         var token;
+                        var noop;
+
                         if (!noToken) {
                             token = tokenHandler.getToken();
                             if (token) {
                                 headers['X-Auth-Token'] = token;
                             }
                         }
+
                         $.ajax({
                             url: url,
                             type: reqParams ? 'POST' : 'GET',
@@ -93,7 +96,7 @@ define([
                             headers: headers,
                             async: true,
                             dataType: 'json',
-                            contentType: contentType || undefined,
+                            contentType: contentType || noop,
                             timeout: self.configStorage.getTimeout()
                         })
                         .done(function(data) {
@@ -111,18 +114,20 @@ define([
                             var data;
                             try {
                                 data = JSON.parse(jqXHR.responseText);
-                            } catch (e) {
-                                data = {
-                                    success: false,
-                                    source: 'network',
-                                    purpose: 'proxy',
-                                    context: this,
-                                    code: jqXHR.status,
-                                    type: textStatus || 'error',
-                                    message: errorThrown || __('An error occurred!')
-                                };
+                            } catch(err) {
+                                data = {};
                             }
 
+                            data = _.defaults(data, {
+                                success: false,
+                                source: 'network',
+                                cause : url,
+                                purpose: 'proxy',
+                                context: this,
+                                code: jqXHR.status,
+                                type: textStatus || 'error',
+                                message: errorThrown || __('An error occurred!')
+                            });
                             if (data.token) {
                                 tokenHandler.setToken(data.token);
                             } else if (!noToken) {


### PR DESCRIPTION
Refactor the controller to have a better error handling. If any 403 we redirect the user to the `exitUrl`. This will help in the situation of the original bug so users will be redirected to the correct url.

Note [on exit](https://github.com/oat-sa/extension-tao-testqti/compare/develop...fix/TAO-3835_redirect-session-end?expand=1#diff-11034f9ca39a14fd1bc50ce0ddd29a83R120)  my first intention was to provide an exit reason, but due to the redirection mechanism, the message is kept even after login again...