### PR TITLE
Fix/tao 4859 categories format and throttling

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '10.13.0',
+    'version'     => '10.13.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1428,6 +1428,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.11.1');
         }
 
-        $this->skip('10.11.1', '10.13.0');
+        $this->skip('10.11.1', '10.13.1');
     }
 }

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -43,6 +43,7 @@ define([
         var $itemBox   = $('.item-box', $panel);
 
         var getItems = function getItems(pattern){
+
             return loadItems(pattern).then(function(items){
                 if(!items || !items.length){
                     return update();
@@ -64,15 +65,23 @@ define([
          * @private
          */
         function setUpLiveSearch (){
-            var timeout;
+            var launched = false;
 
             var liveSearch = function(){
                 var pattern = $search.val();
                 if(pattern.length > 1 || pattern.length === 0){
-                    clearTimeout(timeout);
-                    timeout = setTimeout(function(){
-                        getItems(pattern);
-                    }, 300);
+                    if(!launched){
+                        launched = true;
+                        _.delay(function(){
+                            getItems($search.val())
+                                .then(function(){
+                                    launched = false;
+                                })
+                                .catch(function(){
+                                    launched = false;
+                                });
+                        }, 300);
+                    }
                 }
             };
 

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -50,7 +50,7 @@ define([
                 }
                 return getCategories(_.pluck(items, 'uri')).then(function(categories){
                     update(_.map(items, function(item){
-                        item.categories = _.isArray(categories[item.uri]) ? categories[item.uri] : [];
+                        item.categories = categories[item.uri] ? _.values(categories[item.uri]) : [];
                         return item;
                     }));
                 });
@@ -65,20 +65,20 @@ define([
          * @private
          */
         function setUpLiveSearch (){
-            var launched = false;
+            var running = false;
 
             var liveSearch = function(){
                 var pattern = $search.val();
                 if(pattern.length > 1 || pattern.length === 0){
-                    if(!launched){
-                        launched = true;
+                    if(!running){
+                        running = true;
                         _.delay(function(){
                             getItems($search.val())
                                 .then(function(){
-                                    launched = false;
+                                    running = false;
                                 })
                                 .catch(function(){
-                                    launched = false;
+                                    running = false;
                                 });
                         }, 300);
                     }
@@ -86,8 +86,7 @@ define([
             };
 
             //trigger the search on keyp and on the magnifer button click
-            $search.keyup(liveSearch)
-                     .siblings('.ctrl').click(liveSearch);
+            $search.keyup(liveSearch).siblings('.ctrl').click(liveSearch);
         }
 
         /**


### PR DESCRIPTION
 At the end the bug was the JSON payload of the `getCategories` request was sometimes arrays and sometimes objects. It now works for both.
I've also prevented to run too much requests.