### PR TITLE
Fix/tao 6006 validate authoring identifiers

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '24.4.0',
+    'version'     => '24.4.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=13.4.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1825,6 +1825,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('24.2.0');
         }
 
-        $this->skip('24.2.0', '24.4.0');
+        $this->skip('24.2.0', '24.4.1');
     }
 }

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -174,7 +174,7 @@ define([
                     //register validators
                     validators.register('idFormat', qtiTestHelper.idFormatValidator());
                     validators.register('testIdFormat', qtiTestHelper.testidFormatValidator());
-                    validators.register('testIdAvailable', qtiTestHelper.idAvailableValidator(self.identifiers), true);
+                    validators.register('testIdAvailable', qtiTestHelper.idAvailableValidator(null, modelOverseer), true);
 
                     //once model is loaded, we set up the test view
                     testView(creatorContext);

--- a/views/js/controller/creator/templates/itemref-props.tpl
+++ b/views/js/controller/creator/templates/itemref-props.tpl
@@ -8,7 +8,7 @@
             <label for="itemref-identifier">{{__ 'Identifier'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
         </div>
         <div class="col-6">
-            <input type="text" name="itemref-identifier" data-bind="identifier" data-validate="$notEmpty; $testIdFormat; $testIdAvailable(original={{identifier}});" />
+            <input type="text" name="itemref-identifier" data-bind="identifier" data-validate="$notEmpty; $testIdFormat; $testIdAvailable;" />
         </div>
         <div class="col-1 help">
             <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -7,7 +7,7 @@
             <label for="section-identifier">{{__ 'Identifier'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
         </div>
         <div class="col-6">
-            <input type="text" name="section-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable(original={{identifier}});" />
+            <input type="text" name="section-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable;" />
         </div>
         <div class="col-1 help">
             <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -9,7 +9,7 @@
             <label for="test-identifier">{{__ 'Identifier'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
         </div>
         <div class="col-6">
-            <input type="text" name="test-identifier" data-bind="identifier" data-validate="$notEmpty; $testIdFormat; $testIdAvailable(original={{identifier}});" />
+            <input type="text" name="test-identifier" data-bind="identifier" data-validate="$notEmpty; $testIdFormat; $testIdAvailable;" />
         </div>
         <div class="col-1 help">
             <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -9,7 +9,7 @@
                 <label for="testpart-identifier">{{__ 'Identifier'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
             </div>
             <div class="col-6">
-                <input type="text" name="testpart-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable(original={{identifier}});" />
+                <input type="text" name="testpart-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable;" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/test/creator/helpers/qtiTest/test.html
+++ b/views/js/test/creator/helpers/qtiTest/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Authoring - qtiTest Helper</title>
+    <base href="../../../../../../../tao/views/" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/qtiTest.js"></script>
+
+    <script  type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //load the test
+            require(['taoQtiTest/test/creator/helpers/qtiTest/test'], function(){
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/creator/helpers/qtiTest/test.js
+++ b/views/js/test/creator/helpers/qtiTest/test.js
@@ -1,0 +1,96 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'taoQtiTest/controller/creator/helpers/qtiTest'
+], function (qtiTestHelper) {
+    'use strict';
+
+
+    QUnit.module('API');
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+        assert.equal(typeof qtiTestHelper, 'object', "The module exposes an object");
+    });
+
+    QUnit.cases([{
+        title: 'idAvailableValidator'
+    }]).test('method ', function (data, assert) {
+        QUnit.expect(1);
+        assert.equal(typeof qtiTestHelper[data.title], 'function', 'The helper exposes a "' + data.title + '" method');
+    });
+
+
+    QUnit.module('validators');
+
+    QUnit.test('idAvailableValidator is a validator', function (assert) {
+        var identifierValidator =  qtiTestHelper.idAvailableValidator();
+
+        QUnit.expect(3);
+
+        assert.equal(typeof identifierValidator, 'object', 'The method creates an object');
+        assert.equal(typeof identifierValidator.validate, 'function', 'The generated validator has the validate method');
+        assert.equal(identifierValidator.name, 'testIdAvailable', 'The validator name is correct');
+    });
+
+    QUnit.cases([{
+        ids : ['foo', 'bar'],
+        value: 'noz',
+        result : true
+    }, {
+        ids : ['foo', 'bar', 'foo'],
+        value: 'foo',
+        result : false
+    }]).asyncTest('idAvailableValidator validates by list', function (data, assert) {
+        QUnit.expect(1);
+        qtiTestHelper.idAvailableValidator(data.ids).validate(data.value, function(result){
+            assert.equal(data.result, result);
+            QUnit.start();
+        });
+    });
+
+    QUnit.asyncTest('idAvailableValidator validates by model', function (assert) {
+        var modelOverseerMock = {
+            getModel : function getModel(){
+                return {
+                    identifier : 'foo',
+                    testParts : [{
+                        identfier: 'bar',
+                    }, {
+                        identfier: 'noz',
+                        sections : [{
+                            identfier: 'bee',
+                        }, {
+                            identifier: 'foo'
+                        }]
+                    }]
+                };
+            }
+        };
+
+        QUnit.expect(1);
+
+        qtiTestHelper.idAvailableValidator(null, modelOverseerMock).validate('foo', function(result){
+            assert.ok(!result, 'The validator invalidate the value');
+            QUnit.start();
+        });
+    });
+});


### PR DESCRIPTION
About https://oat-sa.atlassian.net/browse/TAO-6006

Fix and test the unique id validator within the test authoring.

If you create a test with non unique identifiers in develop and try to save it, I've added a warning to let you know an id is not unique (not perfect, but helps in addition to the field validation)