### PR TITLE
Fix/tao 4459 no map support

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '9.10.1',
+    'version'     => '9.10.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1254,6 +1254,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('9.10.0');
         }
 
-        $this->skip('9.10.0', '9.10.1');
+        $this->skip('9.10.0', '9.10.2');
     }
 }

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -312,7 +312,7 @@ define([
                 var states = self.getTestData().states;
                 var item = mapHelper.getItemAt(testMap, context.itemPosition);
 
-                if(context.state !== states.interacting){
+                if(!item || context.state !== states.interacting){
                     return;
                 }
 


### PR DESCRIPTION
If the map doesn't contain items or items at the given position (adaptive tests for example) this at least prevent the TR to fail.