### PR TITLE
Feature/tao 3851 remove popup shortcut

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -428,10 +428,7 @@ return array(
         'previous' => [
             'trigger' => 'K'
         ],
-        'dialog' => [
-            'accept' => 'Enter',
-            'reject' => 'Esc'
-        ],
+        'dialog' => [],
         'magnifier' => array(
             'toggle' => 'L',
             'in' => 'Shift+I',

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '6.7.1',
+    'version' => '6.8.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'requires' => array(
         'taoTests' => '>=3.7.0',
         'taoQtiItem' => '>=6.12.0',
-        'tao'        => '>=7.70.0'
+        'tao'        => '>=7.71.0'
     ),
 	'models' => array(
 		'http://www.tao.lu/Ontologies/TAOTest.rdf'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1055,7 +1055,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
         $this->skip('6.3.1', '6.4.3');
 
-         if ($this->isVersion('6.4.3')) {
+        if ($this->isVersion('6.4.3')) {
             $service = new QtiRunnerConfig();
             $service->setServiceManager($this->getServiceManager());
             $this->getServiceManager()->register(QtiRunnerConfig::SERVICE_ID, $service);
@@ -1064,5 +1064,16 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
         
         $this->skip('6.5.0', '6.7.1');
+
+        if ($this->isVersion('6.7.1')) {
+
+            //removes the shortcut from dialog
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $config['shortcuts']['dialog'] = [];
+            $extension->setConfig('testRunner', $config);
+
+            $this->setVersion('6.8.0');
+        }
     }
 }

--- a/views/js/runner/plugins/content/accessibility/keyNavigation.js
+++ b/views/js/runner/plugins/content/accessibility/keyNavigation.js
@@ -79,6 +79,8 @@ define([
                 elements : navigables,
                 loop : true,
                 replace : true
+            }).on('activate', function(cursor){
+                cursor.navigable.getElement().click();
             })];
         }
         return [];

--- a/views/js/runner/plugins/content/dialog/dialog.js
+++ b/views/js/runner/plugins/content/dialog/dialog.js
@@ -136,6 +136,7 @@ define([
                 stack.push(handle);
                 opened.push(handle);
 
+                handle.dialog.focus();
                 handle.dialog.on('closed.modal', function() {
                     removeHandle(stack, handle.dialog);
                     removeHandle(opened, handle.dialog);


### PR DESCRIPTION
requires https://github.com/oat-sa/tao-core/pull/1213

1. removes the registered shortcut for dialog plugin
2. programmatically set the focus on the dialog plugin
3. fixed activation of the exit button with the key space