### PR TITLE
Fix/tao 5951 texthelp image alternative text

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '22.0.0',
+    'version'     => '22.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=13.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1777,5 +1777,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('22.0.0');
         }
+
+        $this->skip('22.0.0', '22.0.1');
     }
 }

--- a/views/js/runner/plugins/tools/textToSpeech/textToSpeech.js
+++ b/views/js/runner/plugins/tools/textToSpeech/textToSpeech.js
@@ -159,6 +159,15 @@ define([
                 tss.g_strBookId = deliveryId;
                 tss.g_strPageId = itemId;
 
+                // ensure alt attributes are well loaded by TextHelp on each image
+                // (TextHelp does not directly read the alt attribute, but cache it in a data-msg attribute)
+                options.$contentArea.find('img').each(function() {
+                    var msg = this.getAttribute('data-msg');
+                    if (!msg && this.hasAttribute('alt')) {
+                        this.setAttribute('data-msg', this.getAttribute('alt'));
+                    }
+                });
+
                 this._exec('tagSentences', options.$contentArea.selector);
 
                 return this;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5951

Ensure the `alt` attributes are taken into account by TextHelp.

TextHelp does not directly access to the `alt` or `title` attributes when reading the text, but relies instead on a cached content in a `data-msg` attribute.
