### PR TITLE
Feature/tao 4203 item trace variable

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -857,7 +857,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $size   = count($traceData);
 
             foreach($traceData  as $variableIdentifier => $variableValue){
-                if($this->runnerService->storeTraceVariable($serviceContext, $itemRef, $variableIdentifier, json_encode($variableValue))){
+                if($this->runnerService->storeTraceVariable($serviceContext, $itemRef, $variableIdentifier, $variableValue)){
                     $stored++;
                 }
             }

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '7.4.0',
+    'version'     => '7.5.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=4.0.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1233,6 +1233,10 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     public function storeTraceVariable(RunnerServiceContext $context, $itemUri, $variableIdentifier, $variableValue)
     {
         if ($context instanceof QtiRunnerServiceContext) {
+            if (!is_string($variableValue) && !is_numeric($variableValue)) {
+                $variableValue = json_encode($variableValue);
+            }
+            
             $metaVariable = new \taoResultServer_models_classes_TraceVariable();
             $metaVariable->setIdentifier($variableIdentifier);
             $metaVariable->setBaseType('string');
@@ -1248,7 +1252,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $currentItem = $context->getTestSession()->getCurrentAssessmentItemRef();
                 $currentOccurrence = $context->getTestSession()->getCurrentAssessmentItemRefOccurence();
 
-                $transmissionId = "${sessionId}.${$currentItem}.${$currentOccurrence}";
+                $transmissionId = "${sessionId}.${currentItem}.${currentOccurrence}";
                 $resultServer->storeItemVariable($testUri, $itemUri, $metaVariable, $transmissionId);
             } else {
                 $resultServer->storeTestVariable($testUri, $metaVariable, $sessionId);

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -150,6 +150,14 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'category' => 'controls',
                 'active' => true,
                 'tags' => [ 'core', 'technical', 'required' ]
+            ], [
+                'id' => 'itemTraceVariables',
+                'name' => 'Item trace variables',
+                'module' => 'taoQtiTest/runner/plugins/controls/trace/itemTraceVariables',
+                'description' => 'Send item trace variables',
+                'category' => 'controls',
+                'active' => false,
+                'tags' => [ 'core', 'technical' ]
             ]
         ],
         'navigation' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1153,5 +1153,22 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('6.18.0', '7.4.0');
+
+        if($this->isVersion('7.4.0')){
+            // Register item trace variables plugin
+            $registry = PluginRegistry::getRegistry();
+            $registry->remove('taoQtiTest/runner/plugins/controls/trace/itemTraceVariables');
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'itemTraceVariables',
+                'name' => 'Item trace variables',
+                'module' => 'taoQtiTest/runner/plugins/controls/trace/itemTraceVariables',
+                'description' => 'Send item trace variables',
+                'category' => 'controls',
+                'active' => false,
+                'tags' => [ 'core', 'technical' ]
+            ]));
+
+            $this->setVersion('7.5.0');
+        }
     }
 }

