### PR TITLE
Feature/cat get placeholder item refs

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '10.18.0',
+    'version'     => '11.0.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/models/classes/cat/CatService.php
+++ b/models/classes/cat/CatService.php
@@ -7,6 +7,7 @@ use oat\generis\model\OntologyAwareTrait;
 use oat\libCat\CatEngine;
 use qtism\data\AssessmentTest;
 use qtism\data\AssessmentSection;
+use qtism\data\AssessmentItemRef;
 use qtism\data\storage\php\PhpDocument;
 
 /**
@@ -75,6 +76,24 @@ class CatService extends ConfigurableService
         $doc->loadFromString($privateCompilationDirectory->read("adaptive-assessment-item-ref-${identifier}.php"));
         
         return $doc->getDocumentComponent();
+    }
+    
+    /**
+     * Get AssessmentItemRefs corresponding to a given Adaptive Placeholder.
+     * 
+     * This method will return an array of AssessmentItemRef objects corresponding to an Adaptive Placeholder.
+     * 
+     * @return array
+     */
+    public function getAssessmentItemRefsByPlaceholder(\tao_models_classes_service_StorageDirectory $privateCompilationDirectory, AssessmentItemRef $placeholder)
+    {
+        $urlinfo = parse_url($placeholder->getHref());
+        $adaptiveSectionId = ltrim($urlinfo['path'], '/');
+        
+        $doc = new PhpDocument();
+        $doc->loadFromString($privateCompilationDirectory->read("adaptive-assessment-section-${adaptiveSectionId}.php"));
+        
+        return $doc->getDocumentComponent()->getComponentsByClassName('assessmentItemRef')->getArrayCopy();
     }
     
     /**

--- a/models/classes/cat/CatService.php
+++ b/models/classes/cat/CatService.php
@@ -189,4 +189,31 @@ class CatService extends ConfigurableService
             throw new \common_Exception("Unable to store CAT property value to test '${testUri}'.");
         }
     }
+    
+    /**
+     * Is an AssessmentSection Adaptive?
+     * 
+     * This method returns whether or not a given $section is adaptive.
+     * 
+     * @param \qtism\data\AssessmentSection $section
+     * @return boolean
+     */
+    public function isAssessmentSectionAdaptive(AssessmentSection $section)
+    {
+        $assessmentItemRefs = $section->getComponentsByClassName('assessmentItemRef');
+        return count($assessmentItemRefs) === 1 && $this->isAdaptivePlaceholder($assessmentItemRefs[0]);
+    }
+    
+    /**
+     * Is an AssessmentItemRef an Adaptive Placeholder?
+     * 
+     * This method returns whether or not a given $assessmentItemRef is a runtime adaptive placeholder.
+     * 
+     * @param \qtism\data\AssessmentItemRef $assessmentItemRef
+     * @return boolean
+     */
+    public function isAdaptivePlaceholder(AssessmentItemRef $assessmentItemRef)
+    {
+        return in_array(\taoQtiTest_models_classes_QtiTestCompiler::ADAPTIVE_PLACEHOLDER_CATEGORY, $assessmentItemRef->getCategories()->getArrayCopy());
+    }
 }

--- a/models/classes/class.QtiTestCompiler.php
+++ b/models/classes/class.QtiTestCompiler.php
@@ -54,8 +54,6 @@ use oat\taoDelivery\model\container\delivery\ContainerProvider;
  */
 class taoQtiTest_models_classes_QtiTestCompiler extends taoTests_models_classes_TestCompiler implements ContainerProvider
 {
-    const ADAPTIVE_INFO_MAP_FILENAME = 'adaptive-info-map.json';
-    
     const ADAPTIVE_SECTION_MAP_FILENAME = 'adaptive-section-map.json';
     
     const ADAPTIVE_PLACEHOLDER_CATEGORY = 'x-tao-qti-adaptive-placeholder';
@@ -808,6 +806,10 @@ class taoQtiTest_models_classes_QtiTestCompiler extends taoTests_models_classes_
                     
                     // QTI Adaptive Section detected.
                     \common_Logger::d("QTI Adaptive Section with identifier '" . $current->getIdentifier() . "' found.");
+                    
+                    // Deal with AssessmentSection Compiling.
+                    $phpDocument->setDocumentComponent($current);
+                    $this->getPrivateDirectory()->write("adaptive-assessment-section-${sectionIdentifier}.php", $phpDocument->saveToString());
                     
                     foreach ($sectionParts->getKeys() as $sectionPartIdentifier) {
                         $sectionPart =  $sectionParts[$sectionPartIdentifier];

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -562,8 +562,7 @@ class QtiRunnerServiceContext extends RunnerServiceContext
     {
         $currentAssessmentItemRef = $this->getTestSession()->getCurrentAssessmentItemRef();
         if ($currentAssessmentItemRef) {
-            $categories = $currentAssessmentItemRef->getCategories()->getArrayCopy();
-            return in_array(\taoQtiTest_models_classes_QtiTestCompiler::ADAPTIVE_PLACEHOLDER_CATEGORY, $categories);
+            return $this->getServiceManager()->get(CatService::SERVICE_ID)->isAdaptivePlaceholder($currentAssessmentItemRef);
         } else {
             return false;
         }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1460,6 +1460,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.17.0');
         }
         
-        $this->skip('10.17.0', '10.18.0');
+        $this->skip('10.17.0', '11.0.0');
     }
 }


### PR DESCRIPTION
This PR will add to compiled adaptive tests a compiled version of every adaptive section. This is required to build the test definition ODS payload at delivery compilation time, without affecting the complexity of the test that will be run at delivery time.

At ODS Test Payload generation time, the `CatEngine::getAssessmentItemRefsByPlaceholder` method can be called to retrieve `AssessmentItemRef`s that are part of a given adaptive section.