### PR TITLE
Feature/tao 4687 improve lti outcome

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '10.1.2',
+    'version'     => '10.2.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1321,6 +1321,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.1.0');
         }
 
-        $this->skip('10.1.0', '10.1.2');
+        $this->skip('10.1.0', '10.2.0');
     }
 }

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -68,7 +68,7 @@ define([
         cut: {
             key: 'cut',
             label: __('Cut score'),
-            description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed, the result will be compared to the cut score, then the PASS_TOTAL outcome will be set accordingly.')
+            description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed and divided by the sum of MAX SCORE, the result will be compared to the cut score (or pass ratio), then the PASS_TOTAL outcome will be set accordingly.')
                          + ' ' +
                          __('If the category option is set, the score will also be processed per categories, and each results will take place in the PASS_xxx outcome, where xxx is the name of the category.')
         }

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -393,9 +393,10 @@ define([
      */
     function addMaxScoreOutcomes(model, scoring, identifier, weight, category) {
         var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.FLOAT);
+        console.log('scoring.weightIdentifier', scoring.weightIdentifier);
         var processingRule = processingRuleHelper.setOutcomeValue(identifier,
             processingRuleHelper.sum(
-                processingRuleHelper.outcomeMaximum(scoring.scoreIdentifier, weight && scoring.weightIdentifier, category)
+                processingRuleHelper.testVariables('MAXSCORE', -1, weight && scoring.weightIdentifier, category)
             )
         );
         outcomeHelper.addOutcome(model, outcome, processingRule);

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -89,7 +89,7 @@ define([
         },
         total: {
             key: 'total',
-            signature: /^(SCORE)_([a-zA-Z][a-zA-Z0-9_\.-]*)$/,
+            signature: /^SCORE_([a-zA-Z][a-zA-Z0-9_\.-]*)$/,
             outcomes: [{
                 writer: 'total',
                 identifier: 'SCORE_TOTAL',
@@ -139,7 +139,12 @@ define([
      * @type {Object}
      */
     var outcomesWriters = {
-
+        /**
+         * Generates the outcomes that compute the "Score ratio"
+         * @param {Object} descriptor
+         * @param {Object} scoring
+         * @param {Object} outcomes
+         */
         ratio : function writerRatio(descriptor, scoring, outcomes){
             addRatioOutcomes(outcomes, descriptor.identifier, descriptor.scoreIdentifier.total, descriptor.scoreIdentifier.max);
             if(scoring.weightIdentifier){

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -142,7 +142,10 @@ define([
 
         ratio : function writerRatio(descriptor, scoring, outcomes){
             addRatioOutcomes(outcomes, descriptor.identifier, descriptor.scoreIdentifier.total, descriptor.scoreIdentifier.max);
-            addRatioOutcomes(outcomes, descriptor.weighted, descriptor.scoreWeighted.total, descriptor.scoreWeighted.max);
+            if(scoring.weightIdentifier){
+                //add weighted ratio outcome only when the scoring outcome processing rule uses a weight
+                addRatioOutcomes(outcomes, descriptor.weighted, descriptor.scoreWeighted.total, descriptor.scoreWeighted.max);
+            }
         },
 
         /**

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -393,7 +393,6 @@ define([
      */
     function addMaxScoreOutcomes(model, scoring, identifier, weight, category) {
         var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.FLOAT);
-        console.log('scoring.weightIdentifier', scoring.weightIdentifier);
         var processingRule = processingRuleHelper.setOutcomeValue(identifier,
             processingRuleHelper.sum(
                 processingRuleHelper.testVariables('MAXSCORE', -1, weight && scoring.weightIdentifier, category)

--- a/views/js/controller/creator/templates/outcomes.tpl
+++ b/views/js/controller/creator/templates/outcomes.tpl
@@ -13,6 +13,6 @@
     {{/each}}
 {{else}}
     <div class="grid-row">
-        <div class="col-12 line">{{__ 'There is not outcomes!'}}</div>
+        <div class="col-12 line">{{__ 'no outcome declaration found'}}</div>
     </div>
 {{/if}}

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -142,7 +142,7 @@
 <!-- assessmentTest/scoring/cutScore -->
         <div class="grid-row test-cut-score">
             <div class="col-5">
-                <label for="test-cut-score">{{__ 'Cut score'}}</label>
+                <label for="test-cut-score">{{__ 'Cut score (pass ratio)'}}</label>
             </div>
             <div class="col-6">
                 <input type="text" name="test-cut-score" value="0" data-bind="scoring.cutScore" data-bind-encoder="float" data-validate="$numeric;" />
@@ -150,7 +150,7 @@
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
                 <div class="tooltip-content">
-                    {{__ "Set the cut score associated to the test"}}
+                    {{__ "Set the cut score (or pass score ratio) associated to the test. It must be a float between 0 and 1."}}
                 </div>
             </div>
         </div>

--- a/views/js/test/creator/samples/scoringCut.json
+++ b/views/js/test/creator/samples/scoringCut.json
@@ -171,12 +171,13 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
-                            "weightIdentifier": ""
+                            "variableIdentifier": "MAXSCORE",
+                            "weightIdentifier":  ""
                         }
                     ],
                     "maxOperands": -1,
@@ -199,11 +200,12 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],

--- a/views/js/test/creator/samples/scoringCut.json
+++ b/views/js/test/creator/samples/scoringCut.json
@@ -1,529 +1,720 @@
 {
-  "qti-type": "assessmentTest",
-  "identifier": "Test-1",
-  "title": "Test 1",
-  "outcomeDeclarations": [{
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_ALL",
-    "cardinality": 0,
-    "baseType": 1
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_ALL_RENDERING",
-    "cardinality": 0,
-    "baseType": 0
-  }],
-  "timeLimits": {
-    "qti-type": "timeLimits",
-    "allowLateSubmission": false
-  },
-  "testParts": [{
-    "qti-type": "testPart",
-    "identifier": "testPart-1",
-    "navigationMode": 0,
-    "submissionMode": 0,
-    "preConditions": [],
-    "branchRules": [],
-    "itemSessionControl": {
-      "qti-type": "itemSessionControl",
-      "maxAttempts": 0,
-      "showFeedback": false,
-      "allowReview": true,
-      "showSolution": false,
-      "allowComment": false,
-      "validateResponses": false,
-      "allowSkipping": false
-    },
-    "timeLimits": {
-      "qti-type": "timeLimits",
-      "allowLateSubmission": false
-    },
-    "assessmentSections": [{
-      "qti-type": "assessmentSection",
-      "title": "Section 1",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090611690885",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-1",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+    "identifier": "Test-1",
+    "outcomeDeclarations": [
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090613110988",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-3",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090616225291",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-2",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-1",
-      "required": true,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 0
-    }, {
-      "qti-type": "assessmentSection",
-      "title": "Section 2",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i148309061819894",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-4",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090620510297",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-5",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i14830906232870100",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-6",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-2",
-      "required": false,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 1
-    }],
-    "testFeedbacks": [],
-    "index": 0
-  }],
-  "outcomeProcessing": {
-    "qti-type": "outcomeProcessing",
-    "outcomeRules": [{
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_TOTAL_MAX",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "PASS_ALL",
-      "expression": {
-        "qti-type": "gte",
-        "minOperands": 2,
-        "maxOperands": 2,
-        "acceptedCardinalities": [0],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "divide",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [0],
-          "acceptedBaseTypes": [2, 3],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_WEIGHTED",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "variable",
-            "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-            "weightIdentifier": ""
-          }]
-        }, {
-          "qti-type": "baseValue",
-          "baseType": 3,
-          "value": 60
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "match",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [4],
-          "acceptedBaseTypes": [4],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "PASS_ALL",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "baseValue",
-            "baseType": 1,
-            "value": true
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_ALL_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL_MAX",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 1,
+            "cardinality": 0,
+            "identifier": "PASS_ALL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
             "baseType": 0,
-            "value": "passed"
-          }
-        }]
-      },
-      "outcomeElseIfs": [],
-      "outcomeElse": {
-        "qti-type": "outcomeElse",
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_ALL_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
-            "baseType": 0,
-            "value": "not_passed"
-          }
-        }]
-      }
-    }]
-  },
-  "testFeedbacks": []
+            "cardinality": 0,
+            "identifier": "PASS_ALL_RENDERING",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        }
+    ],
+    "outcomeProcessing": {
+        "outcomeRules": [
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0
+                    ],
+                    "expressions": [
+                        {
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "variable",
+                            "weightIdentifier": ""
+                        },
+                        {
+                            "baseType": 3,
+                            "qti-type": "baseValue",
+                            "value": 60
+                        }
+                    ],
+                    "maxOperands": 2,
+                    "minOperands": 2,
+                    "qti-type": "gte"
+                },
+                "identifier": "PASS_ALL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "not_passed"
+                            },
+                            "identifier": "PASS_ALL_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            4
+                        ],
+                        "acceptedCardinalities": [
+                            4
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "PASS_ALL",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            },
+                            {
+                                "baseType": 1,
+                                "qti-type": "baseValue",
+                                "value": true
+                            }
+                        ],
+                        "maxOperands": 2,
+                        "minOperands": 2,
+                        "qti-type": "match"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "passed"
+                            },
+                            "identifier": "PASS_ALL_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            }
+        ],
+        "qti-type": "outcomeProcessing"
+    },
+    "qti-type": "assessmentTest",
+    "testFeedbacks": [],
+    "testParts": [
+        {
+            "assessmentSections": [
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-1",
+                    "index": 0,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": true,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090611690885",
+                            "identifier": "item-1",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090613110988",
+                            "identifier": "item-3",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090616225291",
+                            "identifier": "item-2",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 1",
+                    "visible": true
+                },
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-2",
+                    "index": 1,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": false,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i148309061819894",
+                            "identifier": "item-4",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090620510297",
+                            "identifier": "item-5",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i14830906232870100",
+                            "identifier": "item-6",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 2",
+                    "visible": true
+                }
+            ],
+            "branchRules": [],
+            "identifier": "testPart-1",
+            "index": 0,
+            "itemSessionControl": {
+                "allowComment": false,
+                "allowReview": true,
+                "allowSkipping": false,
+                "maxAttempts": 0,
+                "qti-type": "itemSessionControl",
+                "showFeedback": false,
+                "showSolution": false,
+                "validateResponses": false
+            },
+            "navigationMode": 0,
+            "preConditions": [],
+            "qti-type": "testPart",
+            "submissionMode": 0,
+            "testFeedbacks": [],
+            "timeLimits": {
+                "allowLateSubmission": false,
+                "qti-type": "timeLimits"
+            }
+        }
+    ],
+    "timeLimits": {
+        "allowLateSubmission": false,
+        "qti-type": "timeLimits"
+    },
+    "title": "Test 1"
 }

