### PR TITLE
Feature/tao 4178 request serie

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,12 +28,12 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '7.2.0',
+    'version'     => '7.3.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=4.0.0',
         'taoQtiItem' => '>=6.19.0',
-        'tao'        => '>=7.87.0',
+        'tao'        => '>=8.3.0',
         'generis'    => '>=3.19.0',
     ),
 	'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1152,6 +1152,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion(('6.18.0'));
         }
 
-        $this->skip('6.18.0', '7.2.0');
+        $this->skip('6.18.0', '7.3.0');
     }
 }

--- a/views/js/runner/proxy/cache/proxy.js
+++ b/views/js/runner/proxy/cache/proxy.js
@@ -180,8 +180,9 @@ define([
         },
 
         submitItem: function submitItem(uri, state, response, params) {
+            var itemData;
             if (this.itemStore.has(uri)) {
-                var itemData = this.itemStore.get(uri);
+                itemData = this.itemStore.get(uri);
                 itemData.itemState = state;
                 this.itemStore.set(uri, itemData);
             }
@@ -229,7 +230,6 @@ define([
                 });
         }
     }, qtiServiceProxy);
-
 
     return cacheProxy;
 });


### PR DESCRIPTION
To reproduce the bug, I've added a `sleep(5);` into the [storeTraceData](https://github.com/oat-sa/extension-tao-testqti/blob/master/actions/class.Runner.php#L872) call. 
The previous implementation of promises in serie was supporting only 2 promises, but with latencies we can have 3 requests in the queue :  `storeTraceData`, `submitItem` and `getNextItemData`.
The promise queue enforce the promises to run in serie.

Requires https://github.com/oat-sa/tao-core/pull/1268