### PR TITLE
Fix/tao 4450 session uri

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '9.10.0',
+    'version'     => '9.10.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.2.0',

--- a/models/classes/TestSessionService.php
+++ b/models/classes/TestSessionService.php
@@ -98,6 +98,9 @@ class TestSessionService extends ConfigurableService
      */
     protected function hasTestSession($sessionId)
     {
+        if ($sessionId instanceof \core_kernel_classes_Resource) {
+            $sessionId = $sessionId->getUri();
+        }
         return (isset(self::$cache[$sessionId]) && isset(self::$cache[$sessionId]['session']));
     }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1253,5 +1253,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $registry->set('taoQtiTest', '\oat\taoQtiTest\models\QtiCategoryPresetProvider');
             $this->setVersion('9.10.0');
         }
+
+        $this->skip('9.10.0', '9.10.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4450

Another try to fix this weird issue. As the log is stating the offset is not of an acceptable type, I guess the method received a resource. So the fix is just to extract the `uri` from the provided resource.

Error from the log: `AH01071: Got error 'PHP message: PHP Warning: Illegal offset type in isset or empty in /var/www/html/tao/taoQtiTest/models/classes/TestSessionService.php on line 101
n', referer: http://ltiapps.net/test/tc.php`