--- a/views/js/test/creator/samples/scoringCutCategory.json
+++ b/views/js/test/creator/samples/scoringCutCategory.json
@@ -439,11 +439,12 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -467,11 +468,12 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],
@@ -495,13 +497,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "history"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -525,13 +528,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "history"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],
@@ -555,13 +559,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "math"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -585,13 +590,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "math"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],

--- a/views/js/test/creator/samples/scoringCutCategory.json
+++ b/views/js/test/creator/samples/scoringCutCategory.json
@@ -1,1067 +1,1312 @@
 {
-  "qti-type": "assessmentTest",
-  "identifier": "Test-1",
-  "title": "Test 1",
-  "outcomeDeclarations": [{
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MAX_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_ALL",
-    "cardinality": 0,
-    "baseType": 1
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_ALL_RENDERING",
-    "cardinality": 0,
-    "baseType": 0
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_CATEGORY_HISTORY",
-    "cardinality": 0,
-    "baseType": 1
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_CATEGORY_HISTORY_RENDERING",
-    "cardinality": 0,
-    "baseType": 0
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_CATEGORY_MATH",
-    "cardinality": 0,
-    "baseType": 1
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "PASS_CATEGORY_MATH_RENDERING",
-    "cardinality": 0,
-    "baseType": 0
-  }],
-  "timeLimits": {
-    "qti-type": "timeLimits",
-    "allowLateSubmission": false
-  },
-  "testParts": [{
-    "qti-type": "testPart",
-    "identifier": "testPart-1",
-    "navigationMode": 0,
-    "submissionMode": 0,
-    "preConditions": [],
-    "branchRules": [],
-    "itemSessionControl": {
-      "qti-type": "itemSessionControl",
-      "maxAttempts": 0,
-      "showFeedback": false,
-      "allowReview": true,
-      "showSolution": false,
-      "allowComment": false,
-      "validateResponses": false,
-      "allowSkipping": false
-    },
-    "timeLimits": {
-      "qti-type": "timeLimits",
-      "allowLateSubmission": false
-    },
-    "assessmentSections": [{
-      "qti-type": "assessmentSection",
-      "title": "Section 1",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090611690885",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-1",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+    "identifier": "Test-1",
+    "outcomeDeclarations": [
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090613110988",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-3",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090616225291",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-2",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-1",
-      "required": true,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 0
-    }, {
-      "qti-type": "assessmentSection",
-      "title": "Section 2",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i148309061819894",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-4",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090620510297",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-5",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i14830906232870100",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-6",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-2",
-      "required": false,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 1
-    }],
-    "testFeedbacks": [],
-    "index": 0
-  }],
-  "outcomeProcessing": {
-    "qti-type": "outcomeProcessing",
-    "outcomeRules": [{
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_TOTAL_MAX",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["history"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["history"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MAX_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_CATEGORY_MAX_MATH",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_MAX_MATH",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["math"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-            "weightIdentifier": ""
-          }]
-        },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["math"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "PASS_ALL",
-      "expression": {
-        "qti-type": "gte",
-        "minOperands": 2,
-        "maxOperands": 2,
-        "acceptedCardinalities": [0],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "divide",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [0],
-          "acceptedBaseTypes": [2, 3],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_WEIGHTED",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "variable",
-            "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-            "weightIdentifier": ""
-          }]
-        }, {
-          "qti-type": "baseValue",
-          "baseType": 3,
-          "value": 60
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "match",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [4],
-          "acceptedBaseTypes": [4],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "PASS_ALL",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "baseValue",
-            "baseType": 1,
-            "value": true
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_ALL_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
-            "baseType": 0,
-            "value": "passed"
-          }
-        }]
-      },
-      "outcomeElseIfs": [],
-      "outcomeElse": {
-        "qti-type": "outcomeElse",
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_ALL_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
-            "baseType": 0,
-            "value": "not_passed"
-          }
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "PASS_CATEGORY_HISTORY",
-      "expression": {
-        "qti-type": "gte",
-        "minOperands": 2,
-        "maxOperands": 2,
-        "acceptedCardinalities": [0],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "divide",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [0],
-          "acceptedBaseTypes": [2, 3],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_HISTORY",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "variable",
-            "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-            "weightIdentifier": ""
-          }]
-        }, {
-          "qti-type": "baseValue",
-          "baseType": 3,
-          "value": 60
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "match",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [4],
-          "acceptedBaseTypes": [4],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "PASS_CATEGORY_HISTORY",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "baseValue",
-            "baseType": 1,
-            "value": true
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_CATEGORY_HISTORY_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
-            "baseType": 0,
-            "value": "passed"
-          }
-        }]
-      },
-      "outcomeElseIfs": [],
-      "outcomeElse": {
-        "qti-type": "outcomeElse",
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_CATEGORY_HISTORY_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
-            "baseType": 0,
-            "value": "not_passed"
-          }
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "PASS_CATEGORY_MATH",
-      "expression": {
-        "qti-type": "gte",
-        "minOperands": 2,
-        "maxOperands": 2,
-        "acceptedCardinalities": [0],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "divide",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [0],
-          "acceptedBaseTypes": [2, 3],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_MATH",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "variable",
-            "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-            "weightIdentifier": ""
-          }]
-        }, {
-          "qti-type": "baseValue",
-          "baseType": 3,
-          "value": 60
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "match",
-          "minOperands": 2,
-          "maxOperands": 2,
-          "acceptedCardinalities": [4],
-          "acceptedBaseTypes": [4],
-          "expressions": [{
-            "qti-type": "variable",
-            "identifier": "PASS_CATEGORY_MATH",
-            "weightIdentifier": ""
-          }, {
-            "qti-type": "baseValue",
-            "baseType": 1,
-            "value": true
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_CATEGORY_MATH_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL_MAX",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_MAX_HISTORY",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_MAX_MATH",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 1,
+            "cardinality": 0,
+            "identifier": "PASS_ALL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
             "baseType": 0,
-            "value": "passed"
-          }
-        }]
-      },
-      "outcomeElseIfs": [],
-      "outcomeElse": {
-        "qti-type": "outcomeElse",
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "PASS_CATEGORY_MATH_RENDERING",
-          "expression": {
-            "qti-type": "baseValue",
+            "cardinality": 0,
+            "identifier": "PASS_ALL_RENDERING",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 1,
+            "cardinality": 0,
+            "identifier": "PASS_CATEGORY_HISTORY",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
             "baseType": 0,
-            "value": "not_passed"
-          }
-        }]
-      }
-    }]
-  },
-  "testFeedbacks": []
+            "cardinality": 0,
+            "identifier": "PASS_CATEGORY_HISTORY_RENDERING",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 1,
+            "cardinality": 0,
+            "identifier": "PASS_CATEGORY_MATH",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 0,
+            "cardinality": 0,
+            "identifier": "PASS_CATEGORY_MATH_RENDERING",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        }
+    ],
+    "outcomeProcessing": {
+        "outcomeRules": [
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MAX_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MAX_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0
+                    ],
+                    "expressions": [
+                        {
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "variable",
+                            "weightIdentifier": ""
+                        },
+                        {
+                            "baseType": 3,
+                            "qti-type": "baseValue",
+                            "value": 60
+                        }
+                    ],
+                    "maxOperands": 2,
+                    "minOperands": 2,
+                    "qti-type": "gte"
+                },
+                "identifier": "PASS_ALL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "not_passed"
+                            },
+                            "identifier": "PASS_ALL_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            4
+                        ],
+                        "acceptedCardinalities": [
+                            4
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "PASS_ALL",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            },
+                            {
+                                "baseType": 1,
+                                "qti-type": "baseValue",
+                                "value": true
+                            }
+                        ],
+                        "maxOperands": 2,
+                        "minOperands": 2,
+                        "qti-type": "match"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "passed"
+                            },
+                            "identifier": "PASS_ALL_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0
+                    ],
+                    "expressions": [
+                        {
+                            "acceptedBaseTypes": [
+                                2,
+                                3
+                            ],
+                            "acceptedCardinalities": [
+                                0
+                            ],
+                            "expressions": [
+                                {
+                                    "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
+                                    "qti-type": "variable",
+                                    "weightIdentifier": ""
+                                },
+                                {
+                                    "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
+                                    "qti-type": "variable",
+                                    "weightIdentifier": ""
+                                }
+                            ],
+                            "maxOperands": 2,
+                            "minOperands": 2,
+                            "qti-type": "divide"
+                        },
+                        {
+                            "baseType": 3,
+                            "qti-type": "baseValue",
+                            "value": 60
+                        }
+                    ],
+                    "maxOperands": 2,
+                    "minOperands": 2,
+                    "qti-type": "gte"
+                },
+                "identifier": "PASS_CATEGORY_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "not_passed"
+                            },
+                            "identifier": "PASS_CATEGORY_HISTORY_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            4
+                        ],
+                        "acceptedCardinalities": [
+                            4
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "PASS_CATEGORY_HISTORY",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            },
+                            {
+                                "baseType": 1,
+                                "qti-type": "baseValue",
+                                "value": true
+                            }
+                        ],
+                        "maxOperands": 2,
+                        "minOperands": 2,
+                        "qti-type": "match"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "passed"
+                            },
+                            "identifier": "PASS_CATEGORY_HISTORY_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0
+                    ],
+                    "expressions": [
+                        {
+                            "acceptedBaseTypes": [
+                                2,
+                                3
+                            ],
+                            "acceptedCardinalities": [
+                                0
+                            ],
+                            "expressions": [
+                                {
+                                    "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
+                                    "qti-type": "variable",
+                                    "weightIdentifier": ""
+                                },
+                                {
+                                    "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
+                                    "qti-type": "variable",
+                                    "weightIdentifier": ""
+                                }
+                            ],
+                            "maxOperands": 2,
+                            "minOperands": 2,
+                            "qti-type": "divide"
+                        },
+                        {
+                            "baseType": 3,
+                            "qti-type": "baseValue",
+                            "value": 60
+                        }
+                    ],
+                    "maxOperands": 2,
+                    "minOperands": 2,
+                    "qti-type": "gte"
+                },
+                "identifier": "PASS_CATEGORY_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "not_passed"
+                            },
+                            "identifier": "PASS_CATEGORY_MATH_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            4
+                        ],
+                        "acceptedCardinalities": [
+                            4
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "PASS_CATEGORY_MATH",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            },
+                            {
+                                "baseType": 1,
+                                "qti-type": "baseValue",
+                                "value": true
+                            }
+                        ],
+                        "maxOperands": 2,
+                        "minOperands": 2,
+                        "qti-type": "match"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 0,
+                                "qti-type": "baseValue",
+                                "value": "passed"
+                            },
+                            "identifier": "PASS_CATEGORY_MATH_RENDERING",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            }
+        ],
+        "qti-type": "outcomeProcessing"
+    },
+    "qti-type": "assessmentTest",
+    "testFeedbacks": [],
+    "testParts": [
+        {
+            "assessmentSections": [
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-1",
+                    "index": 0,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": true,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090611690885",
+                            "identifier": "item-1",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090613110988",
+                            "identifier": "item-3",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090616225291",
+                            "identifier": "item-2",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 1",
+                    "visible": true
+                },
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-2",
+                    "index": 1,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": false,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i148309061819894",
+                            "identifier": "item-4",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090620510297",
+                            "identifier": "item-5",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i14830906232870100",
+                            "identifier": "item-6",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 2",
+                    "visible": true
+                }
+            ],
+            "branchRules": [],
+            "identifier": "testPart-1",
+            "index": 0,
+            "itemSessionControl": {
+                "allowComment": false,
+                "allowReview": true,
+                "allowSkipping": false,
+                "maxAttempts": 0,
+                "qti-type": "itemSessionControl",
+                "showFeedback": false,
+                "showSolution": false,
+                "validateResponses": false
+            },
+            "navigationMode": 0,
+            "preConditions": [],
+            "qti-type": "testPart",
+            "submissionMode": 0,
+            "testFeedbacks": [],
+            "timeLimits": {
+                "allowLateSubmission": false,
+                "qti-type": "timeLimits"
+            }
+        }
+    ],
+    "timeLimits": {
+        "allowLateSubmission": false,
+        "qti-type": "timeLimits"
+    },
+    "title": "Test 1"
 }

