### PR TITLE
Fix/tao 5084 previous backward nav in cat

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '15.6.1',
+    'version'     => '15.6.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '15.5.2',
+    'version'     => '15.6.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -409,7 +409,10 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $response['itemSessionState'] = $itemSession->getState();
 
                 // Whether the current item is adaptive.
-                $response['isAdaptive'] = $context->isAdaptive();
+                $response['isAdaptive'] = $session->isCurrentAssessmentItemAdaptive();
+
+                // Whether the current section is adaptive.
+                $response['isCatAdaptive'] = $context->isAdaptive();
 
                 // Whether the test map must be updated.
                 // TODO: detect if the map need to be updated and set the flag

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -409,8 +409,8 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 $response['itemSessionState'] = $itemSession->getState();
 
                 // Whether the current item is adaptive.
-                $response['isAdaptive'] = $session->isCurrentAssessmentItemAdaptive();
-                
+                $response['isAdaptive'] = $context->isAdaptive();
+
                 // Whether the test map must be updated.
                 // TODO: detect if the map need to be updated and set the flag
                 $response['needMapUpdate'] = false;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1589,6 +1589,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.1.5');
         }
 
-        $this->skip('14.1.5', '15.6.1');
+        $this->skip('14.1.5', '15.6.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1589,6 +1589,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.1.5');
         }
 
-        $this->skip('14.1.5', '15.5.2');
+        $this->skip('14.1.5', '15.6.0');
     }
 }

