### PR TITLE
Fix spelling mistake of initialization

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '9.18.1',
+    'version'     => '9.18.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1288,6 +1288,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('9.18.0');
         }
 
-        $this->skip('9.18.0', '9.18.1');
+        $this->skip('9.18.0', '9.18.2');
     }
 }

--- a/views/js/controller/runner/runner.js
+++ b/views/js/controller/runner/runner.js
@@ -189,7 +189,7 @@ define([
                         .init();
                 })
                 .catch(function(err){
-                    onError(err, __('An error occured during the test iniialization!'));
+                    onError(err, __('An error occured during the test initialization!'));
                 });
         }
     };


### PR DESCRIPTION
A simple spelling mistake fix. I also need to update the translation files before merging.

So first, are po files populated programmatically? Or do I need to update the msgid for each file containing the misspelling manually?

Second, once po files are updated, how do I generate the .lang.php and .js file?