### PR TITLE
Feature/tao 5559 offline pause and section pause

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '17.15.4',
+    'version'     => '17.16.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.7.0',

--- a/models/classes/SectionPauseService.php
+++ b/models/classes/SectionPauseService.php
@@ -30,6 +30,17 @@ class SectionPauseService extends ConfigurableService
     const SERVICE_ID = 'taoQtiTest/SectionPauseService';
 
     /**
+     * Checked the given session could be paused at some point
+     * (in other words : is section pause enabled)
+     * @param $session
+     * @return bool
+     */
+    public function couldBePaused(TestSession $session = null)
+    {
+        return false;
+    }
+
+    /**
      * Checked that section can be paused
      * @param $session
      * @return bool

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -39,7 +39,6 @@ use oat\taoQtiTest\models\runner\map\QtiRunnerMap;
 use oat\taoQtiTest\models\runner\navigation\QtiRunnerNavigation;
 use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
 use oat\taoQtiTest\models\runner\session\TestSession;
-use oat\taoQtiTest\models\SectionPauseService;
 use oat\taoQtiTest\models\TestSessionService;
 use oat\taoTests\models\runner\time\TimePoint;
 use qtism\common\datatypes\QtiString as QtismString;
@@ -431,7 +430,6 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
                 // Current Section title.
                 $response['sectionId'] = $currentSection->getIdentifier();
                 $response['sectionTitle'] = $currentSection->getTitle();
-                $response['sectionPause'] = $this->getServiceManager()->get(SectionPauseService::SERVICE_ID)->isPausable($session);
 
                 // Number of items composing the test session.
                 $response['numberItems'] = $route->count();

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -23,6 +23,7 @@
 namespace oat\taoQtiTest\models\runner\config;
 
 use oat\oatbox\service\ConfigurableService;
+use oat\taoQtiTest\models\SectionPauseService;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 
 /**
@@ -156,6 +157,7 @@ class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
             'exitButton'        => \taoQtiTest_helpers_TestRunnerUtils::doesAllowExit($session, $context),
             'logoutButton'      => \taoQtiTest_helpers_TestRunnerUtils::doesAllowLogout($session),
             'validateResponses' => \taoQtiTest_helpers_TestRunnerUtils::doesValidateResponses($session),
+            'sectionPause'      => $this->getServiceManager()->get(SectionPauseService::SERVICE_ID)->couldBePaused($session)
         ];
 
         // get the options from the categories owned by the current item

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -241,6 +241,7 @@ class QtiRunnerMap extends ConfigurableService implements RunnerMap
                         'answered' => ($itemSession) ? TestRunnerUtils::isItemCompleted($routeItem, $itemSession) : in_array($itemId, $previouslySeenItems),
                         'flagged' => $extendedStorage->getItemFlag($session->getSessionId(), $itemId),
                         'viewed' => ($itemSession) ? $itemSession->isPresented() : in_array($itemId, $previouslySeenItems),
+                        'categories' => $itemRef->getCategories()->getArrayCopy()
                     ];
 
                     if ($checkInformational) {

--- a/models/classes/runner/synchronisation/action/Pause.php
+++ b/models/classes/runner/synchronisation/action/Pause.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoQtiTest\models\runner\synchronisation\action;
+
+use oat\taoQtiTest\models\runner\synchronisation\TestRunnerAction;
+
+/**
+ * Class Pause
+ *
+ * Pause the test
+ *
+ * @package oat\taoQtiTest\models\runner\synchronisation\action
+ */
+class Pause extends TestRunnerAction
+{
+    /**
+     * Process the pause action.
+     *
+     * @return array
+     */
+    public function process()
+    {
+        $this->validate();
+
+        try {
+            $serviceContext = $this->getServiceContext();
+
+            if ($this->getRequestParameter('offline') === true) {
+                $this->setOffline();
+            }
+
+            $result = $this->getRunnerService()->pause($serviceContext);
+
+            $response = [
+                'success' => $result
+            ];
+
+
+        } catch (\Exception $e) {
+            $response = $this->getErrorResponse($e);
+        }
+
+        return $response;
+    }
+}

