### PR TITLE
Feature/enhanced cat service

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '14.1.6',
+    'version'     => '15.0.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/models/classes/TestSessionService.php
+++ b/models/classes/TestSessionService.php
@@ -85,10 +85,18 @@ class TestSessionService extends ConfigurableService
         } else {
             $session = null;
         }
+        
+        $fileStorage = \tao_models_classes_service_FileStorage::singleton();
+        $directoryIds = explode('|', $inputParameters['QtiTestCompilation']);
+        $directories = array(
+            'private' => $fileStorage->getDirectoryById($directoryIds[0]),
+            'public' => $fileStorage->getDirectoryById($directoryIds[1])
+        );
 
         self::$cache[$sessionId] = [
             'session' => $session,
-            'storage' => $qtiStorage
+            'storage' => $qtiStorage,
+            'compilation' => $directories
         ];
     }
 
@@ -125,15 +133,15 @@ class TestSessionService extends ConfigurableService
      *
      * @param TestSession $session
      * @param \taoQtiTest_helpers_TestSessionStorage $storage
-     * @param RunnerServiceContext $context (optional)
+     * @param array $compilationDirectories
      */
-    public function registerTestSession(AssessmentTestSession $session, \taoQtiTest_helpers_TestSessionStorage $storage, RunnerServiceContext $context = null)
+    public function registerTestSession(AssessmentTestSession $session, \taoQtiTest_helpers_TestSessionStorage $storage, array $compilationDirectories)
     {
         $sessionId = $session->getSessionId();
         self::$cache[$sessionId] = [
             'session' => $session,
             'storage' => $storage,
-            'context' => $context
+            'compilation' => $compilationDirectories
         ];
     }
     

--- a/models/classes/TestSessionService.php
+++ b/models/classes/TestSessionService.php
@@ -85,8 +85,9 @@ class TestSessionService extends ConfigurableService
         } else {
             $session = null;
         }
-        
-        $fileStorage = \tao_models_classes_service_FileStorage::singleton();
+
+        /** @var \tao_models_classes_service_FileStorage $fileStorage */
+        $fileStorage = $this->getServiceManager()->get(\tao_models_classes_service_FileStorage::SERVICE_ID);
         $directoryIds = explode('|', $inputParameters['QtiTestCompilation']);
         $directories = array(
             'private' => $fileStorage->getDirectoryById($directoryIds[0]),

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -155,7 +155,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         $serviceContext->setTestConfig($this->getTestConfig());
 
         $sessionService = $this->getServiceManager()->get(TestSessionService::SERVICE_ID);
-        $sessionService->registerTestSession($serviceContext->getTestSession(), $serviceContext->getStorage(), $serviceContext);
+        $sessionService->registerTestSession($serviceContext->getTestSession(), $serviceContext->getStorage(), $serviceContext->getCompilationDirectory());
 
         return $serviceContext;
     }

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -103,8 +103,6 @@ class QtiRunnerServiceContext extends RunnerServiceContext
     
     private $catSession = [];
     
-    private $catSection = [];
-    
     private $lastCatItemId = null;
 
     /**
@@ -538,25 +536,11 @@ class QtiRunnerServiceContext extends RunnerServiceContext
      */
     public function getCatSection(RouteItem $routeItem = null)
     {
-        $routeItem = $routeItem ? $routeItem : $this->getTestSession()->getRoute()->current();
-        $sectionId = $routeItem->getAssessmentSection()->getIdentifier();
-        
-        if (!isset($this->catSection[$sectionId])) {
-
-            // No retrieval trial yet.
-            $compiledDirectory = $this->getCompilationDirectory()['private'];
-            $adaptiveSectionMap = $this->getServiceManager()->get(CatService::SERVICE_ID)->getAdaptiveSectionMap($compiledDirectory);
-
-
-            if (isset($adaptiveSectionMap[$sectionId])) {
-                $this->catSection[$sectionId] = $this->getCatEngine($routeItem)->restoreSection($adaptiveSectionMap[$sectionId]['section']);
-            } else {
-                $this->catSection[$sectionId] = false;
-            }
-
-        }
-        
-        return $this->catSection[$sectionId];
+        return $this->getServiceManager()->get(CatService::SERVICE_ID)->getCatSection(
+            $this->getTestSession(),
+            $this->getCompilationDirectory()['private'],
+            $routeItem
+        );
     }
     
     /**
@@ -569,13 +553,7 @@ class QtiRunnerServiceContext extends RunnerServiceContext
      */
     public function isAdaptive(AssessmentItemRef $currentAssessmentItemRef = null)
     {
-        $currentAssessmentItemRef = (is_null($currentAssessmentItemRef)) ? $this->getTestSession()->getCurrentAssessmentItemRef() : $currentAssessmentItemRef;
-        
-        if ($currentAssessmentItemRef) {
-            return $this->getServiceManager()->get(CatService::SERVICE_ID)->isAdaptivePlaceholder($currentAssessmentItemRef);
-        } else {
-            return false;
-        }
+        return $this->getServiceManager()->get(CatService::SERVICE_ID)->isAdaptive($this->getTestSession(), $currentAssessmentItemRef);
     }
     
     /**
@@ -682,15 +660,11 @@ class QtiRunnerServiceContext extends RunnerServiceContext
     
     public function getCurrentCatItemId(RouteItem $routeItem = null)
     {
-        $sessionId = $this->getTestSession()->getSessionId();
-        
-        $catItemId = $this->getServiceManager()->get(ExtendedStateService::SERVICE_ID)->getCatValue(
-            $sessionId,
-            $this->getCatSection($routeItem)->getSectionId(),
-            'current-cat-item-id'
+        return $this->getServiceManager()->get(CatService::SERVICE_ID)->getCurrentCatItemId(
+            $this->getTestSession(),
+            $this->getCompilationDirectory()['private'],
+            $routeItem
         );
-        
-        return $catItemId;
     }
     
     public function persistCurrentCatItemId($catItemId)

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1589,6 +1589,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.1.5');
         }
         
-        $this->skip('14.1.5', '14.1.6');
+        $this->skip('14.1.5', '15.0.0');
     }
 }


### PR DESCRIPTION
prevents a crash on guest access mode. Steps to reproduce are

1. Login as a guest
2. Take a test and stop on an adaptive item
3. write the ROOT_URL of your platform in your adress bar and press enter.
4. 500 crash