### PR TITLE
Feature/tao 3963 item responses

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '6.11.1',
+    'version' => '6.12.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoTests' => '>=3.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1075,17 +1075,17 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('6.10.0');
         }
-        
+
         if ($this->isVersion('6.10.0')) {
-            
+
             $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
             $config = $extension->getConfig('testRunner');
             $config['test-session-storage'] = '\taoQtiTest_helpers_TestSessionStorage';
             $extension->setConfig('testRunner', $config);
-            
+
             $this->setVersion('6.11.0');
         }
 
-        $this->skip('6.11.0', '6.11.1');
+        $this->skip('6.11.0', '6.12.0');
     }
 }

--- a/views/js/runner/helpers/currentItem.js
+++ b/views/js/runner/helpers/currentItem.js
@@ -21,9 +21,8 @@
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
 define([
-    'jquery',
     'lodash'
-], function ($, _) {
+], function (_) {
     'use strict';
 
     /**

--- a/views/js/runner/helpers/currentItem.js
+++ b/views/js/runner/helpers/currentItem.js
@@ -31,94 +31,144 @@ define([
      * @type {Object}
      */
     var responseCardinalities = {
-        single : 'base',
-        multiple : 'list',
-        ordered : 'list',
-        record : 'record'
+        single: 'base',
+        multiple: 'list',
+        ordered: 'list',
+        record: 'record'
     };
 
     /**
-     * Checks if the provided value can be considered as null
-     * @param {Object} value
-     * @param {String} baseType
-     * @param {String} cardinality
-     * @returns {boolean}
+     * @typedef {currentItemHelper}
      */
-    function isQtiValueNull(value, baseType, cardinality) {
-        var mappedCardinality = responseCardinalities[cardinality];
-        if (_.isObject(value) && value[mappedCardinality] && 'undefined' !== typeof value[mappedCardinality][baseType]) {
-            value = value[mappedCardinality][baseType];
-        }
-        return null === value || ('string' === baseType && _.isEmpty(value)) || (cardinality !== 'single' && _.isEmpty(value));
-    }
+    var currentItemHelper = {
+        /**
+         * Gets the responses declarations of the current item.
+         * @param {Object} runner - testRunner instance
+         * @returns {Object}
+         */
+        getDeclarations: function getDeclarations(runner) {
+            var itemRunner = runner.itemRunner;
+            return itemRunner._item && itemRunner._item.responses;
+        },
 
-    /**
-     * Convert a value to a response object
-     * @param {Array} value
-     * @param {String} baseType
-     * @param {String} cardinality
-     * @returns {Object}
-     */
-    function toResponse(value, baseType, cardinality) {
-        var mappedCardinality = responseCardinalities[cardinality];
-        var response = {};
-
-        value = _.map(value || [], function(v){
-            return (baseType === 'boolean') ? (v === true || v === 'true') : v;
-        });
-
-        if (mappedCardinality) {
-            if (mappedCardinality === 'base') {
-                if (value.length === 0) {
-                    //return empty response:
-                    response.base = null;
-                } else {
-                    response.base = {};
-                    response.base[baseType] = value[0];
-                }
-            } else {
-                response[mappedCardinality] = {};
-                response[mappedCardinality][baseType] = value;
-            }
-        }
-
-        return response;
-    }
-
-    /**
-     * Tells is the current item has been answered or not
-     * The item is considered answered when at least one response has been set to not empty {base : null}
-     * @param {Object} runner - testRunner instance
-     * @returns {Boolean}
-     */
-    function isAnswered(runner) {
-        var itemRunner = runner.itemRunner;
-        var responses = itemRunner && itemRunner.getResponses();
-        var count = 0;
-        var empty = 0;
-
-        if (itemRunner) {
-            _.forEach(itemRunner._item && itemRunner._item.responses, function (declaration) {
+        /**
+         * Gets a response declaration by the identifier of the response
+         * @param {Object} runner - testRunner instance
+         * @param {String} identifier - The identifier of the response
+         * @returns {Object|null}
+         */
+        getResponseDeclaration: function getResponseDeclaration(runner, identifier) {
+            var found = null;
+            _.forEach(currentItemHelper.getDeclarations(runner), function (declaration) {
                 var attributes = declaration.attributes || {};
-                var response = responses[attributes.identifier];
-                var baseType = attributes.baseType;
-                var cardinality = attributes.cardinality;
-
-                count ++;
-                if (isQtiValueNull(response, baseType, cardinality)) {
-                    if (isQtiValueNull(declaration.defaultValue, baseType, cardinality)) {
-                        empty++;
-                    }
-                } else if (_.isEqual(response, toResponse(declaration.defaultValue, baseType, cardinality))) {
-                    empty++;
+                if (attributes.identifier === identifier) {
+                    found = declaration;
+                    return false;
                 }
             });
+            return found;
+        },
+
+        /**
+         * Convert a value to a response object
+         * @param {Array|String} value
+         * @param {String} baseType
+         * @param {String} cardinality
+         * @returns {Object}
+         */
+        toResponse: function toResponse(value, baseType, cardinality) {
+            var mappedCardinality = responseCardinalities[cardinality];
+            var response = {};
+
+            if (_.isString(value)) {
+                value = [value];
+            }
+
+            value = _.map(value || [], function (v) {
+                return (baseType === 'boolean') ? (v === true || v === 'true') : v;
+            });
+
+            if (mappedCardinality) {
+                if (mappedCardinality === 'base') {
+                    if (value.length === 0) {
+                        //return empty response:
+                        response.base = null;
+                    } else {
+                        response.base = {};
+                        response.base[baseType] = value[0];
+                    }
+                } else {
+                    response[mappedCardinality] = {};
+                    response[mappedCardinality][baseType] = value;
+                }
+            }
+
+            return response;
+        },
+
+        /**
+         * Checks if the provided value can be considered as null
+         * @param {Object} value
+         * @param {String} baseType
+         * @param {String} cardinality
+         * @returns {boolean}
+         */
+        isQtiValueNull: function isQtiValueNull(value, baseType, cardinality) {
+            var mappedCardinality = responseCardinalities[cardinality];
+            if (_.isObject(value) && value[mappedCardinality] && 'undefined' !== typeof value[mappedCardinality][baseType]) {
+                value = value[mappedCardinality][baseType];
+            }
+            return null === value || ('string' === baseType && _.isEmpty(value)) || (cardinality !== 'single' && _.isEmpty(value));
+        },
+
+        /**
+         * Tells if an item question has been answered or not
+         * @param response
+         * @param baseType
+         * @param cardinality
+         * @param [defaultValue]
+         * @returns {*}
+         */
+        isQuestionAnswered: function isQuestionAnswered(response, baseType, cardinality, defaultValue) {
+            var answered;
+            defaultValue = defaultValue || null;
+            if (currentItemHelper.isQtiValueNull(response, baseType, cardinality)) {
+                answered = !currentItemHelper.isQtiValueNull(defaultValue, baseType, cardinality);
+            } else {
+                answered = !_.isEqual(response, currentItemHelper.toResponse(defaultValue, baseType, cardinality));
+            }
+            return answered;
+        },
+
+        /**
+         * Tells is the current item has been answered or not
+         * The item is considered answered when at least one response has been set to not empty {base : null}
+         * @param {Object} runner - testRunner instance
+         * @returns {Boolean}
+         */
+        isAnswered: function isAnswered(runner) {
+            var itemRunner = runner.itemRunner;
+            var responses = itemRunner && itemRunner.getResponses();
+            var count = 0;
+            var empty = 0;
+
+            if (itemRunner) {
+                _.forEach(currentItemHelper.getDeclarations(runner), function (declaration) {
+                    var attributes = declaration.attributes || {};
+                    var response = responses[attributes.identifier];
+                    var baseType = attributes.baseType;
+                    var cardinality = attributes.cardinality;
+
+                    count++;
+                    if (!currentItemHelper.isQuestionAnswered(response, baseType, cardinality, declaration.defaultValue)) {
+                        empty++;
+                    }
+                });
+            }
+
+            return count !== 0 && empty !== count;
         }
-
-        return count !== 0 && empty !== count;
-    }
-
-    return {
-        isAnswered: isAnswered
     };
+
+    return currentItemHelper;
 });

--- a/views/js/runner/helpers/messages.js
+++ b/views/js/runner/helpers/messages.js
@@ -19,12 +19,10 @@
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
 define([
-    'jquery',
-    'lodash',
     'i18n',
     'taoQtiTest/runner/helpers/map',
     'taoQtiTest/runner/helpers/stats'
-], function ($, _, __, mapHelper, statsHelper) {
+], function (__, mapHelper, statsHelper) {
     'use strict';
 
     /**

--- a/views/js/runner/helpers/stats.js
+++ b/views/js/runner/helpers/stats.js
@@ -21,12 +21,10 @@
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
 define([
-    'jquery',
     'lodash',
-    'i18n',
     'taoQtiTest/runner/helpers/map',
     'taoQtiTest/runner/helpers/currentItem'
-], function ($, _, __, mapHelper, currentItemHelper) {
+], function (_, mapHelper, currentItemHelper) {
     'use strict';
 
     /**

--- a/views/js/test/runner/helpers/currentItem/test.html
+++ b/views/js/test/runner/helpers/currentItem/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner - CurrentItemHelper</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="runner/helpers/currentItem.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiTest/test/runner/helpers/currentItem/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/helpers/currentItem/test.js
+++ b/views/js/test/runner/helpers/currentItem/test.js
@@ -1,0 +1,206 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'helpers',
+    'taoQtiTest/runner/helpers/currentItem'
+], function (_, helpers, currentItemHelper) {
+    'use strict';
+
+    var messagesHelperApi = [
+        {title: 'getDeclarations'},
+        {title: 'getResponseDeclaration'},
+        {title: 'toResponse'},
+        {title: 'isQtiValueNull'},
+        {title: 'isQuestionAnswered'},
+        {title: 'isAnswered'}
+    ];
+
+    /**
+     * Build a fake test runner with embedded item runner
+     * @param {Object} responses
+     * @param {Object} declarations
+     * @returns {Object}
+     */
+    function runnerMock(responses, declarations) {
+        return {
+            itemRunner: {
+                _item: {
+                    responses: declarations
+                },
+                getResponses: function () {
+                    return responses;
+                }
+            }
+        };
+    }
+
+
+    QUnit.module('helpers/currentItem');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+
+        assert.equal(typeof currentItemHelper, 'object', "The currentItem helper module exposes an object");
+    });
+
+
+    QUnit
+        .cases(messagesHelperApi)
+        .test('helpers/currentItem API ', function (data, assert) {
+            QUnit.expect(1);
+
+            assert.equal(typeof currentItemHelper[data.title], 'function', 'The currentItem helper expose a "' + data.title + '" function');
+        });
+
+
+    QUnit.test('helpers/currentItem.getDeclarations', function (assert) {
+        var declarations = {
+            "responsedeclaration1": {
+                "identifier": "RESPONSE1",
+                "serial": "responsedeclaration1",
+                "qtiClass": "responseDeclaration",
+                "attributes": {
+                    "identifier": "RESPONSE1", "cardinality": "single", "baseType": "string"
+                },
+                "defaultValue": []
+            },
+            "responsedeclaration2": {
+                "identifier": "RESPONSE2",
+                "serial": "responsedeclaration2",
+                "qtiClass": "responseDeclaration",
+                "attributes": {
+                    "identifier": "RESPONSE2", "cardinality": "single", "baseType": "string"
+                },
+                "defaultValue": []
+            }
+        };
+        var runner = runnerMock({}, declarations);
+
+        QUnit.expect(1);
+
+        assert.equal(currentItemHelper.getDeclarations(runner), declarations, 'The helper has returned the right list of responses declarations');
+
+    });
+
+
+    QUnit.test('helpers/currentItem.getResponseDeclaration', function (assert) {
+        var declarations = {
+            "responsedeclaration1": {
+                "identifier": "RESPONSE1",
+                "serial": "responsedeclaration1",
+                "qtiClass": "responseDeclaration",
+                "attributes": {
+                    "identifier": "RESPONSE1", "cardinality": "single", "baseType": "string"
+                },
+                "defaultValue": []
+            },
+            "responsedeclaration2": {
+                "identifier": "RESPONSE2",
+                "serial": "responsedeclaration2",
+                "qtiClass": "responseDeclaration",
+                "attributes": {
+                    "identifier": "RESPONSE2", "cardinality": "single", "baseType": "string"
+                },
+                "defaultValue": []
+            }
+        };
+        var runner = runnerMock({}, declarations);
+
+        QUnit.expect(2);
+
+        assert.equal(currentItemHelper.getResponseDeclaration(runner, "RESPONSE1"), declarations.responsedeclaration1, 'The helper has returned the first declaration');
+        assert.equal(currentItemHelper.getResponseDeclaration(runner, "RESPONSE2"), declarations.responsedeclaration2, 'The helper has returned the second declaration');
+
+    });
+
+
+    QUnit.test('helpers/currentItem.toResponse', function (assert) {
+        QUnit.expect(5);
+
+        assert.deepEqual(currentItemHelper.toResponse(null, 'string', 'single'), {base: null}, 'The helper has built the right response');
+        assert.deepEqual(currentItemHelper.toResponse('foo', 'string', 'single'), {base: {string: 'foo'}}, 'The helper has built the right response');
+        assert.deepEqual(currentItemHelper.toResponse(['foo'], 'string', 'single'), {base: {string: 'foo'}}, 'The helper has built the right response');
+        assert.deepEqual(currentItemHelper.toResponse(['foo'], 'string', 'multiple'), {list: {string: ['foo']}}, 'The helper has built the right response');
+        assert.deepEqual(currentItemHelper.toResponse(null, 'string', 'multiple'), {list: {string: []}}, 'The helper has built the right response');
+    });
+
+
+    QUnit.test('helpers/currentItem.isQtiValueNull', function (assert) {
+        QUnit.expect(5);
+
+        assert.equal(currentItemHelper.isQtiValueNull(null, 'string', 'single'), true, 'The response should be null');
+        assert.equal(currentItemHelper.isQtiValueNull({base: {string: null}}, 'string', 'single'), true, 'The response should be null');
+        assert.equal(currentItemHelper.isQtiValueNull({base: {string: 'foo'}}, 'string', 'single'), false, 'The response should not be null');
+        assert.equal(currentItemHelper.isQtiValueNull({list: {string: ['foo']}}, 'string', 'multiple'), false, 'The response should not be null');
+        assert.equal(currentItemHelper.isQtiValueNull({list: {string: []}}, 'string', 'multiple'), true, 'The response should be null');
+    });
+
+
+    QUnit.test('helpers/currentItem.isQuestionAnswered', function (assert) {
+        QUnit.expect(9);
+
+        assert.equal(currentItemHelper.isQuestionAnswered(null, 'string', 'single'), false, 'The question should not be answered');
+        assert.equal(currentItemHelper.isQuestionAnswered({base: {string: null}}, 'string', 'single'), false, 'The question should not be answered');
+        assert.equal(currentItemHelper.isQuestionAnswered({base: {string: 'foo'}}, 'string', 'single'), true, 'The question should be answered');
+        assert.equal(currentItemHelper.isQuestionAnswered({list: {string: ['foo']}}, 'string', 'multiple'), true, 'The question should be answered');
+        assert.equal(currentItemHelper.isQuestionAnswered({list: {string: []}}, 'string', 'multiple'), false, 'The question should not be answered');
+
+        assert.equal(currentItemHelper.isQuestionAnswered(null, 'string', 'single', 'foo'), true, 'The question should be answered');
+        assert.equal(currentItemHelper.isQuestionAnswered({base: {string: null}}, 'string', 'single', 'foo'), true, 'The question should be answered');
+        assert.equal(currentItemHelper.isQuestionAnswered({base: {string: 'foo'}}, 'string', 'single', 'foo'), false, 'The question should not be answered');
+        assert.equal(currentItemHelper.isQuestionAnswered({list: {string: []}}, 'string', 'multiple', ['foo']), true, 'The question should be answered');
+    });
+
+
+    QUnit.test('helpers/currentItem.isAnswered', function (assert) {
+        var declarations = {
+            "responsedeclaration1": {
+                "identifier": "RESPONSE1",
+                "serial": "responsedeclaration1",
+                "qtiClass": "responseDeclaration",
+                "attributes": {
+                    "identifier": "RESPONSE1", "cardinality": "single", "baseType": "string"
+                },
+                "defaultValue": []
+            },
+            "responsedeclaration2": {
+                "identifier": "RESPONSE2",
+                "serial": "responsedeclaration2",
+                "qtiClass": "responseDeclaration",
+                "attributes": {
+                    "identifier": "RESPONSE2", "cardinality": "single", "baseType": "string"
+                },
+                "defaultValue": []
+            }
+        };
+        var responded = {RESPONSE1: {base: null}, RESPONSE2: {base: {string: 'foo'}}};
+        var notResponded = {RESPONSE1: {base: null}, RESPONSE2: {base: null}};
+        var respondedRunner = runnerMock(responded, declarations);
+        var notRespondedRunner = runnerMock(notResponded, declarations);
+
+        QUnit.expect(2);
+
+        assert.equal(currentItemHelper.isAnswered(respondedRunner), true, 'The item should be answered');
+        assert.equal(currentItemHelper.isAnswered(notRespondedRunner), false, 'The item should not be answered');
+    });
+});

--- a/views/js/test/runner/helpers/messages/test.js
+++ b/views/js/test/runner/helpers/messages/test.js
@@ -28,19 +28,21 @@ define([
     QUnit.module('helpers/messages');
 
 
-    QUnit.test('module', 1, function (assert) {
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
         assert.equal(typeof messagesHelper, 'object', "The messages helper module exposes an object");
     });
 
 
     var messagesHelperApi = [
-        {name: 'getExitMessage', title: 'getExitMessage'}
+        {title: 'getExitMessage'}
     ];
 
     QUnit
         .cases(messagesHelperApi)
-        .test('helpers/messages API ', 1, function (data, assert) {
-            assert.equal(typeof messagesHelper[data.name], 'function', 'The messages helper expose a "' + data.name + '" function');
+        .test('helpers/messages API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof messagesHelper[data.title], 'function', 'The messages helper expose a "' + data.title + '" function');
         });
 
     /**
@@ -136,6 +138,8 @@ define([
         var responses = {RESPONSE: {base: null}};
         var runner = runnerMock(map, context, data, responses, declarations);
         var message = 'This is a test.';
+
+        QUnit.expect(18);
 
         // all answered, no flagged
         assert.equal(messagesHelper.getExitMessage(message, 'test', runner), message, 'The messages helper return the right message when the scope is "test"');
@@ -247,6 +251,8 @@ define([
         var responses = {RESPONSE: {base: null}};
         var runner = runnerMock(map, context, data, responses, declarations);
         var message = 'This is a test.';
+
+        QUnit.expect(18);
 
         // all answered, no flagged
         assert.equal(messagesHelper.getExitMessage(message, 'test', runner), message, 'The messages helper return the right message when the scope is "test"');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3963

Improve the `currentItem` helper by exposing internal functions in order to be able to manage item responses:
- `getDeclarations`: gets the responses declarations of the current item
- `getResponseDeclaration`: gets a particular response declaration from the current item
- `toResponse`: build a response descriptor based on the provided value (need baseType and cardinality from the declaration)
- `isQtiValueNull`: checks if the value is considered as NULL
- `isQuestionAnswered`: tells whether a particular question has been answered
- `isAnswered`: tells whether the current item has been answered

Also add unit tests.