--- a/views/js/test/creator/samples/scoringTotal.json
+++ b/views/js/test/creator/samples/scoringTotal.json
@@ -82,12 +82,13 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
-                            "weightIdentifier": ""
+                            "variableIdentifier": "MAXSCORE",
+                            "weightIdentifier":  ""
                         }
                     ],
                     "maxOperands": -1,

--- a/views/js/test/creator/samples/scoringTotal.json
+++ b/views/js/test/creator/samples/scoringTotal.json
@@ -1,347 +1,451 @@
 {
-  "qti-type": "assessmentTest",
-  "identifier": "Test-1",
-  "title": "Test 1",
-  "outcomeDeclarations": [{
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX",
-    "cardinality": 0,
-    "baseType": 3
-  }],
-  "timeLimits": {
-    "qti-type": "timeLimits",
-    "allowLateSubmission": false
-  },
-  "testParts": [{
-    "qti-type": "testPart",
-    "identifier": "testPart-1",
-    "navigationMode": 0,
-    "submissionMode": 0,
-    "preConditions": [],
-    "branchRules": [],
-    "itemSessionControl": {
-      "qti-type": "itemSessionControl",
-      "maxAttempts": 0,
-      "showFeedback": false,
-      "allowReview": true,
-      "showSolution": false,
-      "allowComment": false,
-      "validateResponses": false,
-      "allowSkipping": false
-    },
-    "timeLimits": {
-      "qti-type": "timeLimits",
-      "allowLateSubmission": false
-    },
-    "assessmentSections": [{
-      "qti-type": "assessmentSection",
-      "title": "Section 1",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090611690885",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-1",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+    "identifier": "Test-1",
+    "outcomeDeclarations": [
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090613110988",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-3",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090616225291",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-2",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-1",
-      "required": true,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 0
-    }, {
-      "qti-type": "assessmentSection",
-      "title": "Section 2",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i148309061819894",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-4",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090620510297",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-5",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i14830906232870100",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-6",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-2",
-      "required": false,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 1
-    }],
-    "testFeedbacks": [],
-    "index": 0
-  }],
-  "outcomeProcessing": {
-    "qti-type": "outcomeProcessing",
-    "outcomeRules": [{
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_MAX",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }]
-  },
-  "testFeedbacks": []
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        }
+    ],
+    "outcomeProcessing": {
+        "outcomeRules": [
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            }
+        ],
+        "qti-type": "outcomeProcessing"
+    },
+    "qti-type": "assessmentTest",
+    "testFeedbacks": [],
+    "testParts": [
+        {
+            "assessmentSections": [
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-1",
+                    "index": 0,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": true,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090611690885",
+                            "identifier": "item-1",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090613110988",
+                            "identifier": "item-3",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090616225291",
+                            "identifier": "item-2",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 1",
+                    "visible": true
+                },
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-2",
+                    "index": 1,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": false,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i148309061819894",
+                            "identifier": "item-4",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090620510297",
+                            "identifier": "item-5",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i14830906232870100",
+                            "identifier": "item-6",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 2",
+                    "visible": true
+                }
+            ],
+            "branchRules": [],
+            "identifier": "testPart-1",
+            "index": 0,
+            "itemSessionControl": {
+                "allowComment": false,
+                "allowReview": true,
+                "allowSkipping": false,
+                "maxAttempts": 0,
+                "qti-type": "itemSessionControl",
+                "showFeedback": false,
+                "showSolution": false,
+                "validateResponses": false
+            },
+            "navigationMode": 0,
+            "preConditions": [],
+            "qti-type": "testPart",
+            "submissionMode": 0,
+            "testFeedbacks": [],
+            "timeLimits": {
+                "allowLateSubmission": false,
+                "qti-type": "timeLimits"
+            }
+        }
+    ],
+    "timeLimits": {
+        "allowLateSubmission": false,
+        "qti-type": "timeLimits"
+    },
+    "title": "Test 1"
 }

