### PR TITLE
Fix/tao 5184 disable tools on move

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '16.2.1',
+    'version'     => '16.2.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1599,18 +1599,18 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('16.1.0');
         }
-        
+
         $this->skip('16.1.0', '16.1.1');
-        
+
         if ($this->isVersion('16.1.1')) {
             $this->getServiceManager()->register(
-                PhpCodeCompilationDataService::SERVICE_ID, 
+                PhpCodeCompilationDataService::SERVICE_ID,
                 new PhpCodeCompilationDataService()
             );
-            
+
             $this->setVersion('16.2.0');
         }
 
-        $this->skip('16.2.0', '16.2.1');
+        $this->skip('16.2.0', '16.2.2');
     }
 }

--- a/views/js/runner/plugins/navigation/allowSkipping.js
+++ b/views/js/runner/plugins/navigation/allowSkipping.js
@@ -65,8 +65,6 @@ define([
 
                 if ( isInteracting && testContext.enableAllowSkipping && !testContext.allowSkipping ) {
 
-                    this.trigger('disablenav disabletools');
-
                     return new Promise(function (resolve, reject) {
                         if(_.size(currentItemHelper.getDeclarations(self)) === 0){
                             return resolve();

--- a/views/js/runner/plugins/navigation/next.js
+++ b/views/js/runner/plugins/navigation/next.js
@@ -154,16 +154,14 @@ define([
                             messages.getExitMessage(
                                 __('You are about to submit the test. You will not be able to access this test once submitted. Click OK to continue and submit the test.'),
                                 warningScope, testRunner),
-                            _.partial(triggerNextAction, context), // if the test taker accept
-                            enable  // if the test taker refuse
+                            _.partial(triggerNextAction, context) // if the test taker accept
                         );
 
                     } else if (warningHelper.shouldWarnBeforeNext()) {
                         testRunner.trigger(
                             'confirm.next',
                             __('You are about to go to the next item. Click OK to continue and go to the next item.'),
-                            _.partial(triggerNextAction, context), // if the test taker accept
-                            enable  // if the test taker refuse
+                            _.partial(triggerNextAction, context) // if the test taker accept
                         );
 
                     } else {

--- a/views/js/runner/plugins/navigation/next.js
+++ b/views/js/runner/plugins/navigation/next.js
@@ -142,10 +142,6 @@ define([
                     unansweredOnly:     unansweredOnly
                 });
 
-                function enable() {
-                    // testRunner.trigger('enablenav enabletools');
-                }
-
                 if(self.getState('enabled') !== false) {
 
                     if (warningHelper.shouldWarnBeforeEnd()) {

--- a/views/js/runner/plugins/navigation/next.js
+++ b/views/js/runner/plugins/navigation/next.js
@@ -143,11 +143,10 @@ define([
                 });
 
                 function enable() {
-                    testRunner.trigger('enablenav enabletools');
+                    // testRunner.trigger('enablenav enabletools');
                 }
 
                 if(self.getState('enabled') !== false) {
-                    testRunner.trigger('disablenav disabletools');
 
                     if (warningHelper.shouldWarnBeforeEnd()) {
                         testRunner.trigger(

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -118,17 +118,12 @@ define([
             function doPrevious(previousItemWarning) {
                 var context = testRunner.getTestContext();
 
-                function enable() {
-                    // testRunner.trigger('enablenav enabletools');
-                }
-
                 if(self.getState('enabled') !== false){
                     if (previousItemWarning && context.remainingAttempts !== -1) {
                         testRunner.trigger(
                             'confirm.previous',
                             __('You are about to go to the previous item. Click OK to continue and go to the previous item.'),
-                            testRunner.previous, // if the test taker accept
-                            enable  // if the test taker refuse
+                            testRunner.previous // if the test taker accept
                         );
 
                     } else {

--- a/views/js/runner/plugins/navigation/previous.js
+++ b/views/js/runner/plugins/navigation/previous.js
@@ -119,12 +119,10 @@ define([
                 var context = testRunner.getTestContext();
 
                 function enable() {
-                    testRunner.trigger('enablenav enabletools');
+                    // testRunner.trigger('enablenav enabletools');
                 }
 
                 if(self.getState('enabled') !== false){
-                    testRunner.trigger('disablenav disabletools');
-
                     if (previousItemWarning && context.remainingAttempts !== -1) {
                         testRunner.trigger(
                             'confirm.previous',

--- a/views/js/runner/plugins/navigation/validateResponses.js
+++ b/views/js/runner/plugins/navigation/validateResponses.js
@@ -62,8 +62,6 @@ define([
                 var isInteracting = !this.getItemState(testContext.itemIdentifier, 'disabled');
 
                 if ( isInteracting && testContext.enableValidateResponses &&  testContext.validateResponses) {
-                    this.trigger('disablenav disabletools');
-
                     return new Promise(function (resolve, reject) {
                         if(_.size(currentItemHelper.getDeclarations(self)) === 0){
                             return resolve();


### PR DESCRIPTION
The `disabletools` and `disablenav` events are actualy already triggered by the QTI provider. They were probably duplicated here to avoid interaction with the tools or the navigation when a feedback was this displayed (by mouse or keyboard), but this seems to be taken care of differently now.

Companion PR:
https://github.com/oat-sa/extension-tao-act/pull/767