### PR TITLE
 Fix/tao 5138 do not enter closed timed section

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '15.7.6',
+    'version'     => '15.7.7',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1379,27 +1379,12 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
      */
     protected function buildTimeConstraints(RunnerServiceContext $context)
     {
-        $constraints = array();
+        $constraints = [];
 
-        /* @var TestSession $session */
         $session = $context->getTestSession();
-
-        foreach ($session->getRegularTimeConstraints() as $tc) {
-            $maxTimeSeconds = $this->getTimeLimitsFromSession($session, $tc->getSource()->getQtiClassName());
-
-            $timeRemaining = $tc->getMaximumRemainingTime();
-            if ($timeRemaining !== false) {
-                $source = $tc->getSource();
-                $identifier = $source->getIdentifier();
-                $seconds = TestRunnerUtils::getDurationWithMicroseconds($timeRemaining);
-                $constraints[] = array(
-                    'label' => method_exists($source, 'getTitle') ? $source->getTitle() : $identifier,
-                    'source' => $identifier,
-                    'seconds' => $seconds,
-                    'extraTime' => $tc->getTimer()->getExtraTime($maxTimeSeconds),
-                    'allowLateSubmission' => $tc->allowLateSubmission(),
-                    'qtiClassName' => $source->getQtiClassName()
-                );
+        foreach ($session->getRegularTimeConstraints() as $constraint) {
+            if ($constraint->getMaximumRemainingTime() != false) {
+                $constraints[] = $constraint;
             }
         }
 

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -32,6 +32,8 @@ use qtism\runtime\tests\AssessmentTestSession;
 use qtism\runtime\tests\RouteItem;
 use taoQtiTest_helpers_TestRunnerUtils as TestRunnerUtils;
 use oat\taoQtiTest\models\cat\CatService;
+use oat\taoQtiTest\models\cat\CatUtils;
+
 
 /**
  * Class QtiRunnerMap
@@ -258,6 +260,7 @@ class QtiRunnerMap extends ConfigurableService implements RunnerMap
                     if (!isset($map['parts'][$partId]['sections'][$sectionId])) {
                         $map['parts'][$partId]['sections'][$sectionId]['id'] = $sectionId;
                         $map['parts'][$partId]['sections'][$sectionId]['label'] = $section->getTitle();
+                        $map['parts'][$partId]['sections'][$sectionId]['isCatAdaptive'] = CatUtils::isAssessmentSectionAdaptive($section);
                         $map['parts'][$partId]['sections'][$sectionId]['position'] = $offset;
                     }
                     

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1589,6 +1589,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.1.5');
         }
 
-        $this->skip('14.1.5', '15.7.6');
+        $this->skip('14.1.5', '15.7.7');
     }
 }

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -60,6 +60,7 @@ define([
                 var testMap = testRunner.getTestMap();
                 var context = testRunner.getTestContext();
                 var previousSection;
+                var previousPart;
 
                 //first item of the test
                 if (navigationHelper.isFirst(testMap, context.itemIdentifier)) {
@@ -80,6 +81,16 @@ define([
                     if(previousSection.isCatAdaptive || previousSection.timeConstraint){
                         return false;
                     }
+                }
+
+                if (namespaceHelper.isFirstOf(testMap, context.itemIdentifier, 'part')) {
+
+                    //if the previous part is linear, we don't enter it too
+                    previousPart = mapHelper.getItemPart(testMap, context.itemPosition - 1);
+                    if(previousPart.isLinear){
+                        return false;
+                    }
+
                 }
                 return context.isLinear === false && context.canMoveBackward === true;
             };

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -75,9 +75,9 @@ define([
                         return false;
                     }
 
-                    //if the previous section is adaptive we can't go back
+                    //if the previous section is adaptive or a timed section
                     previousSection = mapHelper.getItemSection(testMap, context.itemPosition - 1);
-                    if(previousSection.isCatAdaptive){
+                    if(previousSection.isCatAdaptive || previousSection.timeConstraint){
                         return false;
                     }
                 }

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -30,8 +30,9 @@ define([
     'util/shortcut',
     'util/namespace',
     'taoQtiTest/runner/helpers/navigation',
+    'taoQtiTest/runner/helpers/map',
     'tpl!taoQtiTest/runner/plugins/templates/button'
-], function ($, _, __, hider, pluginFactory, shortcut, namespaceHelper, navigationHelper, buttonTpl){
+], function ($, _, __, hider, pluginFactory, shortcut, namespaceHelper, navigationHelper, mapHelper, buttonTpl){
     'use strict';
 
     /**
@@ -58,14 +59,29 @@ define([
             var canDoPrevious = function canDoPrevious() {
                 var testMap = testRunner.getTestMap();
                 var context = testRunner.getTestContext();
-                var canMove = !navigationHelper.isFirst(testMap, context.itemIdentifier);
+                var previousSection;
 
-                //when entering an adaptive section,
-                //you can't leave the section from the beginning
-                if (canMove && context.isCatAdaptive) {
-                    canMove = !navigationHelper.isFirstOf(testMap, context.itemIdentifier, 'section');
+                //first item of the test
+                if (navigationHelper.isFirst(testMap, context.itemIdentifier)) {
+                    return false;
                 }
-                return canMove && context.isLinear === false && context.canMoveBackward === true;
+
+                //first item of a section
+                if (navigationHelper.isFirstOf(testMap, context.itemIdentifier, 'section')) {
+
+                    //when entering an adaptive section,
+                    //you can't leave the section from the beginning
+                    if(context.isCatAdaptive){
+                        return false;
+                    }
+
+                    //if the previous section is adaptive we can't go back
+                    previousSection = mapHelper.getItemSection(testMap, context.itemPosition - 1);
+                    if(previousSection.isCatAdaptive){
+                        return false;
+                    }
+                }
+                return context.isLinear === false && context.canMoveBackward === true;
             };
 
             /**


### PR DESCRIPTION
Prevent to navigate backward if : 
 - the previous section is timed (consistent with warning at the end of a timed section)
 - the previous section is adaptive
 - the previous testPart is linear

Adding the `timeConstraint` field to the testMap is also a requirement for another task (to get timers in offline mode), so I've cherry-picked them.


 