--- a/views/js/test/creator/samples/scoringTotalCategory.json
+++ b/views/js/test/creator/samples/scoringTotalCategory.json
@@ -1,521 +1,621 @@
 {
-  "qti-type": "assessmentTest",
-  "identifier": "Test-1",
-  "title": "Test 1",
-  "outcomeDeclarations": [{
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MAX_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }],
-  "timeLimits": {
-    "qti-type": "timeLimits",
-    "allowLateSubmission": false
-  },
-  "testParts": [{
-    "qti-type": "testPart",
-    "identifier": "testPart-1",
-    "navigationMode": 0,
-    "submissionMode": 0,
-    "preConditions": [],
-    "branchRules": [],
-    "itemSessionControl": {
-      "qti-type": "itemSessionControl",
-      "maxAttempts": 0,
-      "showFeedback": false,
-      "allowReview": true,
-      "showSolution": false,
-      "allowComment": false,
-      "validateResponses": false,
-      "allowSkipping": false
-    },
-    "timeLimits": {
-      "qti-type": "timeLimits",
-      "allowLateSubmission": false
-    },
-    "assessmentSections": [{
-      "qti-type": "assessmentSection",
-      "title": "Section 1",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090611690885",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-1",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+    "identifier": "Test-1",
+    "outcomeDeclarations": [
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_HISTORY",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090613110988",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-3",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_MATH",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090616225291",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-2",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-1",
-      "required": true,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 0
-    }, {
-      "qti-type": "assessmentSection",
-      "title": "Section 2",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i148309061819894",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-4",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090620510297",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-5",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i14830906232870100",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [],
-        "templateDefaults": {},
-        "identifier": "item-6",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-2",
-      "required": false,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 1
-    }],
-    "testFeedbacks": [],
-    "index": 0
-  }],
-  "outcomeProcessing": {
-    "qti-type": "outcomeProcessing",
-    "outcomeRules": [{
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_MAX",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["history"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MAX_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_MAX_MATH",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_MAX_MATH",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["math"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }]
-  },
-  "testFeedbacks": []
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        }
+    ],
+    "outcomeProcessing": {
+        "outcomeRules": [
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MAX_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MAX_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            }
+        ],
+        "qti-type": "outcomeProcessing"
+    },
+    "qti-type": "assessmentTest",
+    "testFeedbacks": [],
+    "testParts": [
+        {
+            "assessmentSections": [
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-1",
+                    "index": 0,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": true,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090611690885",
+                            "identifier": "item-1",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090613110988",
+                            "identifier": "item-3",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090616225291",
+                            "identifier": "item-2",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 1",
+                    "visible": true
+                },
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-2",
+                    "index": 1,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": false,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i148309061819894",
+                            "identifier": "item-4",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090620510297",
+                            "identifier": "item-5",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i14830906232870100",
+                            "identifier": "item-6",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": []
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 2",
+                    "visible": true
+                }
+            ],
+            "branchRules": [],
+            "identifier": "testPart-1",
+            "index": 0,
+            "itemSessionControl": {
+                "allowComment": false,
+                "allowReview": true,
+                "allowSkipping": false,
+                "maxAttempts": 0,
+                "qti-type": "itemSessionControl",
+                "showFeedback": false,
+                "showSolution": false,
+                "validateResponses": false
+            },
+            "navigationMode": 0,
+            "preConditions": [],
+            "qti-type": "testPart",
+            "submissionMode": 0,
+            "testFeedbacks": [],
+            "timeLimits": {
+                "allowLateSubmission": false,
+                "qti-type": "timeLimits"
+            }
+        }
+    ],
+    "timeLimits": {
+        "allowLateSubmission": false,
+        "qti-type": "timeLimits"
+    },
+    "title": "Test 1"
 }

