### PR TITLE
Feature/tao 5361 refactor storage

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -99,16 +99,19 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             }
         }
 
-        // auto append platform messages, if any
-        if ($this->serviceContext && !isset($data['messages'])) {
-            try {
+        try {
+            // auto append platform messages, if any
+            if ($this->serviceContext && !isset($data['messages'])) {
                 /* @var $communicationService \oat\taoQtiTest\models\runner\communicator\CommunicationService */
                 $communicationService = $this->getServiceManager()->get(QtiCommunicationService::SERVICE_ID);
                 $data['messages'] = $communicationService->processOutput($this->serviceContext);
-            } catch (common_Exception $e) {
-                $data = $this->getErrorResponse($e);
-                $httpStatus = $this->getErrorCode($e);
             }
+            
+            // ensure the state storage is properly updated
+            $this->getStorageManager()->persist();
+        } catch (common_Exception $e) {
+            $data = $this->getErrorResponse($e);
+            $httpStatus = $this->getErrorCode($e);
         }
 
         return parent::returnJson($data, $httpStatus);
@@ -289,7 +292,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -314,7 +316,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -339,7 +340,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -364,7 +364,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -395,7 +394,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -433,7 +431,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -586,7 +583,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -647,7 +643,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -696,7 +691,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -753,7 +747,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -788,7 +781,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -814,7 +806,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -850,7 +841,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -894,7 +884,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -921,7 +910,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -964,7 +952,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -1011,7 +998,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-        $this->getStorageManager()->persist();
         $this->returnJson($response, $code, false);
     }
 }

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -28,6 +28,7 @@ use oat\taoQtiTest\models\runner\QtiRunnerPausedException;
 use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\communicator\QtiCommunicationService;
+use oat\taoQtiTest\models\runner\StorageManager;
 use oat\tao\model\security\xsrf\TokenService;
 use taoQtiTest_helpers_TestRunnerUtils as TestRunnerUtils;
 
@@ -50,7 +51,6 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
      */
     protected $serviceContext;
 
-
     /**
      * taoQtiTest_actions_Runner constructor.
      */
@@ -60,6 +60,14 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
         // Prevent anything to be cached by the client.
         TestRunnerUtils::noHttpClientCache();
+    }
+
+    /**
+     * @return StorageManager
+     */
+    protected function getStorageManager()
+    {
+        return $this->getServiceManager()->get(StorageManager::SERVICE_ID);
     }
 
     /**
@@ -93,9 +101,14 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
         // auto append platform messages, if any
         if ($this->serviceContext && !isset($data['messages'])) {
-            /* @var $communicationService \oat\taoQtiTest\models\runner\communicator\CommunicationService */
-            $communicationService = $this->getServiceManager()->get(QtiCommunicationService::SERVICE_ID);
-            $data['messages'] = $communicationService->processOutput($this->serviceContext);
+            try {
+                /* @var $communicationService \oat\taoQtiTest\models\runner\communicator\CommunicationService */
+                $communicationService = $this->getServiceManager()->get(QtiCommunicationService::SERVICE_ID);
+                $data['messages'] = $communicationService->processOutput($this->serviceContext);
+            } catch (common_Exception $e) {
+                $data = $this->getErrorResponse($e);
+                $httpStatus = $this->getErrorCode($e);
+            }
         }
 
         return parent::returnJson($data, $httpStatus);
@@ -276,7 +289,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
-
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -301,6 +314,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -325,6 +339,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -349,6 +364,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -379,6 +395,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -416,6 +433,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -423,6 +441,9 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
      * Create the item definition response for a given item
      * @param string $itemIdentifier the item id
      * @return array the item data
+     * @throws common_Exception
+     * @throws common_exception_Error
+     * @throws common_exception_InvalidArgumentType
      */
     protected function getItemData($itemIdentifier)
     {
@@ -565,6 +586,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -625,6 +647,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -673,6 +696,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -729,6 +753,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -763,6 +788,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -788,6 +814,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -823,6 +850,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -866,6 +894,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -892,6 +921,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -934,6 +964,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code);
     }
 
@@ -980,6 +1011,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $code = $this->getErrorCode($e);
         }
 
+        $this->getStorageManager()->persist();
         $this->returnJson($response, $code, false);
     }
 }

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -37,6 +37,7 @@ use oat\taoQtiItem\helpers\QtiRunner;
 use oat\taoQtiTest\models\TestSessionMetaData;
 use oat\taoQtiTest\models\QtiTestCompilerIndex;
 use oat\taoQtiTest\models\files\QtiFlysystemFileManager;
+use oat\taoQtiTest\models\runner\StorageManager;
 use oat\oatbox\service\ServiceManager;
 
 /**
@@ -63,13 +64,6 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
      * @var AssessmentTest
      */
     private $testDefinition = null;
