### PR TITLE
Fix/tao 5577/improve tts caching limit speeds specify ids

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '19.0.1',
+    'version'     => '19.0.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoTests'   => '>=6.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1762,6 +1762,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('18.9.5');
         }
 
-        $this->skip('18.9.5', '19.0.1');
+        $this->skip('18.9.5', '19.0.2');
     }
 }

--- a/views/js/runner/plugins/tools/textToSpeech/plugin.js
+++ b/views/js/runner/plugins/tools/textToSpeech/plugin.js
@@ -131,7 +131,7 @@ define([
             })
             .on('disabletools unloaditem', function () {
                 var context = testRunner.getTestContext();
-                if (context.options.textToSpeech && typeof self.tts !== typeof undefined) {
+                if (context.options && context.options.textToSpeech && typeof self.tts !== typeof undefined) {
                     //textHelp requested stopping of running playback on item unload
                     self.tts.stop();
                     self.tts._exec('setCurrentTarget', null);


### PR DESCRIPTION
Fixed a problem when context.options is undefined on item unload;