### PR TITLE
Fix version from previous fix so as not to get stuck on 9.12.0

### DIFF
--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1265,7 +1265,9 @@ class Updater extends \common_ext_ExtensionUpdater {
             $testModelService->setOption('exportHandlers', $exportHandlers);
             $this->getServiceManager()->register(TestModelService::SERVICE_ID, $testModelService);
 
-            $this->setVersion('9.12.1');
+            $this->setVersion('9.12.0');
         }
+
+        $this->skip('9.12.0', '9.12.1');
     }
 }


### PR DESCRIPTION
@chilly86, I thought you should see the fix to versioning from [your hotfix](https://github.com/oat-sa/extension-tao-testqti/pull/867). Basically, just incrementing the setVersion() function could place someone's version permanently into 9.12.0. So, you must add a skip() for these types of version increments.