### PR TITLE
Tao 4756/fix/test taker tools adaptive context

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '11.10.1',
+    'version'     => '11.10.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/models/classes/cat/CatService.php
+++ b/models/classes/cat/CatService.php
@@ -260,7 +260,7 @@ class CatService extends ConfigurableService
                 $isCat = true;
             }
 
-            $itemIdentifier = $event->getRunnerService()->getCurrentAssessmentItemRef($context)->getIdentifier();
+            $itemIdentifier = $event->getContext()->getCurrentAssessmentItemRef()->getIdentifier();
             $hrefParts = explode('|', $event->getRunnerService()->getItemHref($context, $itemIdentifier));
             $event->getRunnerService()->storeTraceVariable($context, $hrefParts[0], self::IS_CAT_ADAPTIVE, $isCat);
 

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -363,7 +363,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $route = $session->getRoute();
                 $currentItem = $route->current();
                 $itemSession = $session->getCurrentAssessmentItemSession();
-                $itemRef = $this->getCurrentAssessmentItemRef($context);
+                $itemRef = $context->getCurrentAssessmentItemRef();
 
                 $reviewConfig = $config->getConfigValue('review');
                 $displaySubsectionTitle = isset($reviewConfig['displaySubsectionTitle']) ? (bool) $reviewConfig['displaySubsectionTitle'] : true;
@@ -666,7 +666,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
 
             /** @var TestSession $session */
             $session = $context->getTestSession();
-            $currentItem  = $this->getCurrentAssessmentItemRef($context);
+            $currentItem  = $context->getCurrentAssessmentItemRef();
             $responses = new State();
 
             if ($currentItem === false) {
@@ -1442,7 +1442,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
             $sessionId = $context->getTestSession()->getSessionId();
 
             if (!is_null($itemUri)) {
-                $currentItem = $this->getCurrentAssessmentItemRef($context);
+                $currentItem = $context->getCurrentAssessmentItemRef();
                 $currentOccurrence = $context->getTestSession()->getCurrentAssessmentItemRefOccurence();
 
                 $transmissionId = "${sessionId}.${currentItem}.${currentOccurrence}";
@@ -1554,25 +1554,6 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     }
     
     /**
-     * Get Current AssessmentItemRef object.
-     * 
-     * This method returns the current AssessmentItemRef object depending on the test $context.
-     * 
-     * @return \qtism\data\ExtendedAssessmentItemRef
-     */
-    public function getCurrentAssessmentItemRef(RunnerServiceContext $context)
-    {
-        if ($context->isAdaptive()) {
-            return $this->getServiceManager()->get(CatService::SERVICE_ID)->getAssessmentItemRefByIdentifier(
-                $context->getCompilationDirectory()['private'],
-                $context->getLastCatItemId()
-            );
-        } else {
-            return $context->getTestSession()->getCurrentAssessmentItemRef();
-        }
-    }
-    
-    /**
      * Get Current Assessment Session.
      * 
      * Depending on the context (adaptive or not), it will return an appropriate Assessment Object to deal with.
@@ -1587,7 +1568,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     public function getCurrentAssessmentSession(RunnerServiceContext $context)
     {
         if ($context->isAdaptive()) {
-            return new AssessmentItemSession($this->getCurrentAssessmentItemRef($context), new SessionManager());
+            return new AssessmentItemSession($context->getCurrentAssessmentItemRef(), new SessionManager());
         } else {
             return $context->getTestSession();
         }

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -616,4 +616,23 @@ class QtiRunnerServiceContext extends RunnerServiceContext
             return $selection[0];
         }
     }
+    
+    /**
+     * Get Current AssessmentItemRef object.
+     * 
+     * This method returns the current AssessmentItemRef object depending on the test $context.
+     * 
+     * @return \qtism\data\ExtendedAssessmentItemRef
+     */
+    public function getCurrentAssessmentItemRef()
+    {
+        if ($this->isAdaptive()) {
+            return $this->getServiceManager()->get(CatService::SERVICE_ID)->getAssessmentItemRefByIdentifier(
+                $this->getCompilationDirectory()['private'],
+                $this->getLastCatItemId()
+            );
+        } else {
+            return $this->getTestSession()->getCurrentAssessmentItemRef();
+        }
+    }
 }

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -159,7 +159,7 @@ class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
         ];
 
         // get the options from the categories owned by the current item
-        $categories = $context->getCurrentAssessmentItemRef()->getCategories()->getArrayCopy();
+        $categories = $this->getCategories($context);
         $prefixCategory = 'x-tao-option-';
         $prefixCategoryLen = strlen($prefixCategory);
         foreach ($categories as $category) {
@@ -187,5 +187,18 @@ class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
             $this->options = $this->buildOptions($context);
         }
         return $this->options;
+    }
+    
+    /**
+     * Get Categories.
+     * 
+     * Get the categories of the current AssessmentItemRef in the route depending on a given $context.
+     * 
+     * @param RunnerServiceContext $context
+     * @return array An array of strings.
+     */
+    protected function getCategories(RunnerServiceContext $context)
+    {
+        return $context->getCurrentAssessmentItemRef()->getCategories()->getArrayCopy();
     }
 }

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -159,7 +159,7 @@ class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
         ];
 
         // get the options from the categories owned by the current item
-        $categories = \taoQtiTest_helpers_TestRunnerUtils::getCategories($session);
+        $categories = $context->getCurrentAssessmentItemRef()->getCategories()->getArrayCopy();
         $prefixCategory = 'x-tao-option-';
         $prefixCategoryLen = strlen($prefixCategory);
         foreach ($categories as $category) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1526,6 +1526,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('11.9.0');
         }
         
-        $this->skip('11.9.0', '11.10.1');
+        $this->skip('11.9.0', '11.10.2');
     }
 }


### PR DESCRIPTION
**TO BE TESTED IN AN ACT CONTEXT!**

This PR brings back the possibility to use category based test taker plugins/tools on items that are part of adaptive questions.

**Be careful**, I basically moved the method `QtiRunnerService::getCurrentAssessmentItemRef` to `QtiRunnerServiceContext::getCurrentAssessmentItemRef`. Please make sure I took everything into account.
