### PR TITLE
Tao 5356 store cat session after last item

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '17.19.1',
+    'version'     => '17.19.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.7.0',

--- a/models/classes/cat/CatService.php
+++ b/models/classes/cat/CatService.php
@@ -487,7 +487,7 @@ class CatService extends ConfigurableService
             $result = !$items ? [] : json_decode($items);
         }
 
-        return $result;
+        return is_array($result) ? $result : [];
     }
 
     /**

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -590,11 +590,11 @@ class QtiRunnerServiceContext extends RunnerServiceContext
             $event = new SelectAdaptiveNextItemEvent($this->getTestSession(), $lastItemId, $preSelection, $selection, $isShadowItem);
             $this->getServiceManager()->get(EventManager::SERVICE_ID)->trigger($event);
 
-            if (is_array($selection) && count($selection) == 0) {
+            $this->persistCatSession($catSession);
+            if ((is_array($selection) && count($selection) == 0) || $selection === null) {
                 \common_Logger::d('No new CAT item selection.');
                 return null;
             } else {
-                $this->persistCatSession($catSession);
                 \common_Logger::d("New CAT item selection is '" . implode(', ', $selection) . "'.");
                 return $selection[0];
             }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1683,7 +1683,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('17.8.0');
         }
 
-        $this->skip('17.8.0', '17.9.0');
+        $this->skip('17.8.0', '17.9.1');
 
         if ($this->isVersion('17.9.0')) {
             $storageManager = new StorageManager();


### PR DESCRIPTION
In case if test taker on the last item presses `previous` button or jumps to any previous item the last item will be submitted and cat session should be stored. Otherwise shadow cat will always contain the last item as if it was not submitted.
Depends on https://github.com/oat-sa/lib-test-cat/pull/21