### PR TITLE
Fix/tao 3069 double skip error

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '9.12.1',
+    'version'     => '9.12.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1268,6 +1268,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('9.12.0');
         }
 
-        $this->skip('9.12.0', '9.12.1');
+        $this->skip('9.12.0', '9.12.2');
     }
 }

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -283,13 +283,15 @@ define([
                             });
                         });
 
-                    submitItem.catch(function() {
-                        self.trigger('alert.submitError',
-                            __('An error occurred during results submission. Please retry.'),
-                            function () {
-                                self.trigger('resumeitem');
-                            }
-                        );
+                    submitItem.catch(function(err) {
+                        if (err !== true) {
+                            self.trigger('alert.submitError',
+                                __('An error occurred during results submission. Please retry.'),
+                                function () {
+                                    self.trigger('resumeitem');
+                                }
+                            );
+                        }
                     });
 
                     return submitItem;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3069

When the `enable-allow-skipping` option is set in the test runner config, the test taker cannot move to another question without answering the current item if the skipping is not allowed (item session control).

This behavior is implemented server side, so the test runner receives a notification after submit, and must prevent the move. A message is displayed to warn the test taker about the prohibition. However, the test runner displays two messages: one for the skipping not allowed, and another one for a connectivity issue. This second message should not be displayed, and this PR fix that.