### PR TITLE
Fix/tao 3942 end message

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '6.18.2',
+    'version'     => '6.18.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=3.9.0',

--- a/models/classes/QtiTestListenerService.php
+++ b/models/classes/QtiTestListenerService.php
@@ -66,14 +66,17 @@ class QtiTestListenerService extends ConfigurableService
      */
     protected function logStateEvent(AssessmentTestSession $session)
     {
-        $messageService = $this->getServiceManager()->get(QtiRunnerMessageService::SERVICE_ID);
-        $stateService = $this->getServiceManager()->get(ExtendedStateService::SERVICE_ID);
+        $route = $session->getRoute();
+        if ($route->valid()) {
+            $messageService = $this->getServiceManager()->get(QtiRunnerMessageService::SERVICE_ID);
+            $stateService = $this->getServiceManager()->get(ExtendedStateService::SERVICE_ID);
 
-        $data = [
-            'state' => $session->getState(),
-            'message' => $messageService->getStateMessage($session),
-        ];
+            $data = [
+                'state' => $session->getState(),
+                'message' => $messageService->getStateMessage($session),
+            ];
 
-        $stateService->addEvent($session->getSessionId(), TestStateChannel::CHANNEL_NAME, $data);
+            $stateService->addEvent($session->getSessionId(), TestStateChannel::CHANNEL_NAME, $data);
+        }
     }
 }

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -883,6 +883,8 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
             $this->getServiceManager()->get(EventManager::SERVICE_ID)->trigger($event);
 
             $session->endTestSession();
+
+            $this->getServiceManager()->get(ExtendedStateService::SERVICE_ID)->clearEvents($session->getSessionId());
         } else {
             throw new \common_exception_InvalidArgumentType(
                 'QtiRunnerService',
@@ -920,6 +922,8 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 \common_Logger::w("Non owner {$userUri} tried to finish deliveryExecution {$executionUri}");
                 $result = false;
             }
+
+            $this->getServiceManager()->get(ExtendedStateService::SERVICE_ID)->clearEvents($executionUri);
         } else {
             throw new \common_exception_InvalidArgumentType(
                 'QtiRunnerService',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1152,6 +1152,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion(('6.18.0'));
         }
 
-        $this->skip('6.18.0', '6.18.2');
+        $this->skip('6.18.0', '6.18.3');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3942

Prevent the pause/terminate message to be displayed when the test is ending in a normal way.