### PR TITLE
Fix/tao 4224 qti sm dependency move

### DIFF
--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -18,6 +18,7 @@
  */
 
 use oat\taoItems\model\CategoryService;
+use qtism\common\utils\Format;
 
 /**
  * Actions about Items in a Test context.
@@ -86,7 +87,17 @@ class taoQtiTest_actions_Items extends tao_actions_CommonModule
 
         if (count($items) > 0) {
             $service = $this->getServiceManager()->get(CategoryService::SERVICE_ID);
-            $categories = $service->getItemsCategories($items);
+            $itemsCategories = $service->getItemsCategories($items);
+
+            //filter all values that wouldn't be valid XML identifiers
+            foreach ($itemsCategories as $itemUri => $itemCategories){
+                $filtered = array_filter($itemCategories, function($categorie){
+                    return Format::isIdentifier($categorie);
+                });
+                if(count($filtered) > 0){
+                    $categories[$itemUri] = $filtered;
+                }
+            }
         }
         $this->returnJson($categories);
 

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '9.0.0',
+    'version'     => '9.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1207,6 +1207,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('8.1.0');
         }
 
-        $this->skip('8.1.0', '9.0.0');
+        $this->skip('8.1.0', '9.0.1');
     }
 }


### PR DESCRIPTION
Filter categories which aren't QTI/XML compliant (the validation was previously on taoItems)

Related to https://github.com/oat-sa/extension-tao-item/pull/266