### PR TITLE
Fix/exception context

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -266,6 +266,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
     public function init()
     {
         $code = 200;
+        $response = [];
 
         try {
             $serviceContext = $this->runnerService->initServiceContext($this->getServiceContext());
@@ -289,9 +290,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $result = $this->runnerService->init($serviceContext);
             $this->runnerService->persist($serviceContext);
 
-            $response = [
-                'success' => $result,
-            ];
+            $response['success'] = $result;
 
             if ($result) {
                 $response['testData'] = $this->runnerService->getTestData($serviceContext);

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '18.9.2',
+    'version'     => '18.9.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1755,6 +1755,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('18.6.0');
         }
 
-        $this->skip('18.6.0', '18.9.2');
+        $this->skip('18.6.0', '18.9.3');
     }
 }


### PR DESCRIPTION
Fix a misconception in the init action of the test runner: ensure the `$response` variable is set in the entire scope of the exception.