### PR TITLE
Fix/tao 6116 trigger checkbox click

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '24.2.3',
+    'version'     => '24.2.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=13.4.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1825,6 +1825,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('24.2.0');
         }
 
-        $this->skip('24.2.0', '24.2.3');
+        $this->skip('24.2.0', '24.2.4');
     }
 }

--- a/views/js/runner/plugins/content/accessibility/keyNavigation.js
+++ b/views/js/runner/plugins/content/accessibility/keyNavigation.js
@@ -277,7 +277,18 @@ define([
             }).on('left up', function(){
                 this.previous();
             }).on('activate', function(cursor){
-                cursor.navigable.getElement().click();
+                var $elt = cursor.navigable.getElement();
+
+                //jQuery <= 1.9.0 the checkbox values are set
+                //after the click event if triggerred with jQuery
+                if($elt.is(':checkbox')){
+                    $elt.each(function(){
+                        this.click();
+                    });
+                } else {
+                    $elt.click();
+                }
+
             }).on('focus', function(cursor){
                 cursor.navigable.getElement().closest('.qti-choice').addClass('key-navigation-highlight');
             }).on('blur', function(cursor){


### PR DESCRIPTION
**How to reproduce**

 - Create an item with a match interaction
 - Select the first choice, and set Allowed number of uses to 1 (= `matchMax="1"`)
 - Add the item to a test, compile delivery, and see the item as a test taker
 - se the following sequence of keys when after opening the item
      - `TAB` (highligh the interaction)
      - `space` (select first association)
      - ` right arrow` (move to second association)
      -  `space` (select second association)