### PR TITLE
Feature/tao 3962 configurable test session storage

### DIFF
--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -291,7 +291,10 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         $userUri = common_session_SessionManager::getSession()->getUserUri();
         $seeker = new BinaryAssessmentTestSeeker($this->getTestDefinition());
         
-        $this->setStorage(new taoQtiTest_helpers_TestSessionStorage($sessionManager, $seeker, $userUri));
+        $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        $storageClassName = $config['test-session-storage'];
+        $this->setStorage(new $storageClassName($sessionManager, $seeker, $userUri));
+        
         $this->retrieveTestSession();
 
         // @TODO: use some storage to get the potential reason of the state (close/suspended)

--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -270,10 +270,16 @@ return array(
     ],
 
     /**
-     * The namespace of the TestSession class
+     * The FQCN of the TestSession class
      * @type string
      */
     'test-session' => '\taoQtiTest_helpers_TestSession',
+    
+    /**
+     * The FQCN of the TestSessionStorage class
+     * @type string
+     */
+     'test-session-storage' => '\taoQtiTest_helpers_TestSessionStorage',
 
     /**
      * A config set that will be provided though the bootstrap

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '6.10.0',
+    'version' => '6.11.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -161,7 +161,10 @@ class QtiRunnerServiceContext extends RunnerServiceContext
         $seeker = new BinaryAssessmentTestSeeker($this->getTestDefinition());
         $userUri = \common_session_SessionManager::getSession()->getUserUri();
 
-        $this->storage = new \taoQtiTest_helpers_TestSessionStorage($sessionManager, $seeker, $userUri);
+
+        $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        $storageClassName = $config['test-session-storage'];
+        $this->storage = new $storageClassName($sessionManager, $seeker, $userUri);
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1075,5 +1075,14 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('6.10.0');
         }
+        
+        if ($this->isVersion('6.10.0')) {
+            
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $config['test-session-storage'] = '\taoQtiTest_helpers_TestSessionStorage';
+            
+            $this->setVersion('6.11.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1081,6 +1081,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
             $config = $extension->getConfig('testRunner');
             $config['test-session-storage'] = '\taoQtiTest_helpers_TestSessionStorage';
+            $extension->setConfig('testRunner', $config);
             
             $this->setVersion('6.11.0');
         }


### PR DESCRIPTION
Ability to change default QTI Test Session Storage.

**To be tested with both test runners.**

PS: does not cover the entire JIRA issue.