### PR TITLE
Feature/tao 4360 rubricblock mathml support

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,10 +28,10 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '9.3.3',
+    'version'     => '9.4.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
-        'taoTests'   => '>=6.0.0',
+        'taoTests'   => '>=6.2.0',
         'taoQtiItem' => '>=8.1.0',
         'tao'        => '>=10.2.0',
         'generis'    => '>=3.19.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1233,5 +1233,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             }
             $this->setVersion('9.3.3');
         }
+        $this->skip('9.3.3', '9.4.0');
     }
 }

--- a/views/js/runner/plugins/content/rubricBlock/rubricBlock.js
+++ b/views/js/runner/plugins/content/rubricBlock/rubricBlock.js
@@ -43,9 +43,9 @@ define([
      * Apply mathjax
      */
     var mathify = function mathify($container) {
+
         return new Promise(function(resolve){
             if($('math', $container).length > 0){
-
                 //load mathjax only if necessary
                 require(['mathJax'], function(MathJax){
                     if(MathJax){
@@ -107,7 +107,6 @@ define([
          * Called during the runner's render phase
          */
         render : function render(){
-
             //attach the element before the content area
             var $container = this.getAreaBroker().getContentArea();
             $container.before(this.$element);

--- a/views/js/runner/plugins/content/rubricBlock/rubricBlock.js
+++ b/views/js/runner/plugins/content/rubricBlock/rubricBlock.js
@@ -19,17 +19,16 @@
 /**
  * Test Runner Content Plugin : RubricBlock
  *
- * TODO require mathjax on demand
- *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
     'jquery',
     'i18n',
+    'core/promise',
     'ui/hider',
     'taoTests/runner/plugin',
     'tpl!taoQtiTest/runner/plugins/content/rubricBlock/rubricBlock'
-], function ($, __, hider, pluginFactory, containerTpl){
+], function ($, __, Promise, hider, pluginFactory, containerTpl){
     'use strict';
 
     /**
@@ -38,6 +37,28 @@ define([
      */
     var blankifyLinks = function blankifyLinks($container){
         $('a', $container).attr('target', '_blank');
+    };
+
+    /**
+     * Apply mathjax
+     */
+    var mathify = function mathify($container) {
+        return new Promise(function(resolve){
+            if($('math', $container).length > 0){
+
+                //load mathjax only if necessary
+                require(['mathJax'], function(MathJax){
+                    if(MathJax){
+                        MathJax.Hub.Queue(["Typeset", MathJax.Hub], $container[0]);
+                        MathJax.Hub.Queue(resolve);
+                    } else {
+                        resolve();
+                    }
+                }, resolve);
+            } else {
+                resolve();
+            }
+        });
     };
 
     /**
@@ -62,13 +83,15 @@ define([
                 .on('ready', function(){
                     self.hide();
                 })
-                .on('loadrubricblock', function(rubrics){
-                    if(rubrics){
-                        self.$element.html(rubrics);
-                        blankifyLinks(self.$element);
+                .on('loaditem', function(itemRef, itemData){
+                    if(itemData.rubrics) {
+                        self.$element.html(itemData.rubrics);
 
-                        // notify that the rubric blocks are loaded
-                        testRunner.trigger('rubricblock');
+                        blankifyLinks(self.$element);
+                        mathify(self.$element).then(function(){
+                            // notify that the rubric blocks are loaded
+                            testRunner.trigger('rubricblock');
+                        });
                     }
                 })
                 .on('renderitem', function(){

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -618,10 +618,6 @@ define([
                 self.setItemState(itemRef, 'changed', true);
             };
 
-            if (itemData.rubrics) {
-                this.trigger('loadrubricblock', itemData.rubrics);
-            }
-
             return new Promise(function(resolve, reject){
                 assetManager.setData('baseUrl', itemData.baseUrl);
 

--- a/views/js/test/runner/plugins/content/rubricBlock/mathJaxMock.js
+++ b/views/js/test/runner/plugins/content/rubricBlock/mathJaxMock.js
@@ -1,0 +1,39 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Mock MathJax
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([], function(){
+    'use strict';
+
+    var mock =  {
+        called : false,
+        Hub : {
+            Queue : function(done){
+                if(typeof done === 'function'){
+                    mock.called = true;
+                    done();
+                }
+            }
+        }
+    };
+    return mock;
+});

--- a/views/js/test/runner/plugins/content/rubricBlock/test.html
+++ b/views/js/test/runner/plugins/content/rubricBlock/test.html
@@ -12,6 +12,14 @@
     <script  type="text/javascript">
         QUnit.config.autostart = false;
         require(['/tao/ClientConfig/config'], function(){
+            requirejs.config({
+                paths : {
+                    'mathJax' : '../../../taoQtiTest/views/js/test/runner/plugins/content/rubricBlock/mathJaxMock'
+                },
+                shim : {
+                    'mathJax' : {}
+                }
+            });
             require(['taoQtiTest/test/runner/plugins/content/rubricBlock/test'], function(){
                 QUnit.start();
             });

--- a/views/js/test/runner/plugins/content/rubricBlock/test.html
+++ b/views/js/test/runner/plugins/content/rubricBlock/test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Rubric Block - Test Runner Plugin test</title>
+    <base href="../../../../../../../../tao/views/" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/runner/plugins/content/rubricBlock/rubricBlock.js"></script>
+    <script  type="text/javascript">
+        QUnit.config.autostart = false;
+        require(['/tao/ClientConfig/config'], function(){
+            require(['taoQtiTest/test/runner/plugins/content/rubricBlock/test'], function(){
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+        <div id="item-container"></div>
+    </div>
+</body>
+</html>

--- a/views/js/test/runner/plugins/content/rubricBlock/test.js
+++ b/views/js/test/runner/plugins/content/rubricBlock/test.js
@@ -1,0 +1,211 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ */
+define([
+    'jquery',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/runner/plugins/content/rubricBlock/rubricBlock'
+], function($, runnerFactory, providerMock, pluginFactory) {
+    'use strict';
+
+    var pluginApi;
+    var providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    /**
+     * The following tests applies to all plugins
+     */
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', 3, function(assert) {
+        var runner = runnerFactory(providerName);
+
+        assert.equal(typeof pluginFactory, 'function', "The pluginFactory module exposes a function");
+        assert.equal(typeof pluginFactory(runner), 'object', "The plugin factory produces an instance");
+        assert.notStrictEqual(pluginFactory(runner), pluginFactory(runner), "The plugin factory provides a different instance on each call");
+    });
+
+
+    pluginApi = [
+        { name : 'init', title : 'init' },
+        { name : 'render', title : 'render' },
+        { name : 'finish', title : 'finish' },
+        { name : 'destroy', title : 'destroy' },
+        { name : 'trigger', title : 'trigger' },
+        { name : 'getTestRunner', title : 'getTestRunner' },
+        { name : 'getAreaBroker', title : 'getAreaBroker' },
+        { name : 'getConfig', title : 'getConfig' },
+        { name : 'setConfig', title : 'setConfig' },
+        { name : 'getState', title : 'getState' },
+        { name : 'setState', title : 'setState' },
+        { name : 'show', title : 'show' },
+        { name : 'hide', title : 'hide' },
+        { name : 'enable', title : 'enable' },
+        { name : 'disable', title : 'disable' }
+    ];
+
+    QUnit
+        .cases(pluginApi)
+        .test('plugin API ', 1, function(data, assert) {
+            var runner = runnerFactory(providerName);
+            var timer = pluginFactory(runner);
+            assert.equal(typeof timer[data.name], 'function', 'The pluginFactory instances expose a "' + data.name + '" function');
+        });
+
+
+    QUnit.module('load rubric blocks');
+
+    QUnit.asyncTest('render a rubric block', function(assert) {
+        var runner        = runnerFactory(providerName);
+        var plugin        = pluginFactory(runner, runner.getAreaBroker());
+
+        QUnit.expect(2);
+
+        runner.on('rubricblock', function(){
+            var $container = runner.getAreaBroker().getContainer();
+
+            assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
+            assert.equal($('#qti-rubrics', $container).html(), '<p>foo</p>', 'The rubric blocks content is loaded');
+            QUnit.start();
+        });
+
+        plugin
+            .init()
+            .then(plugin.render())
+            .then(function() {
+
+                runner.trigger('loaditem', 'foo', {
+                    rubrics : '<p>foo</p>'
+                });
+                runner.trigger('renderitem');
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('load / unload a rubric block', function(assert) {
+        var runner        = runnerFactory(providerName);
+        var plugin        = pluginFactory(runner, runner.getAreaBroker());
+
+        QUnit.expect(4);
+
+        runner
+            .after('renderitem', function(){
+                var $container = runner.getAreaBroker().getContainer();
+
+                assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
+                assert.equal($('#qti-rubrics', $container).children().length, 1, 'The rubric block element contains an child');
+            })
+            .after('unloaditem', function(){
+                var $container = runner.getAreaBroker().getContainer();
+
+                assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
+                assert.equal($('#qti-rubrics', $container).children().length, 0, 'The rubric block element is empty');
+
+                QUnit.start();
+            });
+
+        plugin
+            .init()
+            .then(plugin.render())
+            .then(function() {
+                runner.trigger('loaditem', 'foo', {
+                    rubrics : '<p>foo</p>'
+                });
+
+                runner.trigger('renderitem');
+
+                setTimeout(function(){
+                    runner.trigger('unloaditem');
+                }, 10);
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('render a rubric block with links', function(assert) {
+        var runner        = runnerFactory(providerName);
+        var plugin        = pluginFactory(runner, runner.getAreaBroker());
+
+        QUnit.expect(3);
+
+        runner.on('rubricblock', function(){
+            var $container = runner.getAreaBroker().getContainer();
+
+            assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
+            assert.equal($('#qti-rubrics a', $container).length, 1, 'The link is in the rubric block');
+            assert.equal($('#qti-rubrics a', $container).attr('target'), '_blank', 'The link has now a _blank target');
+            QUnit.start();
+        });
+
+        plugin
+            .init()
+            .then(plugin.render())
+            .then(function() {
+
+                runner.trigger('loaditem', 'foo', {
+                    rubrics : '<p><a href="http//taotesting.com">foo</a></p>'
+                });
+                runner.trigger('renderitem');
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('render a rubric block with math', function(assert) {
+        var runner        = runnerFactory(providerName);
+        var plugin        = pluginFactory(runner, runner.getAreaBroker());
+
+        QUnit.expect(2);
+
+        runner.on('rubricblock', function(){
+            var $container = runner.getAreaBroker().getContainer();
+
+            assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
+
+            //unfortunately we cannot assert the math content has been rendered correctly since mathjax is probaly not
+            //installed on the test runtime. We just assert the rubric block is loaded
+            assert.equal($('#qti-rubrics', $container).find('math').length, 1, 'The rubric blocks element contains a math element');
+
+            QUnit.start();
+        });
+
+        plugin
+            .init()
+            .then(plugin.render())
+            .then(function() {
+                runner.trigger('loaditem', 'foo', {
+                    rubrics : '<div><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mi>Δ</mi><mo>=</mo><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mrow><mn>4</mn><mo>⁢</mo<mi>a</mi<mo>⁢</mo<mi>c</mi></mrow></mro</math></div>'
+                });
+                runner.trigger('renderitem');
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+});

--- a/views/js/test/runner/plugins/content/rubricBlock/test.js
+++ b/views/js/test/runner/plugins/content/rubricBlock/test.js
@@ -17,13 +17,17 @@
  */
 
 /**
+ * Test the test runner plugin rubricBlock
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
     'jquery',
     'taoTests/runner/runner',
     'taoQtiTest/test/runner/mocks/providerMock',
-    'taoQtiTest/runner/plugins/content/rubricBlock/rubricBlock'
-], function($, runnerFactory, providerMock, pluginFactory) {
+    'taoQtiTest/runner/plugins/content/rubricBlock/rubricBlock',
+    'mathJax'
+], function($, runnerFactory, providerMock, pluginFactory, mathJaxMock) {
     'use strict';
 
     var pluginApi;
@@ -71,7 +75,11 @@ define([
         });
 
 
-    QUnit.module('load rubric blocks');
+    QUnit.module('load rubric blocks', {
+        setup : function(){
+            mathJaxMock.called = false;
+        }
+    });
 
     QUnit.asyncTest('render a rubric block', function(assert) {
         var runner        = runnerFactory(providerName);
@@ -180,19 +188,21 @@ define([
         var runner        = runnerFactory(providerName);
         var plugin        = pluginFactory(runner, runner.getAreaBroker());
 
-        QUnit.expect(2);
+        QUnit.expect(4);
 
         runner.on('rubricblock', function(){
             var $container = runner.getAreaBroker().getContainer();
 
             assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
 
-            //unfortunately we cannot assert the math content has been rendered correctly since mathjax is probaly not
-            //installed on the test runtime. We just assert the rubric block is loaded
+            //mathjax is mocked, so we don't assert the transformation
             assert.equal($('#qti-rubrics', $container).find('math').length, 1, 'The rubric blocks element contains a math element');
+            assert.ok(mathJaxMock.called, 'The mathJax mock has been called');
 
             QUnit.start();
         });
+
+        assert.ok(mathJaxMock.called === false, 'The mathJax mock has not been called');
 
         plugin
             .init()


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-test/pull/175

Change the way the rubric blocks are loaded using the usual runner lifecycle.
Load mathjax dynamically, only when math content is found on a rubricblock to prevent loading MathJax if not necessary. 
A test for this plugin has alos been added.