### PR TITLE
Fix/tao 4840 cat answer required install config

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -386,13 +386,13 @@ return array(
      * Enable Allow/Disallow Skipping feature.
      * @type boolean
      */
-    'enable-allow-skipping' => false,
+    'enable-allow-skipping' => true,
 
     /*
      * Enable Allow/Disallow Validate Responses feature.
      * @type boolean
      */
-    'enable-validate-responses' => false,
+    'enable-validate-responses' => true,
 
     /*
      * Force branch rules to be executed even if the current navigation mode is non-linear.

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '14.0.0',
+    'version'     => '14.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '14.1.1',
+    'version'     => '14.1.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1575,6 +1575,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('13.2.0');
         }
 
-        $this->skip('13.2.0', '14.0.0');
+        $this->skip('13.2.0', '14.0.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1575,6 +1575,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('13.2.0');
         }
 
-        $this->skip('13.2.0', '14.1.1');
+        $this->skip('13.2.0', '14.1.2');
     }
 }


### PR DESCRIPTION
Bugfix - ACT
Jira: https://oat-sa.atlassian.net/browse/TAO-4840

This is to fix configuration for previously created tao-4840 feature. The decision was to make all new installs of tao (for any product) enable allowSkipping and validateResponses features. However, updates will not enable this unless specified by that customer. That is, tao update will not set these variables to true, but will instead be updated in a customer's updater if requested.