### PR TITLE
Fix/tao 5063 answered items in cat

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '15.5.2',
+    'version'     => '15.5.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -475,7 +475,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $response['enableValidateResponses'] = $config->getConfigValue('enableValidateResponses');
 
                 //contextual value
-                $response['validateResponses'] = $tesOptions['validateResponses'];
+                $response['validateResponses'] = $testOptions['validateResponses'];
 
                 //does the item has modal feedbacks ?
                 $response['hasFeedbacks'] = $this->hasFeedbacks($context, $itemRef->getHref());

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -425,7 +425,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $response['itemFlagged'] = TestRunnerUtils::getItemFlag($session, $response['itemPosition'], $context);
 
                 // The current item answered state
-                $response['itemAnswered'] = ($context->isAdaptive()) ? true : TestRunnerUtils::isItemCompleted($currentItem, $itemSession);
+                $response['itemAnswered'] = TestRunnerUtils::isItemCompleted($currentItem, $itemSession);
 
                 // Time constraints.
                 $response['timeConstraints'] = $this->buildTimeConstraints($context);
@@ -475,7 +475,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $response['enableValidateResponses'] = $config->getConfigValue('enableValidateResponses');
 
                 //contextual value
-                $response['validateResponses'] = $testOptions['validateResponses'];
+                $response['validateResponses'] = $tesOptions['validateResponses'];
 
                 //does the item has modal feedbacks ?
                 $response['hasFeedbacks'] = $this->hasFeedbacks($context, $itemRef->getHref());

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1589,6 +1589,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.1.5');
         }
 
-        $this->skip('14.1.5', '15.5.2');
+        $this->skip('14.1.5', '15.5.3');
     }
 }


### PR DESCRIPTION
The item doesn't come as "asnwered". 
I'm also wondering why the seen items are considered as answered in the test map https://github.com/oat-sa/extension-tao-testqti/commit/e84990a7beb92cf002e7e9b77bb610b4cfed5e96#diff-da05797a06045d7cf1ebd0095656ade4R225 