### PR TITLE
Fix/tao 3942 state storage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '6.18.0',
+    'version'     => '6.18.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=3.9.0',

--- a/models/classes/TestSessionService.php
+++ b/models/classes/TestSessionService.php
@@ -23,6 +23,7 @@ namespace oat\taoQtiTest\models;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoDelivery\model\AssignmentService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\session\UserUriAware;
 use qtism\runtime\storage\binary\BinaryAssessmentTestSeeker;
 use qtism\runtime\tests\AssessmentTestSession;
@@ -59,7 +60,10 @@ class TestSessionService extends ConfigurableService
         $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
 
         $userId = $deliveryExecution->getUserIdentifier();
-        $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
+
+        $config = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        $storageClassName = $config['test-session-storage'];
+        $qtiStorage = new $storageClassName(
             $sessionManager,
             new BinaryAssessmentTestSeeker($testDefinition), $userId
         );
@@ -103,6 +107,21 @@ class TestSessionService extends ConfigurableService
         }
 
         return self::$cache[$sessionId]['session'];
+    }
+    
+    /**
+     * Register a test session
+     *
+     * @param TestSession $session
+     * @param \taoQtiTest_helpers_TestSessionStorage $storage
+     */
+    public function registerTestSession($session, $storage)
+    {
+        $sessionId = $session->getSessionId();
+        self::$cache[$sessionId] = [
+            'session' => $session,
+            'storage' => $storage
+        ];
     }
 
     /**

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -36,6 +36,7 @@ use oat\taoQtiTest\models\runner\map\QtiRunnerMap;
 use oat\taoQtiTest\models\runner\navigation\QtiRunnerNavigation;
 use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
 use oat\taoQtiTest\models\runner\session\TestSession;
+use oat\taoQtiTest\models\TestSessionService;
 use oat\taoTests\models\runner\time\TimePoint;
 use qtism\common\datatypes\QtiString as QtismString;
 use qtism\common\enums\BaseType;
@@ -129,6 +130,9 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         $serviceContext = new QtiRunnerServiceContext($testDefinitionUri, $testCompilationUri, $testExecutionUri);
         $serviceContext->setServiceManager($this->getServiceManager());
         $serviceContext->setTestConfig($this->getTestConfig());
+
+        $sessionService = $this->getServiceManager()->get(TestSessionService::SERVICE_ID);
+        $sessionService->registerTestSession($serviceContext->getTestSession(), $serviceContext->getStorage());
 
         if ($check) {
             // will throw exception if the test session is not valid

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -25,6 +25,7 @@ namespace oat\taoQtiTest\models\runner;
 use oat\taoQtiTest\models\QtiTestCompilerIndex;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\SessionStateService;
+use oat\taoQtiTest\models\TestSessionService;
 use qtism\data\AssessmentTest;
 use qtism\runtime\storage\binary\AbstractQtiBinaryStorage;
 use qtism\runtime\storage\binary\BinaryAssessmentTestSeeker;
@@ -116,6 +117,9 @@ class QtiRunnerServiceContext extends RunnerServiceContext
      */
     public function init()
     {
+        $sessionService = $this->getServiceManager()->get(TestSessionService::SERVICE_ID);
+        $sessionService->registerTestSession($this->getTestSession(), $this->getStorage());
+        
         // code borrowed from the previous implementation, maybe obsolete...
         /** @var SessionStateService $sessionStateService */
         $sessionStateService = $this->getServiceManager()->get(SessionStateService::SERVICE_ID);

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -25,7 +25,6 @@ namespace oat\taoQtiTest\models\runner;
 use oat\taoQtiTest\models\QtiTestCompilerIndex;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\SessionStateService;
-use oat\taoQtiTest\models\TestSessionService;
 use qtism\data\AssessmentTest;
 use qtism\runtime\storage\binary\AbstractQtiBinaryStorage;
 use qtism\runtime\storage\binary\BinaryAssessmentTestSeeker;
@@ -117,9 +116,6 @@ class QtiRunnerServiceContext extends RunnerServiceContext
      */
     public function init()
     {
-        $sessionService = $this->getServiceManager()->get(TestSessionService::SERVICE_ID);
-        $sessionService->registerTestSession($this->getTestSession(), $this->getStorage());
-        
         // code borrowed from the previous implementation, maybe obsolete...
         /** @var SessionStateService $sessionStateService */
         $sessionStateService = $this->getServiceManager()->get(SessionStateService::SERVICE_ID);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1151,5 +1151,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion(('6.18.0'));
         }
+
+        $this->skip('6.18.0', '6.18.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3942

When a proctor pause a delivery it should use another user account than a the test taker being paused. Unfortunately, the `ExtendedStateStorage` service did not take care of that, hence when the proctor set a pause, a wrong storage was used.

This PR fix that:
- use the user ID from the delivery execution instead of the logged on user
- use the right session storage (could be overridden by config)
- cache the session as soon as it is loaded, to prevent double session load when using `TestSessionService` to retrieve an existing session