--- a/views/js/runner/helpers/navigation.js
+++ b/views/js/runner/helpers/navigation.js
@@ -117,19 +117,7 @@ define([
          * @returns {Boolean} true if the item is the last one
          */
         isLast : function isLast(testMap, itemIdentifier){
-            var item;
-            var stats;
-            if( ! _.isPlainObject(testMap) ){
-                throw new TypeError('Invalid test map');
-            }
-            if(_.isEmpty(itemIdentifier)){
-                throw new TypeError('Invalid item identifier');
-            }
-
-            item  = mapHelper.getItem(testMap, itemIdentifier);
-            stats = mapHelper.getTestStats(testMap);
-
-            return item.position + 1 === stats.total;
+            return this.isLastOf(testMap, itemIdentifier, 'test');
         },
 
         /**
@@ -139,20 +127,73 @@ define([
          * @returns {Boolean} true if the item is the first one
          */
         isFirst : function isFirst(testMap, itemIdentifier){
-            var item;
-            if( ! _.isPlainObject(testMap) ){
-                throw new TypeError('Invalid test map');
-            }
-            if(_.isEmpty(itemIdentifier)){
-                throw new TypeError('Invalid item identifier');
-            }
-
-            item  = mapHelper.getItem(testMap, itemIdentifier);
-
-            return item.position  === 0;
-
+            return this.isFirstOf(testMap, itemIdentifier, 'test');
         },
 
+        /**
+         * Check if the given  item is the last of a the given scope
+         * @param {Object} testMap - the test map
+         * @param {String} itemIdentifier - the identifier of the item
+         * @param {String} [scope = 'test'] - the target scope
+         * @returns {Boolean} true if the item is the last one
+         */
+        isLastOf : function isLastOf(testMap, itemIdentifier, scope){
+            var item;
+            var stats;
+            if ( ! _.isPlainObject(testMap) ) {
+                throw new TypeError('Invalid test map');
+            }
+            if (_.isEmpty(itemIdentifier)) {
+                throw new TypeError('Invalid item identifier');
+            }
+            scope = scope || 'test';
+            item  = mapHelper.getItem(testMap, itemIdentifier);
+            stats = mapHelper.getScopeStats(testMap, item.position, scope);
+            if (stats && _.isNumber(stats.total)) {
+                if (scope === 'test') {
+                    return item.position + 1  === stats.total;
+                }
+                if (scope === 'section' || scope === 'assessmentSection' || scope === 'testSection') {
+                    return item.positionInSection + 1 === stats.total;
+                }
+                if (scope === 'part' || scope === 'testPart') {
+                    return item.positionInPart + 1 === stats.total;
+                }
+            }
+
+            return false;
+        },
+
+        /**
+         * Check if the given  item is the first of a the given scope
+         * @param {Object} testMap - the test map
+         * @param {String} itemIdentifier - the identifier of the item
+         * @param {String} [scope = 'test'] - the target scope
+         * @returns {Boolean} true if the item is the first one
+         */
+        isFirstOf : function isFirstOf(testMap, itemIdentifier, scope){
+            var item;
+            if (! _.isPlainObject(testMap)) {
+                throw new TypeError('Invalid test map');
+            }
+            if (_.isEmpty(itemIdentifier)) {
+                throw new TypeError('Invalid item identifier');
+            }
+            scope = scope || 'test';
+            item  = mapHelper.getItem(testMap, itemIdentifier);
+
+            if (scope === 'test') {
+                return item.position  === 0;
+            }
+            if (scope === 'section' || scope === 'assessmentSection' || scope === 'testSection') {
+                return item.positionInSection === 0;
+            }
+            if (scope === 'part' || scope === 'testPart') {
+                return item.positionInPart === 0;
+            }
+
+            return false;
+        },
 
         /**
          * Gets the map descriptors of the sibling items

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -29,8 +29,9 @@ define([
     'taoTests/runner/plugin',
     'util/shortcut',
     'util/namespace',
+    'taoQtiTest/runner/helpers/navigation',
     'tpl!taoQtiTest/runner/plugins/templates/button'
-], function ($, _, __, hider, pluginFactory, shortcut, namespaceHelper, buttonTpl){
+], function ($, _, __, hider, pluginFactory, shortcut, namespaceHelper, navigationHelper, buttonTpl){
     'use strict';
 
     /**
@@ -55,8 +56,16 @@ define([
              * Check if the "Previous" functionality should be available or not
              */
             var canDoPrevious = function canDoPrevious() {
+                var testMap = testRunner.getTestMap();
                 var context = testRunner.getTestContext();
-                return context.isLinear === false && context.canMoveBackward === true;
+                var canMove = !navigationHelper.isFirst(testMap, context.itemIdentifier);
+
+                //when entering an adaptive section,
+                //you can't leave the section from the beginning
+                if (canMove && context.isAdaptive) {
+                    canMove = !navigationHelper.isFirstOf(testMap, context.itemIdentifier, 'section');
+                }
+                return canMove && context.isLinear === false && context.canMoveBackward === true;
             };
 
             /**

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -62,7 +62,7 @@ define([
 
                 //when entering an adaptive section,
                 //you can't leave the section from the beginning
-                if (canMove && context.isAdaptive) {
+                if (canMove && context.isCatAdaptive) {
                     canMove = !navigationHelper.isFirstOf(testMap, context.itemIdentifier, 'section');
                 }
                 return canMove && context.isLinear === false && context.canMoveBackward === true;

--- a/views/js/test/runner/helpers/navigation/test.js
+++ b/views/js/test/runner/helpers/navigation/test.js
@@ -39,6 +39,8 @@ define([
         { title: 'isLeavingTestPart' },
         { title: 'isLast' },
         { title: 'isFirst' },
+        { title: 'isLastOf' },
+        { title: 'isFirstOf' },
         { title: 'getSiblingItems' },
         { title: 'getNextItem' },
         { title: 'getPreviousItem' },
@@ -357,6 +359,79 @@ define([
         assert.equal(result, data.expectResult, 'The helper gives the correct result');
     });
 
+    QUnit.module('navigation.isLastOf');
+
+    QUnit.test('Bad paramerters', function(assert){
+        var result;
+
+        QUnit.expect(4);
+
+        assert.throws(function(){
+            navigationHelper.isLastOf();
+        }, TypeError, 'The test map is required');
+
+        assert.throws(function(){
+            navigationHelper.isLastOf('foo');
+        }, TypeError, 'The test map needs to be an object');
+
+        assert.throws(function(){
+            navigationHelper.isLastOf(testMap);
+        }, TypeError, 'An itemIdentifier is required');
+
+        result = navigationHelper.isLastOf(testMap, 'item-17');
+        assert.equal(typeof result, 'boolean', 'The helper does not throw with correct parameters');
+    });
+
+    QUnit.cases([{
+        title: 'test, 3rd item',
+        scope : 'test',
+        expectResult : false,
+        itemIdentifier : 'item-3'
+    }, {
+        title: 'section, 3rd item',
+        scope : 'section',
+        expectResult : true,
+        itemIdentifier : 'item-3'
+    }, {
+        title: 'testPart, 3rd item',
+        scope : 'testPart',
+        expectResult : false,
+        itemIdentifier : 'item-3'
+    }, {
+        title: 'test, 14th item',
+        scope : 'test',
+        expectResult : false,
+        itemIdentifier : 'item-14'
+    }, {
+        title: 'section, 14th item',
+        scope : 'section',
+        expectResult : true,
+        itemIdentifier : 'item-14'
+    }, {
+        title: 'testPart, 14th item',
+        scope : 'testPart',
+        expectResult : true,
+        itemIdentifier : 'item-14'
+    }, {
+        title: 'wrong scope',
+        scope : 'foo',
+        expectResult : false,
+        itemIdentifier : 'item-14'
+    }, {
+        title: 'test (default value), item 17',
+        expectResult : true,
+        itemIdentifier : 'item-17'
+
+    }])
+    .test('is the last of ', function (data, assert) {
+        var result;
+
+        QUnit.expect(1);
+
+        result = navigationHelper.isLastOf(testMap, data.itemIdentifier, data.scope);
+
+        assert.equal(result, data.expectResult, 'The helper gives the correct result');
+    });
 
     QUnit.module('navigation.isFirst');
 
@@ -411,6 +486,96 @@ define([
 
         assert.equal(result, data.expectResult, 'The helper gives the correct result');
     });
+
+    QUnit.module('navigation.isFirstOf');
+
+    QUnit.test('Bad paramerters', function(assert){
+        var result;
+
+        QUnit.expect(4);
+
+        assert.throws(function(){
+            navigationHelper.isFirstOf();
+        }, TypeError, 'The test map is required');
+
+        assert.throws(function(){
+            navigationHelper.isFirstOf('foo');
+        }, TypeError, 'The test map needs to be an object');
+
+        assert.throws(function(){
+            navigationHelper.isFirstOf(testMap);
+        }, TypeError, 'An itemIdentifier is required');
+
+        result = navigationHelper.isFirstOf(testMap, 'item-17');
+        assert.equal(typeof result, 'boolean', 'The helper does not throw with correct parameters');
+    });
+
+    QUnit.cases([{
+        title: 'test, 1st item',
+        scope : 'test',
+        expectResult : true,
+        itemIdentifier : 'item-1'
+    }, {
+        title: 'section, 1st item',
+        scope : 'section',
+        expectResult : true,
+        itemIdentifier : 'item-1'
+    }, {
+        title: 'testPart, 1st item',
+        scope : 'testPart',
+        expectResult : true,
+        itemIdentifier : 'item-1'
+    }, {
+        title: 'test, 7th item',
+        scope : 'test',
+        expectResult : false,
+        itemIdentifier : 'item-7'
+    }, {
+        title: 'section, 7th item',
+        scope : 'section',
+        expectResult : true,
+        itemIdentifier : 'item-7'
+    }, {
+        title: 'testPart, 7th item',
+        scope : 'testPart',
+        expectResult : false,
+        itemIdentifier : 'item-7'
+    }, {
+        title: 'test, 15th item',
+        scope : 'test',
+        expectResult : false,
+        itemIdentifier : 'item-15'
+    }, {
+        title: 'section, 15th item',
+        scope : 'section',
+        expectResult : true,
+        itemIdentifier : 'item-15'
+    }, {
+        title: 'testPart, 15th item',
+        scope : 'testPart',
+        expectResult : true,
+        itemIdentifier : 'item-15'
+    }, {
+        title: 'wrong scope',
+        scope : 'foo',
+        expectResult : false,
+        itemIdentifier : 'item-14'
+    }, {
+        title: 'test (default value), item 1',
+        expectResult : true,
+        itemIdentifier : 'item-1'
+
+    }])
+    .test('is the last of ', function (data, assert) {
+        var result;
+
+        QUnit.expect(1);
+
+        result = navigationHelper.isFirstOf(testMap, data.itemIdentifier, data.scope);
+
+        assert.equal(result, data.expectResult, 'The helper gives the correct result');
+    });
+
 
     QUnit.module('Sibling Items');
 


### PR DESCRIPTION
Prevent the test taker to move backward on the 1st item of an adaptive section.

 - Add `taoQtitest/runner/helpers/navigation.isFirstOf`
 - Add `taoQtitest/runner/helpers/navigation.isLastOf`

And fix `testContext.isAdaptive`