### PR TITLE
Feature/pre caching script

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '10.18.1',
+    'version'     => '10.19.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/scripts/install/SetPreCachingConfig.php
+++ b/scripts/install/SetPreCachingConfig.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+
+namespace oat\taoQtiTest\scripts\install;
+
+use oat\tao\model\ClientLibConfigRegistry;
+
+/**
+ * Set Precaching Configuration Installation Action
+ * 
+ * This action prepares the test runner configuration to use
+ * a caching proxy in order to cache the next N items in item flow
+ * of a given assessment test session.
+ */
+class SetPrecachingConfig extends \common_ext_action_InstallAction
+{
+    /**
+     * @param $params
+     * @return \common_report_Report
+     */
+    public function __invoke($params)
+    {
+        //set the allow flag to true
+        $qtiTest = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+        $config = $qtiTest->getConfig('testRunner');
+        $config = array_merge($config, [
+            'allow-browse-next-item' => true
+        ]);
+        $qtiTest->setConfig('testRunner', $config);
+
+        //change the proxy implementation
+        ClientLibConfigRegistry::getRegistry()->register('taoQtiTest/runner/proxy/loader', [
+            'providerName' => 'preCachingProxy',
+            'module'       => 'taoQtiTest/runner/proxy/cache/proxy'
+        ]);
+
+        return new \common_report_Report(
+            \common_report_Report::TYPE_SUCCESS,
+            "Precaching configuration set."
+        );
+    }
+}
+

--- a/scripts/install/SetPreCachingConfig.php
+++ b/scripts/install/SetPreCachingConfig.php
@@ -41,7 +41,7 @@ class SetPrecachingConfig extends \common_ext_action_InstallAction
     public function __invoke($params)
     {
         //set the allow flag to true
-        $qtiTest = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+        $qtiTest = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');
         $config = $qtiTest->getConfig('testRunner');
         $config = array_merge($config, [
             'allow-browse-next-item' => true

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1460,6 +1460,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.17.0');
         }
         
-        $this->skip('10.17.0', '10.18.1');
+        $this->skip('10.17.0', '10.19.0');
     }
 }


### PR DESCRIPTION
We agreed with @krampstudio that a script enabling the item precaching can be included in taoQtiTest rather than specific customer extensions.

Dependent PR removing this script from customer extensions will in a very next future.