--- a/scripts/install/SetSynchronisationService.php
+++ b/scripts/install/SetSynchronisationService.php
@@ -22,6 +22,7 @@ namespace oat\taoQtiTest\scripts\install;
 use oat\oatbox\extension\InstallAction;
 use oat\taoQtiTest\models\runner\synchronisation\action\ExitTest;
 use oat\taoQtiTest\models\runner\synchronisation\action\Move;
+use oat\taoQtiTest\models\runner\synchronisation\action\Pause;
 use oat\taoQtiTest\models\runner\synchronisation\action\Skip;
 use oat\taoQtiTest\models\runner\synchronisation\action\StoreTraceData;
 use oat\taoQtiTest\models\runner\synchronisation\action\Timeout;
@@ -57,11 +58,12 @@ class SetSynchronisationService extends InstallAction
         }
 
         $newActions = [
-            'exitTest' => ExitTest::class,
-            'move' => Move::class,
-            'skip' => Skip::class,
-            'storeTraceData' => StoreTraceData::class,
-            'timeout' => Timeout::class,
+            'exitTest'        => ExitTest::class,
+            'move'            => Move::class,
+            'pause'           => Pause::class,
+            'skip'            => Skip::class,
+            'storeTraceData'  => StoreTraceData::class,
+            'timeout'         => Timeout::class,
             'getNextItemData' => NextItemData::class
         ];
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -30,6 +30,7 @@ use oat\taoQtiTest\models\runner\map\QtiRunnerMap;
 use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
 use oat\taoQtiTest\models\runner\StorageManager;
 use oat\taoQtiTest\models\runner\synchronisation\action\Move;
+use oat\taoQtiTest\models\runner\synchronisation\action\Pause;
 use oat\taoQtiTest\models\runner\synchronisation\action\Skip;
 use oat\taoQtiTest\models\runner\synchronisation\action\StoreTraceData;
 use oat\taoQtiTest\models\runner\synchronisation\action\Timeout;
@@ -1691,5 +1692,16 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('17.10.0', '17.15.4');
+
+        if ($this->isVersion('17.15.4')) {
+
+            $synchronisationService = $this->getServiceManager()->get(SynchronisationService::SERVICE_ID);
+            $actions = $synchronisationService->getAvailableActions();
+            $actions['pause'] = Pause::class;
+            $synchronisationService->setAvailableActions($actions);
+            $this->getServiceManager()->register(SynchronisationService::SERVICE_ID, $synchronisationService);
+
+            $this->setVersion('17.16.0');
+        }
     }
 }

