### PR TITLE
Fix/answer eliminator always enabled

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '10.1.0',
+    'version'     => '10.1.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1320,5 +1320,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('10.1.0');
         }
+
+        $this->skip('10.1.0', '10.1.1');
     }
 }

--- a/views/js/runner/plugins/tools/answerElimination/eliminator.js
+++ b/views/js/runner/plugins/tools/answerElimination/eliminator.js
@@ -142,7 +142,6 @@ define([
                 }
                 $choices = self.$choiceInteractions.find('.qti-choice');
 
-                self.$choiceInteractions.addClass('eliminable');
                 self.button.turnOn();
                 self.trigger('start');
 
@@ -216,7 +215,6 @@ define([
                 })
                 .on('enabletools renderitem', function (){
                     self.enable();
-                    enableEliminator();
                 })
                 .on('disabletools unloaditem', function (){
                     self.disable();


### PR DESCRIPTION
@dietertaotesting this simply reverts the previous pull request regarding answer eliminator not showing up on fullscreen. I didn't do a full look, but I'm guessing my previous pull request was just an error on my part. Fullscreen and eliminator appear to work fine without this change.