### PR TITLE
Fix/tao 4212 skip button

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '7.5.5',
+    'version'     => '7.5.6',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1171,6 +1171,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.5.5');
+        $this->skip('7.5.0', '7.5.6');
     }
 }

--- a/views/js/runner/plugins/navigation/skip.js
+++ b/views/js/runner/plugins/navigation/skip.js
@@ -23,12 +23,13 @@
  */
 define([
     'jquery',
+    'lodash',
     'i18n',
     'ui/hider',
     'taoTests/runner/plugin',
     'taoQtiTest/runner/helpers/messages',
     'tpl!taoQtiTest/runner/plugins/templates/button'
-], function ($, __, hider, pluginFactory, messages, buttonTpl){
+], function ($, _, __, hider, pluginFactory, messages, buttonTpl){
     'use strict';
 
     /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4212

Did not cause the issue, but could cause others: the `lodash` dependency was used without being required.