### PR TITLE
Fix/tao 5138 allow skipping closed item

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '15.7.4',
+    'version'     => '15.7.5',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1589,6 +1589,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.1.5');
         }
 
-        $this->skip('14.1.5', '15.7.4');
+        $this->skip('14.1.5', '15.7.5');
     }
 }

--- a/views/js/runner/plugins/navigation/allowSkipping.js
+++ b/views/js/runner/plugins/navigation/allowSkipping.js
@@ -38,12 +38,7 @@ define([
     'i18n',
     'taoTests/runner/plugin',
     'taoQtiTest/runner/helpers/currentItem'
-], function(
-    _,
-    __,
-    pluginFactory,
-    currentItemHelper
-) {
+], function(_, __, pluginFactory, currentItemHelper) {
     'use strict';
 
     /**
@@ -63,40 +58,38 @@ define([
          * @returns {this}
          */
         init: function init() {
-            var testRunner = this.getTestRunner();
+            this.getTestRunner().before('move', function () {
+                var self = this;
+                var testContext = this.getTestContext();
+                var isInteracting = !this.getItemState(testContext.itemIdentifier, 'disabled');
 
-            testRunner
-            .before('move', function () {
-                var testContext = testRunner.getTestContext();
+                if ( isInteracting && testContext.enableAllowSkipping && !testContext.allowSkipping ) {
 
-                if (testContext.enableAllowSkipping && !testContext.allowSkipping) {
                     this.trigger('disablenav disabletools');
 
                     return new Promise(function (resolve, reject) {
-                        if(_.size(currentItemHelper.getDeclarations(testRunner)) === 0){
+                        if(_.size(currentItemHelper.getDeclarations(self)) === 0){
                             return resolve();
                         }
-                        if (currentItemHelper.isAnswered(testRunner, true)) {
+                        if (currentItemHelper.isAnswered(self, true)) {
                             return resolve();
                         }
 
-                        if (!testRunner.getState('alerted.notallowed')) { // Only show one alert for itemSessionControl
-                            testRunner.setState('alerted.notallowed', true);
-                            testRunner.trigger(
+                        if (!self.getState('alerted.notallowed')) { // Only show one alert for itemSessionControl
+                            self.setState('alerted.notallowed', true);
+                            self.trigger(
                                 'alert.notallowed',
                                 __('A response to this item is required.'),
                                 function () {
-                                    testRunner.trigger('resumeitem');
+                                    self.trigger('resumeitem');
                                     reject();
-                                    testRunner.setState('alerted.notallowed', false);
+                                    self.setState('alerted.notallowed', false);
                                 }
                             );
                         }
                     });
                 }
             });
-
-            return this;
         }
     });
 });

--- a/views/js/runner/plugins/navigation/validateResponses.js
+++ b/views/js/runner/plugins/navigation/validateResponses.js
@@ -36,12 +36,7 @@ define([
     'i18n',
     'taoTests/runner/plugin',
     'taoQtiTest/runner/helpers/currentItem'
-], function(
-    _,
-    __,
-    pluginFactory,
-    currentItemHelper
-) {
+], function(_, __, pluginFactory, currentItemHelper) {
     'use strict';
 
     /**
@@ -61,30 +56,30 @@ define([
          * @returns {this}
          */
         init: function init() {
-            var testRunner = this.getTestRunner();
+            this.getTestRunner().before('move', function () {
+                var self = this;
+                var testContext = this.getTestContext();
+                var isInteracting = !this.getItemState(testContext.itemIdentifier, 'disabled');
 
-            testRunner
-            .before('move', function () {
-                var testContext = testRunner.getTestContext();
-                if (testContext.enableValidateResponses &&  testContext.validateResponses) {
+                if ( isInteracting && testContext.enableValidateResponses &&  testContext.validateResponses) {
                     this.trigger('disablenav disabletools');
 
                     return new Promise(function (resolve, reject) {
-                        if(_.size(currentItemHelper.getDeclarations(testRunner)) === 0){
+                        if(_.size(currentItemHelper.getDeclarations(self)) === 0){
                             return resolve();
                         }
-                        if (currentItemHelper.isAnswered(testRunner, false)) {
+                        if (currentItemHelper.isAnswered(self, false)) {
                             return resolve();
                         }
-                        if (!testRunner.getState('alerted.notallowed')) { // Only show one alert for itemSessionControl
-                            testRunner.setState('alerted.notallowed', true);
-                            testRunner.trigger(
+                        if (!self.getState('alerted.notallowed')) { // Only show one alert for itemSessionControl
+                            self.setState('alerted.notallowed', true);
+                            self.trigger(
                                 'alert.notallowed',
                                 __('A valid response to this item is required.'),
                                 function () {
-                                    testRunner.trigger('resumeitem');
+                                    self.trigger('resumeitem');
                                     reject();
-                                    testRunner.setState('alerted.notallowed', false);
+                                    self.setState('alerted.notallowed', false);
                                 }
                             );
                         }

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -192,7 +192,8 @@ define([
             function getItemResults() {
                 var results = {};
                 var context = self.getTestContext();
-                if(context && self.itemRunner){
+                var states = self.getTestData().states;
+                if(context && self.itemRunner && context.itemSessionState <= states.interacting){
                     results = {
                         itemResponse   : self.itemRunner.getResponses(),
                         itemState      : self.itemRunner.getState()
@@ -259,7 +260,6 @@ define([
                     //we add an intermediate ns event on unload
                     self.on('unloaditem.' + action, function(){
                         self.off('.'+action);
-
 
                         self.getProxy()
                             .callItemAction(context.itemIdentifier, action, params)
@@ -424,8 +424,7 @@ define([
                             self.trigger('error', err);
                         });
                 })
-                .on('renderitem', function(){
-
+                .on('loaditem', function(){
                     var context = this.getTestContext();
                     var states = this.getTestData().itemStates;
                     var warning = false;
@@ -438,9 +437,6 @@ define([
                         var item = mapHelper.getItem(self.getTestMap(), context.itemIdentifier);
                         return item && item.label ? item.label : context.itemIdentifier;
                     };
-
-                    this.trigger('enablenav enabletools');
-
 
                     //The item is rendered but in a state that prevents us from interacting
                     if (context.isTimeout) {
@@ -460,6 +456,15 @@ define([
                         self.disableItem(context.itemIdentifier);
                         self.trigger('warning', warning);
                     }
+
+                })
+                .on('renderitem', function(){
+                    var context = this.getTestContext();
+
+                    if(!this.getItemState(context.itemIdentifier, 'disabled')){
+                        this.trigger('enabletools');
+                    }
+                    this.trigger('enablenav');
                 })
                 .on('resumeitem', function(){
                     this.trigger('enableitem enablenav');


### PR DESCRIPTION
If the item session is closed or the item in timeout : 
 - do not send state and result on move
 - do not check allowSkipping and valid responses
 - prevent to quickly show the item before the warning 

In order to test the PR, let a section timeout then go back on the section. Items should have the "allowSkipping" false feature to ask for response. 