--- a/views/js/controller/runtime/testRunner.js
+++ b/views/js/controller/runtime/testRunner.js
@@ -1080,7 +1080,7 @@ function (
                 var sec_num = totalSeconds;
                 var hours = Math.floor(sec_num / 3600);
                 var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
-                var seconds = sec_num - (hours * 3600) - (minutes * 60);
+                var seconds = Math.floor(sec_num - (hours * 3600) - (minutes * 60));
 
                 if (hours < 10) {
                     hours = "0" + hours;

--- a/views/js/runner/plugins/controls/trace/ItemTraceVariables.js
+++ b/views/js/runner/plugins/controls/trace/ItemTraceVariables.js
@@ -82,7 +82,7 @@ define([
                     return tracesStore;
                 }).then(function (tracesStore) {
                     testRunner
-                        .after('renderitem resumeitem', function () {
+                        .after('renderitem enableitem', function () {
                             var context = testRunner.getTestContext();
 
                             variables = {
@@ -106,13 +106,14 @@ define([
                             variables.ITEM_END_TIME_CLIENT = timestamp();
                             variables.ITEM_TIMEZONE = moment().utcOffset(moment().utcOffset()).format('Z');
 
-                            return tracesStore.setItem(context.itemUri, variables)
-                                .then(function () {
-                                    testRunner.getProxy().callItemAction(context.itemUri, 'storeTraceData', {
-                                        traceData: JSON.stringify(variables)
-                                    });
-                                })
-                                .catch(onError);
+                            return tracesStore.setItem(context.itemUri, variables).catch(onError);
+                        })
+
+                        .after('move skip exit timeout', function () {
+                            var context = testRunner.getTestContext();
+                            testRunner.getProxy().callItemAction(context.itemUri, 'storeTraceData', {
+                                traceData: JSON.stringify(variables)
+                            });
                         })
 
                         .before('finish', function () {

--- a/views/js/runner/plugins/controls/trace/ItemTraceVariables.js
+++ b/views/js/runner/plugins/controls/trace/ItemTraceVariables.js
@@ -109,9 +109,9 @@ define([
                             return tracesStore.setItem(context.itemUri, variables).catch(onError);
                         })
 
-                        .after('move skip exit timeout', function () {
+                        .before('unloaditem', function () {
                             var context = testRunner.getTestContext();
-                            testRunner.getProxy().callItemAction(context.itemUri, 'storeTraceData', {
+                            return testRunner.getProxy().callItemAction(context.itemUri, 'storeTraceData', {
                                 traceData: JSON.stringify(variables)
                             });
                         })

--- a/views/js/runner/plugins/controls/trace/ItemTraceVariables.js
+++ b/views/js/runner/plugins/controls/trace/ItemTraceVariables.js
@@ -1,0 +1,128 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Test Runner Control Plugin : Item Trace Variables
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'moment',
+    'core/store',
+    'taoTests/runner/plugin'
+], function (_, moment, storeFactory, pluginFactory) {
+    'use strict';
+
+    /**
+     * Duration of a second in the timer's base unit
+     * @type {Number}
+     */
+    var precision = 1000;
+
+    /**
+     * Gets the current timestamp
+     * @returns {Number}
+     */
+    function timestamp() {
+        return Date.now() / precision;
+    }
+
+    /**
+     * Creates the timer plugin
+     */
+    return pluginFactory({
+
+        name: 'itemTraceVariables',
+
+        /**
+         * Installation of the plugin (called before init)
+         */
+        install: function install() {
+            var self = this;
+            self.getTestRunner().on('storechange', function () {
+                self.shouldClearStorage = true;
+            });
+        },
+
+        /**
+         * Initializes the plugin (called during runner's init)
+         */
+        init: function init() {
+
+            var self = this;
+            var testRunner = this.getTestRunner();
+            var variables = {};
+
+            function onError(err) {
+                testRunner.trigger('error', err);
+            }
+
+            return storeFactory('trace-' + testRunner.getConfig().serviceCallId)
+                .then(function (tracesStore) {
+                    if (self.shouldClearStorage) {
+                        return tracesStore.clear().then(function () {
+                            return tracesStore;
+                        });
+                    }
+                    return tracesStore;
+                }).then(function (tracesStore) {
+                    testRunner
+                        .after('renderitem resumeitem', function () {
+                            var context = testRunner.getTestContext();
+
+                            variables = {
+                                ITEM_START_TIME_CLIENT: timestamp()
+                            };
+
+                            tracesStore.getItem(context.itemUri)
+                                .then(function (data) {
+                                    if (data) {
+                                        _.merge(variables, data);
+                                    }
+
+                                    return tracesStore.setItem(context.itemUri, variables);
+                                })
+                                .catch(onError);
+                        })
+
+                        .before('move skip exit timeout', function () {
+                            var context = testRunner.getTestContext();
+
+                            variables.ITEM_END_TIME_CLIENT = timestamp();
+                            variables.ITEM_TIMEZONE = moment().utcOffset(moment().utcOffset()).format('Z');
+
+                            return tracesStore.setItem(context.itemUri, variables)
+                                .then(function () {
+                                    testRunner.getProxy().callItemAction(context.itemUri, 'storeTraceData', {
+                                        traceData: JSON.stringify(variables)
+                                    });
+                                })
+                                .catch(onError);
+                        })
+
+                        .before('finish', function () {
+                            return new Promise(function (resolve) {
+                                tracesStore.removeStore()
+                                    .then(resolve)
+                                    .catch(resolve);
+                            });
+                        });
+                });
+        }
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4203

Add a plugin that send item trace variables to store client start and end times.

The plugin is disabled by default. To enable it, open the file `config/taoTests/test_runner_plugin_registry.conf.php`, then search for `taoQtiTest/runner/plugins/controls/trace/itemTraceVariables` (usually at the end of the file as the plugin has just been added)

The plugin should add the following item trace variables:
- `ITEM_START_TIME_CLIENT`
- `ITEM_END_TIME_CLIENT`
- `ITEM_TIMEZONE`

The PR also fixes the following issues:
- error while building the item variable identifier (bad PHP code, the issue was not discovered before as the code path was never activated)
- wrong data type of trace variable when the value is not an object nor an array (other use of trace variables did not provide other data type than object)
- too big precision of the timer when first displayed (old TestRunner)