### PR TITLE
Fix/tao 5031 duration lifecycle

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '17.17.0',
+    'version'     => '17.17.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1703,5 +1703,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('17.17.0');
         }
+
+        $this->skip('17.17.0', '17.17.1');
     }
 }


### PR DESCRIPTION
When switching to offline an `error` event is triggered but caught, it's the reason why using `.before` is not suitable anymore to disable the the duration recording. 