### PR TITLE
Fix/tao 5949 texthelp buttons state

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '22.0.0',
+    'version'     => '22.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=13.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1777,5 +1777,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('22.0.0');
         }
+
+        $this->skip('22.0.0', '22.0.1');
     }
 }

--- a/views/js/runner/plugins/tools/textToSpeech/textToSpeech.js
+++ b/views/js/runner/plugins/tools/textToSpeech/textToSpeech.js
@@ -65,6 +65,9 @@ define([
                 getSpeed:                '$rw_getSpeed',
                 getVoice:                '$rw_getVoice',
                 hasReachedEnd:           '$rw_hasReachedEnd',
+                speechCompleteCallback:  '$rw_speechCompleteCallback',
+                renderingSpeechCallback: '$rw_renderingSpeechCallback',
+                setSentenceFromSelection:'$rw_setSentenceFromSelection',
                 isPaused:                '$rw_isPaused',
                 isSpeaking:              '$rw_isSpeaking',
                 isTextSelectedForPlay:   '$rw_isTextSelectedForPlay',
@@ -82,6 +85,25 @@ define([
         };
         var speed;
         var volume;
+        var onCompleteDelayer;
+
+        /**
+         * Prevent the delayed action to run
+         */
+        function clearOnCompleteDelayer() {
+            if (onCompleteDelayer) {
+                clearTimeout(onCompleteDelayer);
+                onCompleteDelayer = null;
+            }
+        }
+
+        /**
+         * Register a delayed action
+         */
+        function setOnCompleteDelayer(delayed) {
+            clearOnCompleteDelayer();
+            onCompleteDelayer = setTimeout(delayed, 200);
+        }
 
         _.assign(options || {}, {
             contentArea: $('body'),
@@ -127,6 +149,25 @@ define([
             },
 
             /**
+             * Eventify a texthelp method
+             * @param {String} method
+             * @param {String} [event]
+             */
+            _eventify: function _eventify(method, event) {
+                var prop = texthelpMapping.functions[method] || texthelpMapping.properties[method];
+                var old = prop && window[prop];
+                var self = this;
+                event = event || method;
+                if (_.isFunction(old)) {
+                    return window[prop] = function() {
+                        var params = [event];
+                        self.trigger.apply(self, params.concat(params.slice.call(arguments)));
+                        return old.apply(this, arguments);
+                    };
+                }
+            },
+
+            /**
              * Initialize texthelp
              */
             _init: function _init() {
@@ -146,6 +187,10 @@ define([
                 this._set('pageCompleteCallback', function () {
                     self.trigger('stop');
                 });
+
+                this._eventify('speechCompleteCallback', 'speechComplete');
+                this._eventify('renderingSpeechCallback', 'renderingSpeech');
+                this._eventify('setSentenceFromSelection', 'setSentence');
 
                 return this;
             },
@@ -401,6 +446,20 @@ define([
 
             $el.find('.play').show();
             $el.find('.pause').hide();
+        })
+        .on('setSentence renderingSpeech', function () {
+            clearOnCompleteDelayer();
+            this.trigger('play');
+        })
+        .on('speechComplete', function (source) {
+            var self = this;
+            if (source === "Complete") {
+                // since the speechComplete event may occur each time a sentence is finished to be spoken
+                // we need to apply a delay to differentiate actual end from pause between sentences.
+                setOnCompleteDelayer(function() {
+                    self.trigger('stop');
+                });
+            }
         });
 
         return component;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5949

Ensure the state of the textToSpeech toolbar are aligned with the current play state.

As the `textToSpeech` lib is badly written and does not provide a way to listen to events, I hacked the lifecycle by wrapping some methods in order to trigger events.