### PR TITLE
To the testRunner configuration added new parameter 'next-section-pau…

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -166,6 +166,12 @@ return array(
     'next-section' => false,
 
     /**
+     * Turn the pause on when a section changed
+     * @type boolean
+     */
+    'next-section-paused' => false,
+
+    /**
      * After resuming test session timers will be reset to the time when the last item has been submitted.
      * @type boolean
      */

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '9.14.1',
+    'version'     => '9.15.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.2.0',

--- a/scripts/install/SetupEventListeners.php
+++ b/scripts/install/SetupEventListeners.php
@@ -21,6 +21,7 @@ namespace oat\taoQtiTest\scripts\install;
 
 use oat\oatbox\extension\InstallAction;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoQtiTest\models\event\QtiMoveEvent;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
 use oat\taoQtiTest\models\QtiTestListenerService;
 
@@ -36,5 +37,6 @@ class SetupEventListeners extends InstallAction
     {
         $this->registerEvent(DeliveryExecutionState::class, [QtiTestListenerService::SERVICE_ID, 'executionStateChanged']);
         $this->registerEvent(QtiTestStateChangeEvent::class, [QtiTestListenerService::SERVICE_ID, 'sessionStateChanged']);
+        $this->registerEvent(QtiMoveEvent::class, [QtiTestListenerService::SERVICE_ID, 'catchMove']);
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -19,9 +19,11 @@
 
 namespace oat\taoQtiTest\scripts\update;
 
+use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ServiceNotFoundException;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\accessControl\func\AclProxy;
+use oat\taoQtiTest\models\event\QtiMoveEvent;
 use oat\taoQtiTest\models\export\metadata\TestMetadataByClassExportHandler;
 use oat\taoQtiTest\models\TestCategoryPresetProvider;
 use oat\taoQtiTest\models\ExtendedStateService;
@@ -1271,5 +1273,19 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
       
         $this->skip('9.12.0', '9.14.1');
+
+        if ($this->isVersion('9.14.1')) {
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+            $extension->setConfig('testRunner', array_merge($config, [
+                'next-section-paused' => false,
+            ]));
+
+            $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+            $eventManager->attach(QtiMoveEvent::class, [QtiTestListenerService::SERVICE_ID, 'catchMove']);
+            $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+
+            $this->setVersion('9.15.0');
+        }
     }
 }


### PR DESCRIPTION
…sed' which pause delivery execution when section has changed