### PR TITLE
Fix/tao 5110 item answered state

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '16.2.0',
+    'version'     => '16.2.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1610,5 +1610,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             
             $this->setVersion('16.2.0');
         }
+
+        $this->skip('16.2.0', '16.2.1');
     }
 }

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -317,6 +317,11 @@ define([
                 });
 
                 feedbackPromise.then(function(){
+                    // ensure the current item answer state is correctly set
+                    var item = mapHelper.getItemAt(self.getTestMap(), context.itemPosition);
+                    if (item) {
+                        item.answered = context.itemAnswered;
+                    }
 
                     //to be sure load start after unload...
                     //we add an intermediate ns event on unload


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5110

The answered state of the current item was not well set, especially when navigating in a regular test (not CAT).
To check, take a test with the navigation panel activated. The fix should work both on regular and CAT tests.