### PR TITLE
Fix/tao 4917 fix item state issue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '15.9.1',
+    'version'     => '15.9.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.4.0',

--- a/models/classes/runner/RunnerParamParserTrait.php
+++ b/models/classes/runner/RunnerParamParserTrait.php
@@ -135,10 +135,9 @@ trait RunnerParamParserTrait
         if ($this->getRequestParameter('itemDefinition') && $this->getRequestParameter('itemState')) {
             $serviceContext = $this->getServiceContext(false);
             $itemIdentifier = $this->getRequestParameter('itemDefinition');
-            $stateId =  $serviceContext->getTestExecutionUri() . $itemIdentifier;
             $state = $this->getRequestParameter('itemState') ? json_decode($this->getRequestParameter('itemState'), true) : new \stdClass();
 
-            return $this->getRunnerService()->setItemState($serviceContext, $stateId, $state);
+            return $this->getRunnerService()->setItemState($serviceContext, $itemIdentifier, $state);
         }
 
         return false;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1589,6 +1589,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.1.5');
         }
 
-        $this->skip('14.1.5', '15.9.1');
+        $this->skip('14.1.5', '15.9.2');
     }
 }


### PR DESCRIPTION
The itemState was incorrectly set too. This fix the bug in association with #1060 

To test, answer items offline, and go back on them after sync. The bug doesn't occur when the item is served from the itemStore (the itemState is stored too), but if you refresh the page after the connectivity is back you can easily reproduce the response lost. 