-    
-    /**
-     * The TAO Resource describing the test to be run.
-     * 
-     * @var core_kernel_classes_Resource
-     */
-    private $testResource = null;
     
     /**
      * The current AbstractStorage object.
@@ -375,6 +369,7 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule {
         
         common_Logger::t("Persisting QTI Assessment Test Session '${sessionId}'...");
 	    $this->getStorage()->persist($testSession);
+	    $this->getServiceManager()->get(StorageManager::SERVICE_ID)->persist();
     }
 
     /**

--- a/config/default/StorageManager.conf.php
+++ b/config/default/StorageManager.conf.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+use oat\taoQtiTest\models\runner\StorageManager;
+
+return new StorageManager();

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -21,7 +21,6 @@
 use oat\taoQtiTest\models\runner\RunnerService;
 use qtism\data\NavigationMode;
 use qtism\data\SubmissionMode;
-use qtism\data\View;
 use qtism\runtime\common\Container;
 use qtism\runtime\tests\AssessmentTestSession;
 use qtism\runtime\tests\AssessmentTestSessionException;

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '17.7.0',
+    'version'     => '17.8.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.7.0',

--- a/models/classes/ExtendedStateService.php
+++ b/models/classes/ExtendedStateService.php
@@ -14,14 +14,14 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2015-2017 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoQtiTest\models;
 
 use oat\oatbox\service\ConfigurableService;
 use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoQtiTest\models\runner\StorageManager;
 
 /**
  * Manage the flagged items
@@ -29,7 +29,7 @@ use oat\taoDelivery\model\execution\ServiceProxy;
 class ExtendedStateService extends ConfigurableService
 {
     const SERVICE_ID = 'taoQtiTest/ExtendedStateService';
-    
+
     const STORAGE_PREFIX = 'extra_';
 
     const VAR_REVIEW = 'review';
@@ -38,20 +38,47 @@ class ExtendedStateService extends ConfigurableService
     const VAR_CAT = 'cat';
     const VAR_HREF_INDEX = 'item_href_index';
 
-    private static $cache = null;
-    private static $deliveryExecutions = null;
+    protected $cache = null;
+    protected $deliveryExecutions = null;
+
+    /**
+     * @var StateStorage
+     */
+    protected $storageService;
+
+    /**
+     * Gets the StateStorage service
+     * @return StateStorage
+     */
+    public function getStorageService()
+    {
+        if (!$this->storageService) {
+            $this->storageService = $this->getServiceLocator()->get(StorageManager::SERVICE_ID);
+        }
+        return $this->storageService;
+    }
+
+    /**
+     * Sets the StateStorage service
+     * @param StateStorage $storageService
+     */
+    public function setStorageService($storageService)
+    {
+        $this->storageService = $storageService;
+    }
 
     /**
      * @param string $testSessionId
      * @return string
+     * @throws \common_exception_Error
      */
     protected function getSessionUserUri($testSessionId)
     {
-        if (!isset(self::$deliveryExecutions[$testSessionId])) {
-            self::$deliveryExecutions[$testSessionId] = ServiceProxy::singleton()->getDeliveryExecution($testSessionId);
+        if (!isset($this->deliveryExecutions[$testSessionId])) {
+            $this->deliveryExecutions[$testSessionId] = ServiceProxy::singleton()->getDeliveryExecution($testSessionId);
         }
-        if (self::$deliveryExecutions[$testSessionId]) {
-            return self::$deliveryExecutions[$testSessionId]->getUserIdentifier();
+        if ($this->deliveryExecutions[$testSessionId]) {
+            return $this->deliveryExecutions[$testSessionId]->getUserIdentifier();
         }
         return \common_session_SessionManager::getSession()->getUserUri();
     }
@@ -59,61 +86,57 @@ class ExtendedStateService extends ConfigurableService
     /**
      * Retrieves extended state information
      * @param string $testSessionId
+     * @param string $key
+     * @return mixed
      * @throws \common_Exception
-     * @return array
      */
-    protected function getExtra($testSessionId)
+    protected function load($testSessionId, $key = '')
     {
-        if (!isset(self::$cache[$testSessionId])) {
-            $storageService = \tao_models_classes_service_StateStorage::singleton();
-            $userUri = $this->getSessionUserUri($testSessionId);
+        $storageKey = self::getStorageKeyFromTestSessionId($testSessionId, $key);
+        if (!isset($this->cache[$storageKey])) {
+            $sessionUri = $this->getSessionUserUri($testSessionId);
+            $data = $this->getStorageService()->get($sessionUri, $storageKey);
 
-            $data = $storageService->get($userUri, self::getStorageKeyFromTestSessionId($testSessionId));
-            if ($data) {
-                $data = json_decode($data, true);
-                if (is_null($data)) {
-                    throw new \common_exception_InconsistentData('Unable to decode extra for test session '.$testSessionId);
+            if (is_null($data) && $key) {
+                $data = json_decode($this->getStorageService()->get($sessionUri, self::getStorageKeyFromTestSessionId($testSessionId)), true);
+                if ($data && isset($data[$key])) {
+                    $this->cache[$storageKey] = $data[$key];
+                } else {
+                    $this->cache[$storageKey] = null;
                 }
             } else {
-                $data = array(
-                    self::VAR_REVIEW => array()
-                );
+                $this->cache[$storageKey] = json_decode($data, true);
             }
-            self::$cache[$testSessionId] = $data;
         }
-        return self::$cache[$testSessionId];
+        return $this->cache[$storageKey];
     }
 
     /**
      * Stores extended state information
      * @param string $testSessionId
-     * @param array $extra
+     * @param mixed $data
+     * @param string $key
+     * @throws \common_exception_Error
      */
-    protected function saveExtra($testSessionId, $extra)
+    protected function save($testSessionId, $data, $key = '')
     {
-
-        self::$cache[$testSessionId] = $extra;
-
-        $storageService = \tao_models_classes_service_StateStorage::singleton();
-        $userUri = $this->getSessionUserUri($testSessionId);
-
-        $storageService->set($userUri, self::getStorageKeyFromTestSessionId($testSessionId), json_encode($extra));
+        $storageKey = self::getStorageKeyFromTestSessionId($testSessionId, $key);
+        $this->cache[$storageKey] = $data;
+        $this->getStorageService()->set($this->getSessionUserUri($testSessionId), $storageKey, json_encode($data));
     }
 
     /**
-     * Gets a value from the storage
+     * Storage Key from Test Session Id
+     *
+     * Returns the Storage Key corresponding to a given $testSessionId
+     *
      * @param string $testSessionId
-     * @param string $name
-     * @param null $default
-     * @return mixed|null
-     * @throws \common_exception_InconsistentData
+     * @param string $key
+     * @return string
      */
-    protected function getValue($testSessionId, $name, $default = null)
+    public static function getStorageKeyFromTestSessionId($testSessionId, $key = '')
     {
-        $extra = $this->getExtra($testSessionId);
-        return isset($extra[$name])
-            ? $extra[$name]
-            : $default;
+        return self::STORAGE_PREFIX . $key . $testSessionId;
     }
 
     /**
@@ -121,13 +144,14 @@ class ExtendedStateService extends ConfigurableService
      * @param string $testSessionId
      * @param string $itemRef
      * @param boolean $flag
+     * @throws \common_Exception
+     * @throws \common_exception_Error
      */
     public function setItemFlag($testSessionId, $itemRef, $flag)
     {
-        $extra = $this->getExtra($testSessionId);
-        $extra[self::VAR_REVIEW][$itemRef] = $flag;
-
-        $this->saveExtra($testSessionId, $extra);
+        $flags = $this->load($testSessionId, self::VAR_REVIEW);
+        $flags[$itemRef] = $flag;
+        $this->save($testSessionId, $flags, self::VAR_REVIEW);
     }
 
     /**
@@ -135,27 +159,37 @@ class ExtendedStateService extends ConfigurableService
      * @param string $testSessionId
      * @param string $itemRef
      * @return bool
-     * @throws \common_exception_InconsistentData
+     * @throws \common_Exception
      */
     public function getItemFlag($testSessionId, $itemRef)
     {
-        $extra = $this->getExtra($testSessionId);
-        return isset($extra[self::VAR_REVIEW][$itemRef])
-            ? $extra[self::VAR_REVIEW][$itemRef]
-            : false;
+        $flags = $this->load($testSessionId, self::VAR_REVIEW);
+        return isset($flags[$itemRef]) ? $flags[$itemRef] : false;
     }
 
+    /**
+     * @param string $testSessionId
+     * @param string $storeId
+     * @throws \common_exception_Error
+     * @throws \common_Exception
+     * @throws \common_exception_Error
+     */
     public function setStoreId($testSessionId, $storeId)
     {
-        $extra = $this->getExtra($testSessionId);
-        $extra[self::VAR_STORE_ID] = $storeId;
-        $this->saveExtra($testSessionId, $extra);
+        $data = $this->load($testSessionId);
+        $data[self::VAR_STORE_ID] = $storeId;
+        $this->save($testSessionId, $data);
     }
 
+    /**
+     * @param string $testSessionId
+     * @return bool
+     * @throws \common_Exception
+     */
     public function getStoreId($testSessionId)
     {
-        $extra = $this->getExtra($testSessionId);
-        return isset($extra[self::VAR_STORE_ID]) ? $extra[self::VAR_STORE_ID] : false;
+        $data = $this->load($testSessionId);
+        return isset($data[self::VAR_STORE_ID]) ? $data[self::VAR_STORE_ID] : false;
     }
 
     /**
@@ -164,38 +198,34 @@ class ExtendedStateService extends ConfigurableService
      * @param string $eventName
      * @param mixed $data
      * @return string
+     * @throws \common_Exception
+     * @throws \common_exception_Error
      */
     public function addEvent($testSessionId, $eventName, $data = null)
     {
-        $extra = $this->getExtra($testSessionId);
-        
         $eventId = uniqid('event', true);
-
-        $extra[self::VAR_EVENTS_QUEUE][$eventId] = [
+        $events = $this->load($testSessionId, self::VAR_EVENTS_QUEUE);
+        $events[$eventId] = [
             'id' => $eventId,
             'timestamp' => microtime(true),
             'user' => \common_session_SessionManager::getSession()->getUserUri(),
             'type' => $eventName,
             'data' => $data,
         ];
-        
-        $this->saveExtra($testSessionId, $extra);
-        
+        $this->save($testSessionId, $events, self::VAR_EVENTS_QUEUE);
         return $eventId;
     }
 
     /**
      * Gets all events from the queue
-     * @param $testSessionId
-     * @return array|mixed
+     * @param string $testSessionId
+     * @return array
+     * @throws \common_Exception
      */
     public function getEvents($testSessionId)
     {
-        $extra = $this->getExtra($testSessionId);
-        
-        if (isset($extra[self::VAR_EVENTS_QUEUE])) {
-            $events = $extra[self::VAR_EVENTS_QUEUE];
-        } else {
+        $events = $this->load($testSessionId, self::VAR_EVENTS_QUEUE);
+        if (!$events) {
             $events = [];
         }
         return $events;
@@ -203,131 +233,114 @@ class ExtendedStateService extends ConfigurableService
 
     /**
      * Removes particular events from the queue
-     * @param $testSessionId
+     * @param string $testSessionId
      * @param array $ids
+     * @throws \common_Exception
+     * @throws \common_exception_Error
      */
     public function removeEvents($testSessionId, $ids = [])
     {
-        $extra = $this->getExtra($testSessionId);
-        $toSave = false;
-        if (isset($extra[self::VAR_EVENTS_QUEUE])) {
+        $events = $this->load($testSessionId, self::VAR_EVENTS_QUEUE);
+        if ($events) {
             foreach ($ids as $id) {
-                if (isset($extra[self::VAR_EVENTS_QUEUE][$id])) {
-                    unset($extra[self::VAR_EVENTS_QUEUE][$id]);
-                    $toSave = true;
+                if (isset($events[$id])) {
+                    unset($events[$id]);
                 }
             }
         }
-
-        if($toSave){
-            $this->saveExtra($testSessionId, $extra);
-        }
+        $this->save($testSessionId, $events, self::VAR_EVENTS_QUEUE);
     }
-    
+
     /**
      * Removes all events from the queue
-     * @param $testSessionId
+     * @param string $testSessionId
+     * @throws \common_exception_Error
      */
     public function clearEvents($testSessionId)
     {
-        $extra = $this->getExtra($testSessionId);
-
-        if(isset($extra[self::VAR_EVENTS_QUEUE]) && !empty($extra[self::VAR_EVENTS_QUEUE])){
-            $extra[self::VAR_EVENTS_QUEUE] = [];
-            $this->saveExtra($testSessionId, $extra);
-        }
-
+        $this->save($testSessionId, [], self::VAR_EVENTS_QUEUE);
     }
 
     /**
      * Stores the table that maps the items identifiers to item reference
      * Fallback index in case of the delivery was compiled without the index of item href
-     * @param $testSessionId
+     * @param string $testSessionId
      * @param array $table
+     * @throws \common_exception_Error
      */
     public function storeItemHrefIndex($testSessionId, $table)
     {
-        $extra = $this->getExtra($testSessionId);
-        $extra[self::VAR_HREF_INDEX] = $table;
-        $this->saveExtra($testSessionId, $extra);
+        $this->save($testSessionId, $table, self::VAR_HREF_INDEX);
     }
 
     /**
      * Loads the table that maps the items identifiers to item reference
      * Fallback index in case of the delivery was compiled without the index of item href
-     * @param $testSessionId
+     * @param string $testSessionId
      * @return array
+     * @throws \common_Exception
      */
     public function loadItemHrefIndex($testSessionId)
     {
-        $extra = $this->getExtra($testSessionId);
-
-        if (isset($extra[self::VAR_HREF_INDEX])) {
-            $table = $extra[self::VAR_HREF_INDEX];
-        } else {
-            $table = [];
+        $index = $this->load($testSessionId, self::VAR_HREF_INDEX);
+        if (!$index) {
+            $index = [];
         }
-        return $table;
+        return $index;
     }
 
-
-    /**
-     * Storage Key from Test Session Id
-     *
-     * Returns the Storage Key corresponding to a given $testSessionId
-     *
-     * @param string $testSessionId
-     * @return string
-     */
-    public static function getStorageKeyFromTestSessionId($testSessionId)
-    {
-        return self::STORAGE_PREFIX . $testSessionId;
-    }
-    
     /**
      * Set a CAT Value
-     * 
+     *
      * Set a CAT value in the Extended State.
-     * 
+     *
      * @param string $testSessionId
      * @param string $assessmentSectionId
      * @param string $key
      * @param string $value
+     * @throws \common_Exception
+     * @throws \common_exception_Error
      */
     public function setCatValue($testSessionId, $assessmentSectionId, $key, $value)
     {
-        $extra = $this->getExtra($testSessionId);
-        $extra[self::VAR_CAT][$assessmentSectionId][$key] = $value;
-        $this->saveExtra($testSessionId, $extra);
+        $data = $this->load($testSessionId, self::VAR_CAT);
+        $data[$assessmentSectionId][$key] = $value;
+        $this->save($testSessionId, $data, self::VAR_CAT);
     }
-    
+
     /**
      * Get a CAT Value
-     * 
+     *
      * Get a CAT value from the Extended State.
-     * 
-     * @return string
-     */
-    public function getCatValue($testSessionId, $assessmentSectionId, $key)
-    {
-        $extra = $this->getExtra($testSessionId);
-        return (isset($extra[self::VAR_CAT]) && isset($extra[self::VAR_CAT][$assessmentSectionId]) && isset($extra[self::VAR_CAT][$assessmentSectionId][$key])) ? $extra[self::VAR_CAT][$assessmentSectionId][$key] : null;
-    }
-    
-    /**
-     * Remove a CAT value from the ExtendedState.
-     * 
+     *
      * @param string $testSessionId
      * @param string $assessmentSectionId
      * @param string $key
+     * @return mixed
+     * @throws \common_Exception
+     */
+    public function getCatValue($testSessionId, $assessmentSectionId, $key)
+    {
+        $data = $this->load($testSessionId, self::VAR_CAT);
+        return ($data && isset($data[$assessmentSectionId]) && isset($data[$assessmentSectionId][$key])) ? $data[$assessmentSectionId][$key] : null;
+    }
+
+    /**
+     * Remove a CAT value from the ExtendedState.
+     *
+     * @param string $testSessionId
+     * @param string $assessmentSectionId
+     * @param string $key
+     * @throws \common_Exception
+     * @throws \common_exception_Error
      */
     public function removeCatValue($testSessionId, $assessmentSectionId, $key)
     {
-        $extra = $this->getExtra($testSessionId);
-        if (isset($extra[self::VAR_CAT]) && isset($extra[self::VAR_CAT][$assessmentSectionId]) && isset($extra[self::VAR_CAT][$assessmentSectionId][$key])) {
-            unset($extra[self::VAR_CAT][$assessmentSectionId][$key]); 
+        $data = $this->load($testSessionId, self::VAR_CAT);
+        if ($data && isset($data[$assessmentSectionId]) && isset($data[$assessmentSectionId][$key])) {
+            unset($data[$assessmentSectionId][$key]);
         }
-        
-        $this->saveExtra($testSessionId, $extra);
+
+        $this->save($testSessionId, $data, self::VAR_CAT);
     }
 }

--- a/models/classes/QtiTestListenerService.php
+++ b/models/classes/QtiTestListenerService.php
@@ -26,6 +26,7 @@ use oat\taoQtiTest\models\event\AfterAssessmentTestSessionClosedEvent;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
 use oat\taoQtiTest\models\runner\communicator\TestStateChannel;
 use oat\taoQtiTest\models\runner\QtiRunnerMessageService;
+use oat\taoQtiTest\models\runner\StorageManager;
 use oat\taoQtiTest\models\runner\time\QtiTimeStorage;
 use qtism\runtime\tests\AssessmentTestSession;
 
@@ -161,13 +162,24 @@ class QtiTestListenerService extends ConfigurableService
 
         if (!in_array(self::ARCHIVE_EXCLUDE_EXTRA, $archivingExclusions)) {
             // Remove Extended State
-            // Remove Extended State
             $extendedStorageId = ExtendedStateService::getStorageKeyFromTestSessionId($sessionId);
             if ($stateMigrationService->archive($userId, $extendedStorageId)) {
                 $stateMigrationService->removeState($userId, $extendedStorageId);
                 \common_Logger::t('Extended State archived for user : ' . $userId . ' and storageId : ' . $extendedStorageId);
             }
-
+            $keys = [
+                ExtendedStateService::VAR_REVIEW, 
+                ExtendedStateService::VAR_EVENTS_QUEUE, 
+                ExtendedStateService::VAR_HREF_INDEX, 
+                ExtendedStateService::VAR_CAT
+            ];
+            foreach($keys as $key) {
+                $extendedStorageId = ExtendedStateService::getStorageKeyFromTestSessionId($sessionId, $key);
+                if ($stateMigrationService->archive($userId, $extendedStorageId)) {
+                    $stateMigrationService->removeState($userId, $extendedStorageId);
+                    \common_Logger::t('Extended State Key archived for user : ' . $userId . ' and storageId : ' . $extendedStorageId);
+                }   
+            }
         }
     }
 }

--- a/models/classes/QtiTestListenerService.php
+++ b/models/classes/QtiTestListenerService.php
@@ -167,19 +167,6 @@ class QtiTestListenerService extends ConfigurableService
                 $stateMigrationService->removeState($userId, $extendedStorageId);
                 \common_Logger::t('Extended State archived for user : ' . $userId . ' and storageId : ' . $extendedStorageId);
             }
-            $keys = [
-                ExtendedStateService::VAR_REVIEW, 
-                ExtendedStateService::VAR_EVENTS_QUEUE, 
-                ExtendedStateService::VAR_HREF_INDEX, 
-                ExtendedStateService::VAR_CAT
-            ];
-            foreach($keys as $key) {
-                $extendedStorageId = ExtendedStateService::getStorageKeyFromTestSessionId($sessionId, $key);
-                if ($stateMigrationService->archive($userId, $extendedStorageId)) {
-                    $stateMigrationService->removeState($userId, $extendedStorageId);
-                    \common_Logger::t('Extended State Key archived for user : ' . $userId . ' and storageId : ' . $extendedStorageId);
-                }   
-            }
         }
     }
 }

--- a/models/classes/QtiTestListenerService.php
+++ b/models/classes/QtiTestListenerService.php
@@ -25,8 +25,8 @@ use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
 use oat\taoQtiTest\models\event\AfterAssessmentTestSessionClosedEvent;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
 use oat\taoQtiTest\models\runner\communicator\TestStateChannel;
+use oat\taoQtiTest\models\runner\ExtendedState;
 use oat\taoQtiTest\models\runner\QtiRunnerMessageService;
-use oat\taoQtiTest\models\runner\StorageManager;
 use oat\taoQtiTest\models\runner\time\QtiTimeStorage;
 use qtism\runtime\tests\AssessmentTestSession;
 
@@ -162,7 +162,7 @@ class QtiTestListenerService extends ConfigurableService
 
         if (!in_array(self::ARCHIVE_EXCLUDE_EXTRA, $archivingExclusions)) {
             // Remove Extended State
-            $extendedStorageId = ExtendedStateService::getStorageKeyFromTestSessionId($sessionId);
+            $extendedStorageId = ExtendedState::getStorageKeyFromTestSessionId($sessionId);
             if ($stateMigrationService->archive($userId, $extendedStorageId)) {
                 $stateMigrationService->removeState($userId, $extendedStorageId);
                 \common_Logger::t('Extended State archived for user : ' . $userId . ' and storageId : ' . $extendedStorageId);

--- a/models/classes/runner/ExtendedState.php
+++ b/models/classes/runner/ExtendedState.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015-2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoQtiTest\models\runner;
+
+use oat\oatbox\service\ServiceManagerAwareInterface;
+use oat\oatbox\service\ServiceManagerAwareTrait;
+use oat\tao\model\state\StateStorage;
+
+/**
+ * Manage the flagged items
+ */
+class ExtendedState implements ServiceManagerAwareInterface
+{
+    use ServiceManagerAwareTrait;
+    
+    const STORAGE_PREFIX = 'extra_';
+    const VAR_REVIEW = 'review';
+    const VAR_STORE_ID = 'client_store_id';
+    const VAR_EVENTS_QUEUE = 'events_queue';
+    const VAR_CAT = 'cat';
+    const VAR_HREF_INDEX = 'item_href_index';
+
+    /**
+     * @var string
+     */
+    protected $testSessionId;
+
+    /**
+     * @var string
+     */
+    protected $userId;
+
+    /**
+     * @var array
+     */
+    protected $state = [];
+
+    /**
+     * @var StateStorage
+     */
+    protected $storage;
+
+    /**
+     * ExtendedState constructor.
+     * @param string $testSessionId
+     * @param string $userId
+     */
+    public function __construct($testSessionId = '', $userId = '')
+    {
+        $this->setTestSessionId($testSessionId);
+        $this->setUserId($userId);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTestSessionId()
+    {
+        return $this->testSessionId;
+    }
+
+    /**
+     * @param string $testSessionId
+     * @return ExtendedState
+     */
+    public function setTestSessionId($testSessionId)
+    {
+        $this->testSessionId = $testSessionId;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    /**
+     * @param string $userId
+     * @return ExtendedState
+     */
+    public function setUserId($userId)
+    {
+        $this->userId = $userId;
+        return $this;
+    }
+    
+    /**
+     * Gets the StateStorage service
+     * @return StateStorage
+     */
+    public function getStorage()
+    {
+        if (!$this->storage) {
+            $this->storage = $this->getServiceLocator()->get(StorageManager::SERVICE_ID);
+        }
+        return $this->storage;
+    }
+
+    /**
+     * Sets the StateStorage service
+     * @param StateStorage $storage
+     * @return ExtendedState
+     */
+    public function setStorage($storage)
+    {
+        $this->storage = $storage;
+        return $this;
+    }
+
+    /**
+     * Gets the storage key based on the provided Test Session Id.
+     * @param string $testSessionId
+     * @return string
+     */
+    public static function getStorageKeyFromTestSessionId($testSessionId)
+    {
+        return self::STORAGE_PREFIX . $testSessionId;
+    }
+
+    /**
+     * Gets the storage key based on the nested Test Session Id.
+     * @return string
+     */
+    public function getStorageKey()
+    {
+        return self::getStorageKeyFromTestSessionId($this->testSessionId);
+    }
+
+    /**
+     * Loads the extended state from the storage
+     * @return bool
+     */
+    public function load()
+    {
+        $storage = $this->getStorage();
+        if ($storage) {
+            $data = $storage->get($this->userId, $this->getStorageKey());
+            if ($data) {
+                $this->state = json_decode($data, true);
+            } else {
+                $this->state = [];
+            }
+            $success = is_array($this->state);
+        } else {
+            $success = false;    
+        }
+        return $success;
+    }
+
+    /**
+     * Saves the extended state into the storage
+     * @return bool
+     */
+    public function save()
+    {
+        $storage = $this->getStorage();
+        if ($storage) {
+            $success = $storage->set($this->userId, $this->getStorageKey(), json_encode($this->state));
+        } else {
+            $success = false;
+        }
+        return $success;
+    }
+
+    /**
+     * Set the marked for review state of an item
+     * @param string $itemRef
+     * @param bool $flag
+     * @return ExtendedState
+     */
+    public function setItemFlag($itemRef, $flag)
+    {
+        $this->state[self::VAR_REVIEW][$itemRef] = $flag;
+        return $this;
+    }
+
+    /**
+     * Gets the marked for review state of an item
+     * @param string $itemRef
+     * @return bool
+     */
+    public function getItemFlag($itemRef)
+    {
+        return isset($this->state[self::VAR_REVIEW]) && isset($this->state[self::VAR_REVIEW][$itemRef])
+            ? $this->state[self::VAR_REVIEW][$itemRef]
+            : false;
+    }
+
+    /**
+     * Sets the name of the client store used for the timer
+     * @param string $storeId
+     * @return ExtendedState
+     */
+    public function setStoreId($storeId)
+    {
+        $this->state[self::VAR_STORE_ID] = $storeId;
+        return $this;
+    }
+
+    /**
+     * Gets the name of the client store used for the timer
+     * @return bool
+     */
+    public function getStoreId()
+    {
+        return isset($this->state[self::VAR_STORE_ID]) ? $this->state[self::VAR_STORE_ID] : false;
+    }
+
+    /**
+     * Add an event on top of the queue
+     * @param string $eventName
+     * @param mixed $data
+     * @return string
+     * @throws \common_Exception
+     */
+    public function addEvent($eventName, $data = null)
+    {
+        $eventId = uniqid('event', true);
+        $this->state[self::VAR_EVENTS_QUEUE][$eventId] = [
+            'id' => $eventId,
+            'timestamp' => microtime(true),
+            'user' => \common_session_SessionManager::getSession()->getUserUri(),
+            'type' => $eventName,
+            'data' => $data,
+        ];
+        return $eventId;
+    }
+
+    /**
+     * Gets all events from the queue
+     * @return array
+     */
+    public function getEvents()
+    {
+        if (isset($this->state[self::VAR_EVENTS_QUEUE])) {
+            $events = $this->state[self::VAR_EVENTS_QUEUE];
+        } else {
+            $events = [];
+        }
+        return $events;
+    }
+
+    /**
+     * Removes particular events from the queue
+     * @param array $ids
+     * @return bool
+     */
+    public function removeEvents($ids = [])
+    {
+        $removed = false;
+        if (isset($this->state[self::VAR_EVENTS_QUEUE])) {
+            foreach ($ids as $id) {
+                if (isset($this->state[self::VAR_EVENTS_QUEUE][$id])) {
+                    unset($this->state[self::VAR_EVENTS_QUEUE][$id]);
+                    $removed = true;
+                }
+            }
+        }
+        return $removed;
+    }
+
+    /**
+     * Removes all events from the queue
+     * @return ExtendedState
+     */
+    public function clearEvents()
+    {
+        $this->state[self::VAR_EVENTS_QUEUE] = [];
+        return $this;
+    }
+
+    /**
+     * Stores the table that maps the items identifiers to item reference
+     * Fallback index in case of the delivery was compiled without the index of item href
+     * @param array $table
+     * @return ExtendedState
+     */
+    public function setItemHrefIndex($table)
+    {
+        $this->state[self::VAR_HREF_INDEX] = $table;
+        return $this;
+    }
+
+    /**
+     * Loads the table that maps the items identifiers to item reference
+     * Fallback index in case of the delivery was compiled without the index of item href
+     * @return array
+     */
+    public function getItemHrefIndex()
+    {
+        if (isset($this->state[self::VAR_HREF_INDEX])) {
+            $table = $this->state[self::VAR_HREF_INDEX];
+        } else {
+            $table = [];
+        }
+        return $table;
+    }
+
+    /**
+     * Sets a CAT value in the Extended State.
+     * @param string $assessmentSectionId
+     * @param string $key
+     * @param string $value
+     * @return ExtendedState
+     */
+    public function setCatValue($assessmentSectionId, $key, $value)
+    {
+        $this->state[self::VAR_CAT][$assessmentSectionId][$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Gets a CAT value from the Extended State.
+     * @param string $assessmentSectionId
+     * @param string $key
+     * @return string
+     */
+    public function getCatValue($assessmentSectionId, $key)
+    {
+        return (isset($this->state[self::VAR_CAT]) && isset($this->state[self::VAR_CAT][$assessmentSectionId]) && isset($this->state[self::VAR_CAT][$assessmentSectionId][$key])) ? $this->state[self::VAR_CAT][$assessmentSectionId][$key] : null;
+    }
+
+    /**
+     * Removes a CAT value from the ExtendedState.
+     * @param string $assessmentSectionId
+     * @param string $key
+     * @return ExtendedState
+     */
+    public function removeCatValue($assessmentSectionId, $key)
+    {
+        if (isset($this->state[self::VAR_CAT]) && isset($this->state[self::VAR_CAT][$assessmentSectionId]) && isset($this->state[self::VAR_CAT][$assessmentSectionId][$key])) {
+            unset($this->state[self::VAR_CAT][$assessmentSectionId][$key]);
+        }
+        return $this;
+    }
+}

--- a/models/classes/runner/ExtendedState.php
+++ b/models/classes/runner/ExtendedState.php
@@ -21,7 +21,6 @@ namespace oat\taoQtiTest\models\runner;
 
 use oat\oatbox\service\ServiceManagerAwareInterface;
 use oat\oatbox\service\ServiceManagerAwareTrait;
-use oat\tao\model\state\StateStorage;
 
 /**
  * Manage the flagged items
@@ -53,7 +52,7 @@ class ExtendedState implements ServiceManagerAwareInterface
     protected $state = [];
 
     /**
-     * @var StateStorage
+     * @var StorageManager
      */
     protected $storage;
 
@@ -105,8 +104,8 @@ class ExtendedState implements ServiceManagerAwareInterface
     }
     
     /**
-     * Gets the StateStorage service
-     * @return StateStorage
+     * Gets the StorageManager service
+     * @return StorageManager
      */
     public function getStorage()
     {
@@ -117,8 +116,8 @@ class ExtendedState implements ServiceManagerAwareInterface
     }
 
     /**
-     * Sets the StateStorage service
-     * @param StateStorage $storage
+     * Sets the StorageManager service
+     * @param StorageManager $storage
      * @return ExtendedState
      */
     public function setStorage($storage)

--- a/models/classes/runner/StorageManager.php
+++ b/models/classes/runner/StorageManager.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+namespace oat\taoQtiTest\models\runner;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\state\StateStorage;
+
+/**
+ * Class StorageManager
+ * 
+ * Manage the storage in order to centralize its access.
+ * The reading of data can be done at any time, the first call will put the data in memory cache.
+ * Each change will only update the cache, and mark it to be processed upon persisting.
+ * The actual writing should be done once, at the end of the request, by invoking the `persist()` method.
+ * 
+ * @package oat\taoQtiTest\models\classes\runner
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class StorageManager extends ConfigurableService
+{
+    const SERVICE_ID = 'taoQtiTest/StorageManager';
+
+    /**
+     * The data does not exist in the storage
+     */
+    const STATE_NOT_FOUND = -1;
+
+    /**
+     * The data is aligned with the storage
+     */
+    const STATE_ALIGNED = 0;
+
+    /**
+     * The data is pending write to the storage
+     */
+    const STATE_PENDING_WRITE = 1;
+
+    /**
+     * The data is pending delete from the storage
+     */
+    const STATE_PENDING_DELETE = 2;
+
+    /**
+     * Link to the actual storage adapter
+     * @var StateStorage
+     */
+    protected $storage;
+
+    /**
+     * In memory cache for read/pending data
+     * @var array
+     */
+    protected $cache = [];
+
+    /**
+     * Gets a key that will be used to cache data.
+     *
+     * @param string $userId
+     * @param string $callId
+     * @return string
+     */
+    protected function getCacheKey($userId, $callId)
+    {
+        return $userId . '/' . $callId;
+    }
+
+    /**
+     * Puts data in the cache. Maintain the link to the userId/callId pair.
+     * Also keep the dirty state that will be used when persisting the data to the actual storage.
+     *
+     * @param string $key
+     * @param string $userId
+     * @param string $callId
+     * @param string $data
+     * @param int $state
+     */
+    protected function putInCache($key, $userId, $callId, $data, $state = self::STATE_ALIGNED)
+    {
+        $this->cache[$key] = [
+            'userId' => $userId,
+            'callId' => $callId,
+            'state' => $state,
+            'data' => $data
+        ];
+    }
+
+    /**
+     * Checks if a dataset exists for the provided key.
+     *
+     * @param string $key
+     * @return bool
+     */
+    protected function exists($key)
+    {
+        return isset($this->cache[$key]) && in_array($this->cache[$key]['state'], [self::STATE_ALIGNED, self::STATE_PENDING_WRITE]);
+    }
+
+    /**
+     * Gets a dataset from the cache.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    protected function getFromCache($key)
+    {
+        if ($this->exists($key)) {
+            return $this->cache[$key]['data'];
+        }
+        return null;
+    }
+
+    /**
+     * @return StateStorage
+     */
+    public function getStorage()
+    {
+        if (!$this->storage) {
+            $this->storage = $this->getServiceLocator()->get(StateStorage::SERVICE_ID);
+        }
+        return $this->storage;
+    }
+
+    /**
+     * @param StateStorage $storage
+     * @return StorageManager
+     */
+    public function setStorage(StateStorage $storage)
+    {
+        $this->storage = $storage;
+        return $this;
+    }
+
+    /**
+     * Applies a dataset to be stored.
+     *
+     * @param string $userId
+     * @param string $callId
+     * @param string $data
+     * @return boolean
+     */
+    public function set($userId, $callId, $data)
+    {
+        $key = $this->getCacheKey($userId, $callId);
+        $cache = $this->getFromCache($key);
+        if (is_null($cache) || $cache != $data) {
+            $this->putInCache($key, $userId, $callId, $data, self::STATE_PENDING_WRITE);
+        }
+        return true;
+    }
+
+    /**
+     * Gets a dataset from the store using the provided keys.
+     * Will return null if the dataset doesn't exist.
+     *
+     * @param string $userId
+     * @param string $callId
+     * @return string
+     */
+    public function get($userId, $callId)
+    {
+        $key = $this->getCacheKey($userId, $callId);
+        if (!isset($this->cache[$key])) {
+            $data = $this->getStorage()->get($userId, $callId);
+            $state = is_null($data) ? self::STATE_NOT_FOUND : self::STATE_ALIGNED;
+            $this->putInCache($key, $userId, $callId, $data, $state);
+        }
+
+        return $this->getFromCache($key);
+    }
+
+    /**
+     * Whenever or not a dataset exists.
+     *
+     * @param string $userId
+     * @param string $callId
+     * @return boolean
+     */
+    public function has($userId, $callId)
+    {
+        $key = $this->getCacheKey($userId, $callId);
+        if (!isset($this->cache[$key])) {
+            return $this->getStorage()->has($userId, $callId);
+        }
+        return $this->exists($key);
+    }
+
+    /**
+     * Marks the the dataset to be removed from the storage.
+     *
+     * @param string $userId
+     * @param string $callId
+     * @return boolean
+     */
+    public function del($userId, $callId)
+    {
+        $key = $this->getCacheKey($userId, $callId);
+        $this->putInCache($key, $userId, $callId, null, self::STATE_PENDING_DELETE);
+        return true;
+    }
+
+    /**
+     * Sends the changes to the storage.
+     *
+     * @return bool
+     */
+    public function persist()
+    {
+        $success = true;
+        $storage = $this->getStorage();
+        foreach ($this->cache as $cache) {
+            switch ($cache['state']) {
+                case self::STATE_PENDING_WRITE:
+                    if (!$storage->set($cache['userId'], $cache['callId'], $cache['data'])) {
+                        $success = false;
+                    }
+                    break;
+
+                case self::STATE_PENDING_DELETE:
+                    if (!$storage->del($cache['userId'], $cache['callId'])) {
+                        $success = false;
+                    }
+                    break;
+            }
+        }
+        return $success;
+    }
+}

--- a/models/classes/runner/time/QtiTimeStorage.php
+++ b/models/classes/runner/time/QtiTimeStorage.php
@@ -117,7 +117,7 @@ class QtiTimeStorage implements TimeStorage, QtiTimeStorageFormatAware
      * Sets the StateStorage service
      * @param StateStorage $storageService
      */
-    public function setStorageService(StateStorage $storageService)
+    public function setStorageService($storageService)
     {
         $this->storageService = $storageService;
     }

--- a/models/classes/runner/time/QtiTimerFactory.php
+++ b/models/classes/runner/time/QtiTimerFactory.php
@@ -21,6 +21,7 @@
 namespace oat\taoQtiTest\models\runner\time;
 
 use oat\oatbox\service\ConfigurableService;
+use oat\taoQtiTest\models\runner\StorageManager;
 use oat\taoQtiTest\models\runner\time\storageFormat\QtiTimeStorageJsonFormat;
 use oat\taoTests\models\runner\time\Timer;
 use oat\taoTests\models\runner\time\TimeStorage;
@@ -85,6 +86,7 @@ class QtiTimerFactory extends ConfigurableService
         /* @var TimeStorage $timerStorage */
         $storageClass = $this->getStorageClass();
         $timerStorage = new $storageClass($testSessionId, $userUri);
+        $timerStorage->setStorageService($this->getServiceLocator()->get(StorageManager::SERVICE_ID));
         
         if ($timerStorage instanceof QtiTimeStorageFormatAware) {
             $storageFormatClass = $this->getStorageFormatClass();

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -28,6 +28,7 @@ use oat\taoQtiTest\models\runner\communicator\CommunicationService;
 use oat\taoQtiTest\models\runner\communicator\SyncChannel;
 use oat\taoQtiTest\models\runner\map\QtiRunnerMap;
 use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
+use oat\taoQtiTest\models\runner\StorageManager;
 use oat\taoQtiTest\models\runner\synchronisation\action\Move;
 use oat\taoQtiTest\models\runner\synchronisation\action\Skip;
 use oat\taoQtiTest\models\runner\synchronisation\action\StoreTraceData;
@@ -1660,5 +1661,11 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('17.6.0', '17.7.0');
+
+        if ($this->isVersion('17.7.0')) {
+            $storageManager = new StorageManager();
+            $this->getServiceManager()->register(StorageManager::SERVICE_ID, $storageManager);
+            $this->setVersion('17.8.0');
+        }
     }
 }

--- a/test/runner/ExtendedStateTest.php
+++ b/test/runner/ExtendedStateTest.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+
+namespace oat\taoQtiTest\test\runner;
+
+use oat\tao\model\state\StateStorage;
+use oat\tao\test\TaoPhpUnitTestRunner;
+use oat\taoQtiTest\models\runner\ExtendedState;
+use oat\taoQtiTest\models\runner\StorageManager;
+use Prophecy\Argument;
+use Prophecy\Prophet;
+
+/**
+ * Class ExtendedStateTest
+ * @package oat\taoQtiTest\test\runner
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class ExtendedStateTest extends TaoPhpUnitTestRunner
+{
+    /**
+     * @throws \common_ext_ExtensionException
+     */
+    public function setUp()
+    {
+        \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+    }
+
+    /**
+     * Tests the constructor of ExtendedState
+     */
+    public function testContructor()
+    {
+        $testSessionId = 'http://tao.ce/foo#12345';
+        $userId = 'http://tao.ce/bar#4567';
+        $extendedState = new ExtendedState($testSessionId, $userId);
+        $this->assertEquals($testSessionId, $extendedState->getTestSessionId());
+        $this->assertEquals($userId, $extendedState->getUserId());
+    }
+
+    /**
+     * Tests the setters of ExtendedState
+     */
+    public function testSetters()
+    {
+        $testSessionId = 'http://tao.ce/foo#12345';
+        $userId = 'http://tao.ce/bar#4567';
+        $extendedState = new ExtendedState();
+        $this->assertEquals(null, $extendedState->getTestSessionId());
+        $this->assertEquals(null, $extendedState->getUserId());
+
+        $extendedState->setTestSessionId($testSessionId);
+        $extendedState->setUserId($userId);
+
+        $this->assertEquals($testSessionId, $extendedState->getTestSessionId());
+        $this->assertEquals($userId, $extendedState->getUserId());
+    }
+
+    /**
+     * Tests the storage setters of ExtendedState
+     */
+    public function testStorageSetters()
+    {
+        $prophet = new Prophet();
+        $mockStorageService = $prophet->prophesize(StateStorage::class)->reveal();
+        $mockStorage = $prophet->prophesize(StateStorage::class)->reveal();
+
+        $extendedState = new ExtendedState();
+        $extendedState->setServiceLocator($this->getServiceManagerProphecy([
+            StorageManager::SERVICE_ID => $mockStorageService
+        ]));
+
+        $this->assertInstanceOf(StateStorage::class, $extendedState->getStorage());
+        $this->assertEquals($mockStorageService, $extendedState->getStorage());
+
+        $extendedState->setStorage($mockStorage);
+
+        $this->assertEquals($mockStorage, $extendedState->getStorage());
+    }
+
+    /**
+     * Tests the storage key builder from ExtendedState
+     */
+    public function testStorageKey()
+    {
+        $testSessionId = 'http://tao.ce/foo#12345';
+        $extendedState = new ExtendedState($testSessionId);
+        $this->assertEquals(ExtendedState::STORAGE_PREFIX . $testSessionId, $extendedState->getStorageKey());
+    }
+
+    /**
+     * Tests the item flags setters from ExtendedState
+     */
+    public function testItemFlag()
+    {
+        $extendedState = new ExtendedState();
+
+        $itemRef = 'http://tao.ce/foo#12345';
+        $this->assertEquals(false, $extendedState->getItemFlag($itemRef));
+        $this->assertEquals($extendedState, $extendedState->setItemFlag($itemRef, true));
+        $this->assertEquals(true, $extendedState->getItemFlag($itemRef));
+        $this->assertEquals($extendedState, $extendedState->setItemFlag($itemRef, false));
+        $this->assertEquals(false, $extendedState->getItemFlag($itemRef));
+    }
+
+    /**
+     * Tests the store id setters from ExtendedState
+     */
+    public function testStoreId()
+    {
+        $extendedState = new ExtendedState();
+
+        $storeId = 'fooBar';
+        $this->assertEquals(false, $extendedState->getStoreId());
+        $this->assertEquals($extendedState, $extendedState->setStoreId($storeId));
+        $this->assertEquals($storeId, $extendedState->getStoreId());
+    }
+
+    /**
+     * Tests the items table setters from ExtendedState
+     */
+    public function testItemHrefIndex()
+    {
+        $extendedState = new ExtendedState();
+
+        $index = [
+            'foo' => 'bar'
+        ];
+        $this->assertEquals([], $extendedState->getItemHrefIndex());
+        $this->assertEquals($extendedState, $extendedState->setItemHrefIndex($index));
+        $this->assertEquals($index, $extendedState->getItemHrefIndex());
+    }
+
+    /**
+     * Tests the events setters from ExtendedState
+     */
+    public function testEvents()
+    {
+        $extendedState = new ExtendedState();
+
+        $this->assertEquals([], $extendedState->getEvents());
+
+        $eventName = 'foo';
+        $eventData = ['foo' => 'bar'];
+        $eventId = $extendedState->addEvent($eventName, $eventData);
+
+        $this->assertInternalType('string', $eventId);
+
+        $events = $extendedState->getEvents();
+        $this->assertEquals(1, count($events));
+        $this->assertTrue(isset($events[$eventId]));
+
+        $this->assertFalse($extendedState->removeEvents(['bar']));
+        $this->assertEquals($events, $extendedState->getEvents());
+
+        $this->assertTrue($extendedState->removeEvents([$eventId]));
+        $this->assertEquals([], $extendedState->getEvents());
+
+        $eventId = $extendedState->addEvent($eventName, $eventData);
+        $events = $extendedState->getEvents();
+        $this->assertEquals(1, count($events));
+        $this->assertTrue(isset($events[$eventId]));
+
+        $this->assertEquals($extendedState, $extendedState->clearEvents());
+        $this->assertEquals([], $extendedState->getEvents());
+    }
+
+    /**
+     * Tests the CAT setters from ExtendedState
+     */
+    public function testCat()
+    {
+        $extendedState = new ExtendedState();
+
+        $assessmentSectionId = 'sectionFoo';
+        $key = 'foo';
+        $value = 'bar';
+
+        $this->assertEquals(null, $extendedState->getCatValue($assessmentSectionId, $key));
+        $this->assertEquals($extendedState, $extendedState->setCatValue($assessmentSectionId, $key, $value));
+        $this->assertEquals($value, $extendedState->getCatValue($assessmentSectionId, $key));
+        $this->assertEquals($extendedState, $extendedState->removeCatValue($assessmentSectionId, $key));
+        $this->assertEquals(null, $extendedState->getCatValue($assessmentSectionId, $key));
+    }
+
+    /**
+     * Tests the storage of ExtendedState
+     */
+    public function testStorage()
+    {
+        $assessmentSectionId = 'sectionFoo';
+        $key = 'foo';
+        $value = 'bar';
+        $itemId = 'foo';
+        $itemHref = 'http://tao.ce/fooItem#12345';
+        $testSessionId = 'http://tao.ce/foo#12345';
+        $userId = 'http://tao.ce/bar#4567';
+        $storeId = 'fooBar';
+        $JSON = [
+            ExtendedState::VAR_REVIEW => [
+                $itemId => true
+            ],
+            ExtendedState::VAR_HREF_INDEX => [
+                $itemId => $itemHref
+            ]
+        ];
+        $JSON2 = [
+            ExtendedState::VAR_REVIEW => [
+                $itemId => false
+            ],
+            ExtendedState::VAR_HREF_INDEX => [
+                $itemId => $itemHref
+            ],
+            ExtendedState::VAR_CAT => [
+                $assessmentSectionId => [
+                    $key => $value
+                ]
+            ],
+            ExtendedState::VAR_STORE_ID => $storeId
+        ];        
+        $storedJSON = json_encode($JSON);
+        $storedJSON2 = json_encode($JSON2);
+        $storageKey = ExtendedState::getStorageKeyFromTestSessionId($testSessionId);
+        $buffer = [
+            $userId => [
+                $storageKey => $storedJSON
+            ]
+        ];
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize(StateStorage::class);
+        $prophecy->get(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            if (isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]])) {
+                return $buffer[$args[0]][$args[1]];
+            }
+            return null;
+        });
+        $prophecy->set(Argument::type('string'), Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            $buffer[$args[0]][$args[1]] = $args[2];
+            return true;
+        });
+        $prophecy->has(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            return isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]]);
+        });
+        $prophecy->del(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            if (isset($buffer[$args[0]])) {
+                if (isset($buffer[$args[0]][$args[1]])) {
+                    unset($buffer[$args[0]][$args[1]]);
+                }
+                if (empty($buffer[$args[0]])) {
+                    unset($buffer[$args[0]]);
+                }
+            }
+            return true;
+        });
+
+        $mockStorage = $prophecy->reveal();
+
+        $storageManager = new StorageManager([]);
+        $storageManager->setServiceLocator($this->getServiceManagerProphecy([
+            StateStorage::SERVICE_ID => $mockStorage
+        ]));
+
+        
+        $extendedState = new ExtendedState($testSessionId, $userId);
+        $extendedState->setServiceLocator($this->getServiceManagerProphecy([
+            StorageManager::SERVICE_ID => $storageManager
+        ]));
+
+        $this->assertTrue($extendedState->load());
+        
+        $this->assertTrue($extendedState->getItemFlag($itemId));
+        $this->assertFalse($extendedState->getItemFlag('bar'));
+        $this->assertFalse($extendedState->getStoreId());
+        $this->assertEquals(null, $extendedState->getCatValue($assessmentSectionId, $key));
+        $this->assertEquals($JSON[ExtendedState::VAR_HREF_INDEX], $extendedState->getItemHrefIndex());
+
+        $extendedState->setCatValue($assessmentSectionId, $key, $value);
+        $extendedState->setItemFlag($itemId, false);
+        $extendedState->setStoreId($storeId);
+
+        $this->assertTrue($extendedState->save());
+        $this->assertEquals($buffer[$userId][$storageKey], $storedJSON);
+        $storageManager->persist();
+        $this->assertEquals($buffer[$userId][$storageKey], $storedJSON2);
+    }
+}

