### PR TITLE
Remove plugin textToSpeech from the registry

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '23.2.0',
+    'version'     => '23.2.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=13.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1783,8 +1783,8 @@ class Updater extends \common_ext_ExtensionUpdater {
         if ($this->isVersion('23.2.0')) {
 
             $registry = PluginRegistry::getRegistry();
-            if ($registry->isRegistered('taoQtiTest/runner/plugins/tools/textToSpeech/textToSpeech')) {
-                $registry->remove('taoQtiTest/runner/plugins/tools/textToSpeech/textToSpeech');
+            if ($registry->isRegistered('taoQtiTest/runner/plugins/tools/textToSpeech/plugin')) {
+                $registry->remove('taoQtiTest/runner/plugins/tools/textToSpeech/plugin');
             }
 
             $this->setVersion('23.2.1');

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1779,5 +1779,15 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('22.0.0', '23.2.0');
+
+        if ($this->isVersion('23.2.0')) {
+
+            $registry = PluginRegistry::getRegistry();
+            if ($registry->isRegistered('taoQtiTest/runner/plugins/tools/textToSpeech/textToSpeech')) {
+                $registry->remove('taoQtiTest/runner/plugins/tools/textToSpeech/textToSpeech');
+            }
+
+            $this->setVersion('23.2.1');
+        }
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5957

The plugin `textToSpeech` was removed from this extension, but the registry may still contain it in a wrong place. So, this PR removes the plugin from the registry.