--- a/views/js/test/creator/samples/scoringTotalCategory.json
+++ b/views/js/test/creator/samples/scoringTotalCategory.json
@@ -192,11 +192,13 @@
                     ],
                     "expressions": [
                         {
+                            "sectionIdentifier": "",
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -220,13 +222,13 @@
                     ],
                     "expressions": [
                         {
-                            "excludeCategories": [],
-                            "includeCategories": [
-                                "history"
-                            ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
                             "sectionIdentifier": "",
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": ["history"],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -250,13 +252,13 @@
                     ],
                     "expressions": [
                         {
-                            "excludeCategories": [],
-                            "includeCategories": [
-                                "math"
-                            ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
                             "sectionIdentifier": "",
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": ["math"],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],

--- a/views/js/test/creator/samples/scoringTotalCategoryWeighted.json
+++ b/views/js/test/creator/samples/scoringTotalCategoryWeighted.json
@@ -1,802 +1,983 @@
 {
-  "qti-type": "assessmentTest",
-  "identifier": "Test-1",
-  "title": "Test 1",
-  "outcomeDeclarations": [{
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_MAX_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-    "cardinality": 0,
-    "baseType": 3
-  }],
-  "timeLimits": {
-    "qti-type": "timeLimits",
-    "allowLateSubmission": false
-  },
-  "testParts": [{
-    "qti-type": "testPart",
-    "identifier": "testPart-1",
-    "navigationMode": 0,
-    "submissionMode": 0,
-    "preConditions": [],
-    "branchRules": [],
-    "itemSessionControl": {
-      "qti-type": "itemSessionControl",
-      "maxAttempts": 0,
-      "showFeedback": false,
-      "allowReview": true,
-      "showSolution": false,
-      "allowComment": false,
-      "validateResponses": false,
-      "allowSkipping": false
-    },
-    "timeLimits": {
-      "qti-type": "timeLimits",
-      "allowLateSubmission": false
-    },
-    "assessmentSections": [{
-      "qti-type": "assessmentSection",
-      "title": "Section 1",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090611690885",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-1",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+    "identifier": "Test-1",
+    "outcomeDeclarations": [
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090613110988",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-3",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_HISTORY",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090616225291",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-2",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_MATH",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-1",
-      "required": true,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 0
-    }, {
-      "qti-type": "assessmentSection",
-      "title": "Section 2",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i148309061819894",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-4",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090620510297",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-5",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i14830906232870100",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-6",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-2",
-      "required": false,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 1
-    }],
-    "testFeedbacks": [],
-    "index": 0
-  }],
-  "outcomeProcessing": {
-    "qti-type": "outcomeProcessing",
-    "outcomeRules": [{
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_MAX",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_MAX_HISTORY",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["history"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["history"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["history"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_MAX_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_MAX_MATH",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_MAX_MATH",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["math"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": ["math"],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": ["math"],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }]
-  },
-  "testFeedbacks": []
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        }
+    ],
+    "outcomeProcessing": {
+        "outcomeRules": [
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MAX_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "history"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_HISTORY",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_MAX_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [
+                                "math"
+                            ],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_CATEGORY_WEIGHTED_MAX_MATH",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            }
+        ],
+        "qti-type": "outcomeProcessing"
+    },
+    "qti-type": "assessmentTest",
+    "testFeedbacks": [],
+    "testParts": [
+        {
+            "assessmentSections": [
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-1",
+                    "index": 0,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": true,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090611690885",
+                            "identifier": "item-1",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090613110988",
+                            "identifier": "item-3",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090616225291",
+                            "identifier": "item-2",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 1",
+                    "visible": true
+                },
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-2",
+                    "index": 1,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": false,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i148309061819894",
+                            "identifier": "item-4",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090620510297",
+                            "identifier": "item-5",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i14830906232870100",
+                            "identifier": "item-6",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 2",
+                    "visible": true
+                }
+            ],
+            "branchRules": [],
+            "identifier": "testPart-1",
+            "index": 0,
+            "itemSessionControl": {
+                "allowComment": false,
+                "allowReview": true,
+                "allowSkipping": false,
+                "maxAttempts": 0,
+                "qti-type": "itemSessionControl",
+                "showFeedback": false,
+                "showSolution": false,
+                "validateResponses": false
+            },
+            "navigationMode": 0,
+            "preConditions": [],
+            "qti-type": "testPart",
+            "submissionMode": 0,
+            "testFeedbacks": [],
+            "timeLimits": {
+                "allowLateSubmission": false,
+                "qti-type": "timeLimits"
+            }
+        }
+    ],
+    "timeLimits": {
+        "allowLateSubmission": false,
+        "qti-type": "timeLimits"
+    },
+    "title": "Test 1"
 }

--- a/views/js/test/creator/samples/scoringTotalCategoryWeighted.json
+++ b/views/js/test/creator/samples/scoringTotalCategoryWeighted.json
@@ -367,11 +367,12 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -395,11 +396,12 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],
@@ -423,13 +425,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "history"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -453,13 +456,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "history"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],
@@ -483,13 +487,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "math"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -513,13 +518,14 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [
                                 "math"
                             ],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],

--- a/views/js/test/creator/samples/scoringTotalWeighted.json
+++ b/views/js/test/creator/samples/scoringTotalWeighted.json
@@ -1,454 +1,643 @@
 {
-  "qti-type": "assessmentTest",
-  "identifier": "Test-1",
-  "title": "Test 1",
-  "outcomeDeclarations": [{
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX",
-    "cardinality": 0,
-    "baseType": 3
-  }, {
-    "qti-type": "outcomeDeclaration",
-    "views": [],
-    "interpretation": "",
-    "longInterpretation": "",
-    "normalMaximum": false,
-    "normalMinimum": false,
-    "masteryValue": false,
-    "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-    "cardinality": 0,
-    "baseType": 3
-  }],
-  "timeLimits": {
-    "qti-type": "timeLimits",
-    "allowLateSubmission": false
-  },
-  "testParts": [{
-    "qti-type": "testPart",
-    "identifier": "testPart-1",
-    "navigationMode": 0,
-    "submissionMode": 0,
-    "preConditions": [],
-    "branchRules": [],
-    "itemSessionControl": {
-      "qti-type": "itemSessionControl",
-      "maxAttempts": 0,
-      "showFeedback": false,
-      "allowReview": true,
-      "showSolution": false,
-      "allowComment": false,
-      "validateResponses": false,
-      "allowSkipping": false
-    },
-    "timeLimits": {
-      "qti-type": "timeLimits",
-      "allowLateSubmission": false
-    },
-    "assessmentSections": [{
-      "qti-type": "assessmentSection",
-      "title": "Section 1",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090611690885",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-1",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
+    "identifier": "Test-1",
+    "outcomeDeclarations": [
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_TOTAL_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090613110988",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-3",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090616225291",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-2",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-1",
-      "required": true,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 0
-    }, {
-      "qti-type": "assessmentSection",
-      "title": "Section 2",
-      "visible": true,
-      "keepTogether": true,
-      "rubricBlocks": [],
-      "sectionParts": [{
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i148309061819894",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-4",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 0
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i1483090620510297",
-        "categories": ["history"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-5",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 1
-      }, {
-        "qti-type": "assessmentItemRef",
-        "href": "http://tao.dev/tao.rdf#i14830906232870100",
-        "categories": ["math"],
-        "variableMappings": {},
-        "weights": [{
-          "qti-type": "weight",
-          "identifier": "WEIGHT",
-          "value": 1
-        }],
-        "templateDefaults": {},
-        "identifier": "item-6",
-        "required": false,
-        "fixed": false,
-        "preConditions": [],
-        "branchRules": [],
-        "itemSessionControl": {
-          "qti-type": "itemSessionControl",
-          "maxAttempts": 1,
-          "showFeedback": false,
-          "allowReview": true,
-          "showSolution": false,
-          "allowComment": false,
-          "validateResponses": false,
-          "allowSkipping": true
-        },
-        "timeLimits": {
-          "qti-type": "timeLimits",
-          "allowLateSubmission": false
-        },
-        "index": 2
-      }],
-      "identifier": "assessmentSection-2",
-      "required": false,
-      "fixed": false,
-      "preConditions": [],
-      "branchRules": [],
-      "itemSessionControl": {
-        "qti-type": "itemSessionControl",
-        "maxAttempts": 1,
-        "showFeedback": false,
-        "allowReview": true,
-        "showSolution": false,
-        "allowComment": false,
-        "validateResponses": false,
-        "allowSkipping": true
-      },
-      "timeLimits": {
-        "qti-type": "timeLimits",
-        "allowLateSubmission": false
-      },
-      "index": 1
-    }],
-    "testFeedbacks": [],
-    "index": 0
-  }],
-  "outcomeProcessing": {
-    "qti-type": "outcomeProcessing",
-    "outcomeRules": [{
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "testVariables",
-          "variableIdentifier": "SCORE",
-          "baseType": -1,
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_MAX",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }, {
-      "qti-type": "setOutcomeValue",
-      "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-      "expression": {
-        "qti-type": "sum",
-        "minOperands": 1,
-        "maxOperands": -1,
-        "acceptedCardinalities": [0, 1, 2],
-        "acceptedBaseTypes": [2, 3],
-        "expressions": [{
-          "qti-type": "outcomeMaximum",
-          "outcomeIdentifier": "SCORE",
-          "weightIdentifier": "WEIGHT",
-          "sectionIdentifier": "",
-          "includeCategories": [],
-          "excludeCategories": []
-        }]
-      }
-    }, {
-      "qti-type": "outcomeCondition",
-      "outcomeIf": {
-        "qti-type": "outcomeIf",
-        "expression": {
-          "qti-type": "isNull",
-          "minOperands": 1,
-          "maxOperands": 1,
-          "acceptedCardinalities": [5],
-          "acceptedBaseTypes": [12],
-          "expressions": [{
-            "qti-type": "variable",
+        {
+            "baseType": 3,
+            "cardinality": 0,
             "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-            "weightIdentifier": ""
-          }]
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
         },
-        "outcomeRules": [{
-          "qti-type": "setOutcomeValue",
-          "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
-          "expression": {
-            "qti-type": "numberPresented",
-            "sectionIdentifier": "",
-            "includeCategories": [],
-            "excludeCategories": []
-          }
-        }]
-      },
-      "outcomeElseIfs": []
-    }]
-  },
-  "testFeedbacks": []
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        },
+        {
+            "baseType": 3,
+            "cardinality": 0,
+            "identifier": "SCORE_RATIO_WEIGHTED",
+            "interpretation": "",
+            "longInterpretation": "",
+            "masteryValue": false,
+            "normalMaximum": false,
+            "normalMinimum": false,
+            "qti-type": "outcomeDeclaration",
+            "views": []
+        }
+    ],
+    "outcomeProcessing": {
+        "outcomeRules": [
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "baseType": -1,
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "qti-type": "testVariables",
+                            "sectionIdentifier": "",
+                            "variableIdentifier": "SCORE",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": ""
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "expression": {
+                    "acceptedBaseTypes": [
+                        2,
+                        3
+                    ],
+                    "acceptedCardinalities": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "expressions": [
+                        {
+                            "excludeCategories": [],
+                            "includeCategories": [],
+                            "outcomeIdentifier": "SCORE",
+                            "qti-type": "outcomeMaximum",
+                            "sectionIdentifier": "",
+                            "weightIdentifier": "WEIGHT"
+                        }
+                    ],
+                    "maxOperands": -1,
+                    "minOperands": 1,
+                    "qti-type": "sum"
+                },
+                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                "qti-type": "setOutcomeValue"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            },
+            {
+                "outcomeElse": {
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "acceptedBaseTypes": [
+                                    2,
+                                    3
+                                ],
+                                "acceptedCardinalities": [
+                                    0
+                                ],
+                                "expressions": [
+                                    {
+                                        "identifier": "SCORE_TOTAL_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    },
+                                    {
+                                        "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                        "qti-type": "variable",
+                                        "weightIdentifier": ""
+                                    }
+                                ],
+                                "maxOperands": 2,
+                                "minOperands": 2,
+                                "qti-type": "divide"
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeElse"
+                },
+                "outcomeElseIfs": [],
+                "outcomeIf": {
+                    "expression": {
+                        "acceptedBaseTypes": [
+                            12
+                        ],
+                        "acceptedCardinalities": [
+                            5
+                        ],
+                        "expressions": [
+                            {
+                                "identifier": "SCORE_TOTAL_MAX_WEIGHTED",
+                                "qti-type": "variable",
+                                "weightIdentifier": ""
+                            }
+                        ],
+                        "maxOperands": 1,
+                        "minOperands": 1,
+                        "qti-type": "isNull"
+                    },
+                    "outcomeRules": [
+                        {
+                            "expression": {
+                                "baseType": 3,
+                                "qti-type": "baseValue",
+                                "value": 0
+                            },
+                            "identifier": "SCORE_RATIO_WEIGHTED",
+                            "qti-type": "setOutcomeValue"
+                        }
+                    ],
+                    "qti-type": "outcomeIf"
+                },
+                "qti-type": "outcomeCondition"
+            }
+        ],
+        "qti-type": "outcomeProcessing"
+    },
+    "qti-type": "assessmentTest",
+    "testFeedbacks": [],
+    "testParts": [
+        {
+            "assessmentSections": [
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-1",
+                    "index": 0,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": true,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090611690885",
+                            "identifier": "item-1",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090613110988",
+                            "identifier": "item-3",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090616225291",
+                            "identifier": "item-2",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 1",
+                    "visible": true
+                },
+                {
+                    "branchRules": [],
+                    "fixed": false,
+                    "identifier": "assessmentSection-2",
+                    "index": 1,
+                    "itemSessionControl": {
+                        "allowComment": false,
+                        "allowReview": true,
+                        "allowSkipping": true,
+                        "maxAttempts": 1,
+                        "qti-type": "itemSessionControl",
+                        "showFeedback": false,
+                        "showSolution": false,
+                        "validateResponses": false
+                    },
+                    "keepTogether": true,
+                    "preConditions": [],
+                    "qti-type": "assessmentSection",
+                    "required": false,
+                    "rubricBlocks": [],
+                    "sectionParts": [
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i148309061819894",
+                            "identifier": "item-4",
+                            "index": 0,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "history"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i1483090620510297",
+                            "identifier": "item-5",
+                            "index": 1,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "branchRules": [],
+                            "categories": [
+                                "math"
+                            ],
+                            "fixed": false,
+                            "href": "http://tao.dev/tao.rdf#i14830906232870100",
+                            "identifier": "item-6",
+                            "index": 2,
+                            "itemSessionControl": {
+                                "allowComment": false,
+                                "allowReview": true,
+                                "allowSkipping": true,
+                                "maxAttempts": 1,
+                                "qti-type": "itemSessionControl",
+                                "showFeedback": false,
+                                "showSolution": false,
+                                "validateResponses": false
+                            },
+                            "preConditions": [],
+                            "qti-type": "assessmentItemRef",
+                            "required": false,
+                            "templateDefaults": {},
+                            "timeLimits": {
+                                "allowLateSubmission": false,
+                                "qti-type": "timeLimits"
+                            },
+                            "variableMappings": {},
+                            "weights": [
+                                {
+                                    "identifier": "WEIGHT",
+                                    "qti-type": "weight",
+                                    "value": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "timeLimits": {
+                        "allowLateSubmission": false,
+                        "qti-type": "timeLimits"
+                    },
+                    "title": "Section 2",
+                    "visible": true
+                }
+            ],
+            "branchRules": [],
+            "identifier": "testPart-1",
+            "index": 0,
+            "itemSessionControl": {
+                "allowComment": false,
+                "allowReview": true,
+                "allowSkipping": false,
+                "maxAttempts": 0,
+                "qti-type": "itemSessionControl",
+                "showFeedback": false,
+                "showSolution": false,
+                "validateResponses": false
+            },
+            "navigationMode": 0,
+            "preConditions": [],
+            "qti-type": "testPart",
+            "submissionMode": 0,
+            "testFeedbacks": [],
+            "timeLimits": {
+                "allowLateSubmission": false,
+                "qti-type": "timeLimits"
+            }
+        }
+    ],
+    "timeLimits": {
+        "allowLateSubmission": false,
+        "qti-type": "timeLimits"
+    },
+    "title": "Test 1"
 }

--- a/views/js/test/creator/samples/scoringTotalWeighted.json
+++ b/views/js/test/creator/samples/scoringTotalWeighted.json
@@ -147,11 +147,12 @@
                     ],
                     "expressions": [
                         {
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": ""
                         }
                     ],
@@ -175,11 +176,13 @@
                     ],
                     "expressions": [
                         {
+                            "sectionIdentifier": "",
+                            "baseType": -1,
                             "excludeCategories": [],
                             "includeCategories": [],
-                            "outcomeIdentifier": "SCORE",
-                            "qti-type": "outcomeMaximum",
+                            "qti-type": "testVariables",
                             "sectionIdentifier": "",
+                            "variableIdentifier": "MAXSCORE",
                             "weightIdentifier": "WEIGHT"
                         }
                     ],


### PR DESCRIPTION
This PR adds the generation of the SCORE_RATIO and SCORE_WEIGHTED_RATIO outcomes to enable correct computation of the LtiOutcome.
The SCORE_TOTAL_MAX and SCORE_TOTAL_MAX_WEIGHTED now use the MAXSCORE instead of the normalMaximum.
Legacy support for LtiOutcome computation rule is kept for backward compatibility.