--- a/test/runner/StorageManagerTest.php
+++ b/test/runner/StorageManagerTest.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+namespace oat\taoQtiTest\test\runner;
+
+use oat\tao\model\state\StateStorage;
+use oat\tao\test\TaoPhpUnitTestRunner;
+use oat\taoQtiTest\models\runner\StorageManager;
+use Prophecy\Argument;
+use Prophecy\Prophet;
+
+/**
+ * Class StorageManagerTest
+ * @package oat\taoQtiTest\test\runner
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class StorageManagerTest extends TaoPhpUnitTestRunner
+{
+    /**
+     * @throws \common_ext_ExtensionException
+     */
+    public function setUp()
+    {
+        \common_ext_ExtensionsManager::singleton()->getExtensionById('taoQtiTest');
+    }
+
+    /**
+     * Tests the storage component of StorageManager
+     */
+    public function testStorage()
+    {
+        $prophet = new Prophet();
+        $mockStorageService = $prophet->prophesize(StateStorage::class)->reveal();
+        $mockStorage = $prophet->prophesize(StateStorage::class)->reveal();
+
+        $storageManager = new StorageManager([]);
+        $storageManager->setServiceLocator($this->getServiceManagerProphecy([
+            StateStorage::SERVICE_ID => $mockStorageService
+        ]));
+
+        $this->assertInstanceOf(StateStorage::class, $storageManager->getStorage());
+        $this->assertEquals($mockStorageService, $storageManager->getStorage());
+
+        $storageManager->setStorage($mockStorage);
+
+        $this->assertEquals($mockStorage, $storageManager->getStorage());
+    }
+
+    /**
+     * Test the StorageManager::get() method
+     */
+    public function testGet()
+    {
+        $cachedData = 'this is a test';
+        $userId = 'user123';
+        $callId = '456';
+        $buffer = [
+            $userId => [
+                $callId => $cachedData
+            ]
+        ];
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize(StateStorage::class);
+        $prophecy->get(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            if (isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]])) {
+                return $buffer[$args[0]][$args[1]];
+            }
+            return null;
+        });
+        $mockStorage = $prophecy->reveal();
+
+        $storageManager = new StorageManager([]);
+        $storageManager->setServiceLocator($this->getServiceManagerProphecy([
+            StateStorage::SERVICE_ID => $mockStorage
+        ]));
+
+        $this->assertEquals($cachedData, $storageManager->get($userId, $callId));
+        $this->assertEquals(null, $storageManager->get('foo', $callId));
+        $this->assertEquals(null, $storageManager->get($userId, 'foo'));
+        $this->assertEquals(null, $storageManager->get('foo', 'foo'));
+    }
+
+    /**
+     * Test the StorageManager::set() method
+     */
+    public function testSet()
+    {
+        $data1 = 'this is a test';
+        $data2 = 'this is another test';
+        $userId = 'user123';
+        $callId = '456';
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize(StateStorage::class);
+        $prophecy->get(Argument::type('string'), Argument::type('string'))->willReturn(null);
+        $prophecy->set(Argument::type('string'), Argument::type('string'), Argument::type('string'))->willThrow(new \Exception('Set() should not be called!'));
+        $mockStorage = $prophecy->reveal();
+
+        $storageManager = new StorageManager([]);
+        $storageManager->setServiceLocator($this->getServiceManagerProphecy([
+            StateStorage::SERVICE_ID => $mockStorage
+        ]));
+
+        $this->assertEquals(null, $storageManager->get($userId, $callId));
+
+        $this->assertEquals(true, $storageManager->set($userId, $callId, $data1));
+        $this->assertEquals($data1, $storageManager->get($userId, $callId));
+
+        $this->assertEquals(true, $storageManager->set($userId, $callId, $data2));
+        $this->assertEquals($data2, $storageManager->get($userId, $callId));
+    }
+
+    /**
+     * Test the StorageManager::has() method
+     */
+    public function testHas()
+    {
+        $data1 = 'this is a test';
+        $data2 = 'this is another test';
+        $userId = 'user123';
+        $callId = '456';
+        $buffer = [
+            $userId => [
+                $callId => $data1
+            ]
+        ];
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize(StateStorage::class);
+        $prophecy->get(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            if (isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]])) {
+                return $buffer[$args[0]][$args[1]];
+            }
+            return null;
+        });
+        $prophecy->has(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            return isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]]);
+        });
+        $prophecy->set(Argument::type('string'), Argument::type('string'), Argument::type('string'))->willThrow(new \Exception('Set() should not be called!'));
+        $mockStorage = $prophecy->reveal();
+
+        $storageManager = new StorageManager([]);
+        $storageManager->setServiceLocator($this->getServiceManagerProphecy([
+            StateStorage::SERVICE_ID => $mockStorage
+        ]));
+
+        $this->assertEquals(true, $storageManager->has($userId, $callId));
+        $this->assertEquals($data1, $storageManager->get($userId, $callId));
+
+        $this->assertEquals(false, $storageManager->has('foo', 'bar'));
+        $this->assertEquals(null, $storageManager->get('foo', 'bar'));
+
+        $this->assertEquals(true, $storageManager->set('foo', 'bar', $data2));
+        $this->assertEquals(true, $storageManager->has('foo', 'bar'));
+        $this->assertEquals($data2, $storageManager->get('foo', 'bar'));
+    }
+
+    /**
+     * Test the StorageManager::del() method
+     */
+    public function testDel()
+    {
+        $data1 = 'this is a test';
+        $data2 = 'this is another test';
+        $userId = 'user123';
+        $callId = '456';
+        $buffer = [
+            $userId => [
+                $callId => $data1
+            ]
+        ];
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize(StateStorage::class);
+        $prophecy->get(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            if (isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]])) {
+                return $buffer[$args[0]][$args[1]];
+            }
+            return null;
+        });
+        $prophecy->has(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            return isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]]);
+        });
+        $prophecy->set(Argument::type('string'), Argument::type('string'), Argument::type('string'))->willThrow(new \Exception('Set() should not be called!'));
+        $prophecy->del(Argument::type('string'), Argument::type('string'))->willThrow(new \Exception('Del() should not be called!'));
+
+        $mockStorage = $prophecy->reveal();
+
+        $storageManager = new StorageManager([]);
+        $storageManager->setServiceLocator($this->getServiceManagerProphecy([
+            StateStorage::SERVICE_ID => $mockStorage
+        ]));
+
+        $this->assertEquals(true, $storageManager->has($userId, $callId));
+        $this->assertEquals($data1, $storageManager->get($userId, $callId));
+
+        $this->assertEquals(true, $storageManager->del($userId, $callId));
+        $this->assertEquals(false, $storageManager->has($userId, $callId));
+        $this->assertEquals(null, $storageManager->get($userId, $callId));
+
+        $this->assertEquals(null, $storageManager->get('foo', 'bar'));
+        $this->assertEquals(true, $storageManager->set('foo', 'bar', $data2));
+        $this->assertEquals(true, $storageManager->has('foo', 'bar'));
+        $this->assertEquals($data2, $storageManager->get('foo', 'bar'));
+
+        $this->assertEquals(true, $storageManager->del('foo', 'bar'));
+        $this->assertEquals(false, $storageManager->has('foo', 'bar'));
+        $this->assertEquals(null, $storageManager->get('foo', 'bar'));
+    }
+
+    /**
+     * Test the StorageManager::persist() method
+     */
+    public function testPersist()
+    {
+        $data1 = 'this is a test';
+        $data2 = 'this is another test';
+        $userId = 'user123';
+        $callId = '456';
+        $buffer = [
+            $userId => [
+                $callId => $data1
+            ]
+        ];
+
+        $expectedBuffer0 = $buffer;
+
+        $expectedBuffer1 = [
+            $userId => [
+                $callId => $data2
+            ],
+            'foo' => [
+                'bar' => 'foo bar'
+            ]
+        ];
+
+        $expectedBuffer2 = [
+            $userId => [
+                $callId => $data2
+            ]
+        ];
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize(StateStorage::class);
+        $prophecy->get(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            if (isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]])) {
+                return $buffer[$args[0]][$args[1]];
+            }
+            return null;
+        });
+        $prophecy->set(Argument::type('string'), Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            $buffer[$args[0]][$args[1]] = $args[2];
+            return true;
+        });
+        $prophecy->has(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            return isset($buffer[$args[0]]) && isset($buffer[$args[0]][$args[1]]);
+        });
+        $prophecy->del(Argument::type('string'), Argument::type('string'))->will(function ($args) use (&$buffer) {
+            if (isset($buffer[$args[0]])) {
+                if (isset($buffer[$args[0]][$args[1]])) {
+                    unset($buffer[$args[0]][$args[1]]);
+                }
+                if (empty($buffer[$args[0]])) {
+                    unset($buffer[$args[0]]);
+                }
+            }
+            return true;
+        });
+
+        $mockStorage = $prophecy->reveal();
+
+        $storageManager = new StorageManager([]);
+        $storageManager->setServiceLocator($this->getServiceManagerProphecy([
+            StateStorage::SERVICE_ID => $mockStorage
+        ]));
+
+
+        $this->assertEquals(true, $storageManager->has($userId, $callId));
+        $this->assertEquals($data1, $storageManager->get($userId, $callId));
+
+        $this->assertEquals(true, $storageManager->set($userId, $callId, $data2));
+        $this->assertEquals($data2, $storageManager->get($userId, $callId));
+
+        $this->assertEquals(false, $storageManager->has('foo', 'bar'));
+        $this->assertEquals(null, $storageManager->get('foo', 'bar'));
+        $this->assertEquals(true, $storageManager->set('foo', 'bar', 'foo bar'));
+        $this->assertEquals(true, $storageManager->has('foo', 'bar'));
+        $this->assertEquals('foo bar', $storageManager->get('foo', 'bar'));
+
+        $this->assertEquals($expectedBuffer0, $buffer);
+
+        $this->assertEquals(true, $storageManager->persist());
+
+        $this->assertEquals($expectedBuffer1, $buffer);
+
+        $this->assertEquals(true, $storageManager->del('foo', 'bar'));
+        $this->assertEquals(false, $storageManager->has('foo', 'bar'));
+        $this->assertEquals(null, $storageManager->get('foo', 'bar'));
+
+        $this->assertEquals($expectedBuffer1, $buffer);
+
+        $this->assertEquals(true, $storageManager->persist());
+
+        $this->assertEquals($expectedBuffer2, $buffer);
+    }
+}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5361

Introduces a `StorageManager` to manage the access to the state storage.
This manager puts in memory cache the read data. When a change is made, the memory cache is updated, instead of directly write into the actual storage, and a flag is set to add that data into the write queue. The `persist()` method must be called in order to flush the data to write into the state storage.

The parts that were previously accessing the state storage (`ExtendedStateService` and `QtiTimeStorage`) have been updated to use the `StorageManager`.