--- a/views/js/runner/plugins/controls/connectivity/connectivity.js
+++ b/views/js/runner/plugins/controls/connectivity/connectivity.js
@@ -21,12 +21,21 @@
  */
 define([
     'jquery',
+    'lodash',
     'i18n',
+    'core/promise',
+    'core/polling',
     'ui/waitingDialog/waitingDialog',
     'taoTests/runner/plugin',
     'tpl!taoQtiTest/runner/plugins/controls/connectivity/connectivity'
-], function ($, __, waitingDialog, pluginFactory, connectivityTpl) {
+], function ($, _, __, Promise, pollingFactory, waitingDialog, pluginFactory, connectivityTpl) {
     'use strict';
+
+    /**
+     * Connectivity check interval, in ms
+     * @type {Number}
+     */
+    var checkInterval = 30 * 1000;
 
     /**
      * Creates the connectivity plugin.
@@ -54,63 +63,35 @@ define([
             var testRunner = this.getTestRunner();
             var proxy      = testRunner.getProxy();
 
-            //create the indicator
-            this.$element = $(connectivityTpl({
-                state: proxy.isOnline() ? 'connected' : 'disconnected'
-            }));
+            /**
+             * Display the waiting dialog, while waiting the connection to be back
+             * @param {String} [messsage] - additional message for the dialog
+             * @returns {Promise} resolves once the wait is over and the user click on 'proceed'
+             */
+            var displayWaitingDialog = function displayWaitingDialog(message){
 
-            //the Proxy is the only one to know something about connectivity
-            proxy.on('disconnect', function disconnect(source) {
-                if (!testRunner.getState('disconnected')) {
-                    testRunner.setState('disconnected', true);
-                    testRunner.trigger('disconnect', source);
-                    self.$element.removeClass('connected').addClass('disconnected');
-                }
-            })
-            .on('reconnect', function reconnect() {
-                if (testRunner.getState('disconnected')) {
-                    testRunner.setState('disconnected', false);
-                    testRunner.trigger('reconnect');
-                    self.$element.removeClass('disconnected').addClass('connected');
-                }
-            });
-
-
-            testRunner.before('error', function(e, err) {
                 var dialog;
-
-                // detect and prevent connectivity errors
-                if (proxy.isConnectivityError(err)){
-                    return false;
-                }
-
-                //offline navigation error
-                if (proxy.isOffline()) {
+                return new Promise(function(resolve) {
                     if(!waiting){
                         waiting = true;
 
-                        //is a pause event occurs offline, we wait the connection to be back
+                        //if a pause event occurs while waiting,
+                        //we also wait the connection to be back
                         testRunner.before('pause.waiting', function(){
-                            return new Promise(function(resolve){
+                            return new Promise(function(pauseResolve){
                                 proxy.off('reconnect.pausing')
-                                    .after('reconnect.pausing', resolve);
+                                    .after('reconnect.pausing', pauseResolve);
                             });
                         });
 
                         //creates the waiting modal dialog
                         dialog = waitingDialog({
-                            message : __('You are encountering a prolonged connectivity loss. ') + err.message,
+                            message : __('You are encountering a prolonged connectivity loss. ') + message,
                             waitContent : __('Please wait while we try to restore the connection.'),
                             proceedContent : __('The connection seems to be back, please proceed')
                         })
                         .on('proceed', function(){
-                            var testContext = testRunner.getTestContext();
-                            if(err.type === 'nav'){
-                                testRunner.loadItem(testContext.itemIdentifier);
-                            }
-                            if(err.type === 'finish'){
-                                testRunner.finish();
-                            }
+                            resolve();
                         })
                         .on('render', function(){
                             proxy
@@ -122,7 +103,89 @@ define([
                                 });
                         });
                     }
+                });
+            };
 
+            //Last chance to check the connection,
+            //by regular polling on the "up" signal
+            this.polling = pollingFactory({
+                action: function action () {
+                    testRunner.getProxy()
+                        .telemetry(testRunner.getTestContext().itemIdentifier, 'up')
+                        .catch(_.noop);
+                },
+                interval: checkInterval,
+                autoStart: false
+            });
+
+            //create the indicator
+            this.$element = $(connectivityTpl({
+                state: proxy.isOnline() ? 'connected' : 'disconnected'
+            }));
+
+            //the Proxy is the only one to know something about connectivity
+            proxy.on('disconnect', function disconnect(source) {
+                if (!testRunner.getState('disconnected')) {
+                    testRunner.setState('disconnected', true);
+                    testRunner.trigger('disconnect', source);
+                    self.$element.removeClass('connected').addClass('disconnected');
+                    self.polling.start();
+                }
+            })
+            .on('reconnect', function reconnect() {
+                if (testRunner.getState('disconnected')) {
+                    testRunner.setState('disconnected', false);
+                    testRunner.trigger('reconnect');
+                    self.$element.removeClass('disconnected').addClass('connected');
+                    self.polling.stop();
+                }
+            });
+
+            //intercept tries to leave while offline
+            //this could be caused by pauses for example.
+            //If caused by an action like exitTest it will be handled
+            //by navigation errors (see below)
+            testRunner.before('leave', function(e, data){
+                if (proxy.isOffline()) {
+                    displayWaitingDialog(data.message)
+                        .then(function(){
+                            testRunner.trigger('leave', data);
+                        })
+                        .catch(function(generalErr){
+                            testRunner.trigger('error', generalErr);
+                        });
+
+                    return false;
+                }
+            });
+
+            //intercept offline navigation errors
+            testRunner.before('error', function(e, err) {
+
+                // detect and prevent connectivity errors
+                if (proxy.isConnectivityError(err)){
+                    return false;
+                }
+
+                if (proxy.isOffline()) {
+                    displayWaitingDialog(err.message)
+                        .then(function(){
+                            if(err.type === 'nav'){
+                                testRunner.loadItem(testRunner.getTestContext().itemIdentifier);
+                            }
+                            if(err.type === 'finish'){
+                                testRunner.finish();
+                            }
+                            if(err.type === 'pause'){
+                                testRunner.trigger('pause', {
+                                    reasons: err.data && err.data.reasons,
+                                    message : err.data && err.data.comment
+                                });
+                            }
+                        })
+                        .catch(function(generalErr){
+                            testRunner.trigger('error', generalErr);
+                        });
                     return false;
                 }
             });

--- a/views/js/runner/plugins/controls/testState/testState.js
+++ b/views/js/runner/plugins/controls/testState/testState.js
@@ -44,7 +44,8 @@ define([
                     var data = res && res.data;
 
                     // test has been closed/suspended => redirect to the index page after message acknowledge
-                    if (data && data.type && data.type === 'TestState') {
+                    if (data && data.type && data.type === 'TestState' && !testRunner.getState('closedOrSuspended')) {
+
                         // spread the world about the reason of the leave
                         testRunner.setState('closedOrSuspended', true);
 

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -388,32 +388,24 @@ define([
                     );
                 })
                 .on('pause', function(data){
-                    var pause;
 
                     this.setState('closedOrSuspended', true);
 
-                    if (!this.getState('disconnected')) {
-                        // will notify the server that the test was auto paused
-                        pause = self.getProxy().callTestAction('pause', {
-                            reason: {
-                                reasons: data && data.reasons,
-                                comment : data && data.message
-                            }
+                    this.getProxy().callTestAction('pause', {
+                        reason: {
+                            reasons: data && data.reasons,
+                            comment : data && data.message
+                        }
+                    })
+                    .then(function() {
+                        self.trigger('leave', {
+                            code: self.getTestData().states.suspended,
+                            message: data && data.message
                         });
-                    } else {
-                        pause = Promise.resolve();
-                    }
-
-                    pause
-                        .then(function() {
-                            self.trigger('leave', {
-                                code: self.getTestData().states.suspended,
-                                message: data && data.message
-                            });
-                        })
-                        .catch(function(err){
-                            self.trigger('error', err);
-                        });
+                    })
+                    .catch(function(err){
+                        self.trigger('error', err);
+                    });
                 })
                 .on('loaditem', function(){
                     var context = this.getTestContext();

--- a/views/js/runner/proxy/cache/proxy.js
+++ b/views/js/runner/proxy/cache/proxy.js
@@ -81,6 +81,22 @@ define([
     );
 
     /**
+     * When we are unable to navigate offline
+     * @type {Error}
+     */
+    var offlinePauseError = _.assign(
+        new Error(__('The test has been paused, we are unable to connect to the server.')),
+        {
+            success : false,
+            source: 'navigator',
+            purpose: 'proxy',
+            type: 'pause',
+            code : 404
+        }
+    );
+
+
+    /**
      * Overrides the qtiServiceProxy with the precaching behavior
      * @extends taoQtiTest/runner/proxy/qtiServiceProxy
      */
@@ -188,10 +204,17 @@ define([
                 var testContext = this.getDataHolder().get('testContext');
                 var testMap     = this.getDataHolder().get('testMap');
 
+
+                if( action === 'pause' ) {
+                    if(actionParams.reason){
+                        offlinePauseError.data = actionParams.reason;
+                    }
+                    throw offlinePauseError;
+                }
+
                 //we just block those actions and the end of the test
                 if( _.contains(blockingActions, action) ||
                     ( actionParams.direction === 'next' && navigationHelper.isLast(testMap, testContext.itemIdentifier)) ){
-
                     throw offlineExitError;
                 }
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-5559

The fix goes over the initial bug, but makes the overall feature to works better with offline and online use cases.

1. The section pause is checked now client side.
 - the test map contains now the categories for each items**<sup>(1)</sup>**
 - the context doesn't contains the `sectionPause` flag anymore, a global option `sectionPause` is set instead
 - the plugin checks itself if the item has the request category to pause the test

2. Make the pause to work with sync and offline
 - added the `Pause`action in the sync service
 - display the _waitingDialog_ if a pause occurs

3. It's not really related but if you don't have an heartbeat and your browser doesn't detect `online` events you can be stuck on the waiting dialog. So I've added a small polling that send the telemetry every 30s while offline. Easy and fair.

**<sup>(1)</sup>** ; If you're wondering about the test map size you're right. Adding the categories to each item in the map increases significantly the payload size (I've observed a growth between 0 and 60% for large tests, in the response size). However, since most of the categories are mostly identical, they're very well handled by DEFALTE or GZIP modules, reducing the  difference to  ~6% in the transfered size which is more an acceptable value. 