### PR TITLE
Breaking/tao 6163 fix creator identifier management

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '24.8.4',
+    'version'     => '25.0.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=13.7.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1843,6 +1843,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('24.8.0');
         }
 
-        $this->skip('24.8.0', '24.8.4');
+        $this->skip('24.8.0', '25.0.0');
     }
 }

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -71,8 +71,6 @@ define([
 
         routes : {},
 
-        identifiers: [],
-
          /**
           * Start the controller, main entry method.
           * @public
@@ -155,12 +153,9 @@ define([
             binder = DataBindController
                 .takeControl($container, binderOptions)
                 .get(function(model){
-                    //extract ids
-                    self.identifiers = qtiTestHelper.extractIdentifiers(model);
 
                     creatorContext = qtiTestCreatorFactory($container, {
                         uri : options.uri,
-                        identifiers : self.identifiers,
                         labels : options.labels,
                         routes : options.routes,
                         guidedNavigation : options.guidedNavigation
@@ -174,7 +169,7 @@ define([
                     //register validators
                     validators.register('idFormat', qtiTestHelper.idFormatValidator());
                     validators.register('testIdFormat', qtiTestHelper.testidFormatValidator());
-                    validators.register('testIdAvailable', qtiTestHelper.idAvailableValidator(null, modelOverseer), true);
+                    validators.register('testIdAvailable', qtiTestHelper.idAvailableValidator(modelOverseer), true);
 
                     //once model is loaded, we set up the test view
                     testView(creatorContext);

--- a/views/js/controller/creator/helpers/qtiTest.js
+++ b/views/js/controller/creator/helpers/qtiTest.js
@@ -27,47 +27,107 @@ define([
 ], function(_, __, outcomeHelper, qtiElementHelper){
     'use strict';
 
+    //Identifiers must be unique across
+    //those QTI types
+    var qtiTypesForUniqueIds = [
+        'assessmentTest',
+        'testPart',
+        'assessmentSection',
+        'assessmentItemRef'
+    ];
+
     /**
-     * Utils to manage the QTI Test model
+     * Utility to manage the QTI Test model
      * @exports taoQtiTest/controller/creator/qtiTestHelper
      */
     var qtiTestHelper = {
 
         /**
-         * Extract qti identifiers from a model
-         * @param {Object} obj - the model to extract id from
-         * @returns {Array} the extracted identifiers
+         * Extracts the identifiers from a QTI model
+         * @param {Object|Object[]} model - the JSON QTI model
+         * @param {String[]} [includesOnlyTypes] - list of qti-type to include, exclusively
+         * @param {String[]} [excludeTypes] - list of qti-type to exclude, it excludes the children too
+         * @returns {Object[]} a collection of identifiers (with some meta), if the id is not unique it will appear multiple times, as extracted.
          */
-        extractIdentifiers : function extractIdentifiers(obj){
-            var self = this;
+        extractIdentifiers : function extractIdentifiers(model, includesOnlyTypes, excludeTypes){
+
             var identifiers = [];
-            if(_.has(obj, 'identifier')){
-                identifiers = identifiers.concat(obj.identifier.toLowerCase());
+
+            var extract = function extract( element ) {
+                if(element && _.has(element, 'identifier') && _.isString(element.identifier)){
+                    if(!includesOnlyTypes.length || _.contains(includesOnlyTypes, element['qti-type'])){
+                        identifiers.push({
+                            identifier : element.identifier.toUpperCase(),
+                            originalIdentifier :  element.identifier,
+                            type      : element['qti-type'],
+                            label     : element.title || element.identifier
+                        });
+                    }
+                }
+                _.forEach(element, function(subElement) {
+                    if(_.isPlainObject(subElement) || _.isArray(subElement)){
+                        if(!excludeTypes.length || !_.contains(excludeTypes, subElement['qti-type']) ){
+                            extract(subElement);
+                        }
+                    }
+                });
+            };
+
+            if (_.isPlainObject(model) || _.isArray(model)) {
+                excludeTypes = excludeTypes || [];
+                includesOnlyTypes = includesOnlyTypes || [];
+
+                extract(model);
             }
-            _.flatten(_.forEach(obj, function(value) {
-                identifiers = identifiers.concat(typeof value === "object" ? self.extractIdentifiers(value) : []);
-            }), true);
             return identifiers;
         },
 
         /**
-         * Get a valid and avialable qti identifier
-         * @param {String} qtiType - the type of element you want an id for
-         * @param {Array} lockedIdentifiers - the list of identifiers you cannot use anymore
-         * @returns {String} the identifier
+         * Get the list of unique identifiers for the given model.
+         * @param {Object|Object[]} model - the JSON QTI model
+         * @param {String[]} [includesOnlyTypes] - list of qti-type to include, exclusively
+         * @param {String[]} [excludeTypes] - list of qti-type to exclude, it excludes the children too
+         * @returns {String[]} the list of unique identifiers
          */
-        getIdentifier : function getIdentifier(qtiType, lockedIdentifiers){
+        getIdentifiers : function getIdentifiers(model, includesOnlyTypes, excludeTypes){
+            return _.uniq(_.pluck(this.extractIdentifiers(model, includesOnlyTypes, excludeTypes), 'identifier'));
+        },
+
+        /**
+         * Get the list of identifiers for a given QTI type, only.
+         * @param {Object|Object[]} model - the JSON QTI model
+         * @param {String} qtiType - the type of QTI element to get the identifiers.
+         * @returns {String[]} the list of unique identifiers
+         */
+        getIdentifiersOf : function getIdentifiersOf(model, qtiType){
+            return this.getIdentifiers(model, [qtiType]);
+        },
+
+        /**
+         * Get a valid and available QTI identifier for the given type
+         * @param {Object|Object[]} model - the JSON QTI model to check the existing IDs
+         * @param {String} qtiType - the type of element you want an id for
+         * @param {String} [suggestion] - the default pattern body, we use the type otherwise
+         * @returns {String} the generated identifier
+         */
+        getAvailableIdentifier : function getAvailableIdentifier(model, qtiType, suggestion){
             var index = 1;
-            var suggestion;
             var glue =  '-';
+            var identifier;
+            var current;
+            if(_.contains(qtiTypesForUniqueIds, qtiType)){
+                current = this.getIdentifiers(model, qtiTypesForUniqueIds);
+            } else {
+                current = this.getIdentifiersOf(model, qtiType);
+            }
+
+            suggestion = suggestion || qtiType;
 
             do {
-                suggestion = qtiType +  glue + (index++);
-            } while(_.contains(lockedIdentifiers, suggestion.toLowerCase()));
+                identifier = suggestion +  glue + (index++);
+            } while(_.contains(current, identifier.toUpperCase()));
 
-            lockedIdentifiers.push(suggestion.toLowerCase());
-
-            return suggestion;
+            return identifier;
         },
 
         /**
@@ -106,25 +166,21 @@ define([
 
         /**
          * Gives you a validator that check if a QTI id is available
-         * @param {Array} lockedIdentifiers - deprecated, get them trough the modelOverseer
          * @param {Object} modelOverseer - let's you get the data model
          * @returns {Object} the validator
          */
-        idAvailableValidator : function idAvailableValidator(lockedIdentifiers, modelOverseer){
+        idAvailableValidator : function idAvailableValidator(modelOverseer){
             var self = this;
+
             return {
                 name : 'testIdAvailable',
                 message : __('is already used in the test.'),
                 validate : function(value, callback){
                     var counts = {};
-                    var key    = value.toLowerCase();
-                    var identifiers = lockedIdentifiers;
-                    if(!identifiers && modelOverseer) {
-                        identifiers = self.extractIdentifiers(modelOverseer.getModel());
-                    }
-
+                    var key    = value.toUpperCase();
+                    var identifiers = self.extractIdentifiers(modelOverseer.getModel(), qtiTypesForUniqueIds);
                     if(typeof callback === 'function'){
-                        counts = _.countBy(identifiers);
+                        counts = _.countBy(identifiers, 'identifier');
                         //the identifier list always contains itself
                         //so we check if another one is identical (ie. >= 2)
                         callback(typeof counts[key] === 'undefined' || counts[key] < 2);
@@ -199,7 +255,7 @@ define([
 
                             if(assessmentSection.rubricBlocks && _.isArray(assessmentSection.rubricBlocks)) {
 
-                                //remove rubrick blocks if empty
+                                //remove rubric blocks if empty
                                 if (assessmentSection.rubricBlocks.length === 0 ||
                                     (assessmentSection.rubricBlocks.length === 1 && assessmentSection.rubricBlocks[0].content.length === 0) ) {
 
@@ -229,22 +285,23 @@ define([
          * @throws {Error} if the model is not valid
          */
         validateModel: function validateModel(model) {
-            var identifiers = this.extractIdentifiers(model);
-            var nonUniqueIdentifiers = [];
+            var identifiers = this.extractIdentifiers(model, qtiTypesForUniqueIds);
+            var nonUniqueIdentifiers = 0;
             var outcomes = _.indexBy(outcomeHelper.listOutcomes(model));
+            var messageDetails = '';
 
             _(identifiers)
-                .countBy()
+                .countBy('identifier')
                 .forEach(function(count, id){
                     if(count > 1){
-                        nonUniqueIdentifiers.push(id);
+                        nonUniqueIdentifiers++;
+                        messageDetails += '\n' + id.originalIdentifier + ' : ' +
+                                          id.type + ' ' +
+                                          id.label;
                     }
                 });
-            if(nonUniqueIdentifiers.length === 1){
-                throw new Error(__('The identifier "%s" is not unique accross the test.', nonUniqueIdentifiers[0]));
-            }
             if(nonUniqueIdentifiers.length > 1){
-                throw new Error(__('The following identifiers "%s" are not unique accross the test.', nonUniqueIdentifiers.join('", "')));
+                throw new Error(__('The following identifiers are not unique accross the test : %s', messageDetails));
             }
 
             _.forEach(model.testParts, function (testPart) {

--- a/views/js/controller/creator/modelOverseer.js
+++ b/views/js/controller/creator/modelOverseer.js
@@ -71,6 +71,8 @@ define([
                 return config;
             },
 
+
+
             /**
              * Gets the list of defined outcomes for the nested model. A descriptor is built for each outcomes:
              * {

--- a/views/js/controller/creator/views/itemref.js
+++ b/views/js/controller/creator/views/itemref.js
@@ -238,11 +238,13 @@ function(
             $view.find('.itemref-weight-add').on('click', function(e) {
                 var defaultData = {
                     value: 1,
-                    identifier: (refModel.weights.length === 0) ? 'WEIGHT' : qtiTestHelper.getIdentifier('WEIGHT', qtiTestHelper.extractIdentifiers(refModel))
+                    'qti-type' : 'weight',
+                    identifier: (refModel.weights.length === 0) ? 'WEIGHT' : qtiTestHelper.getAvailableIdentifier(refModel, 'weight', 'WEIGHT')
                 };
                 e.preventDefault();
 
                 $weightList.append(weightTpl(defaultData));
+                refModel.weights.push(defaultData);
                 $weightList.trigger('add.internalbinder'); // trigger model update
 
                 $view.groupValidator();

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -249,7 +249,7 @@ function(
             var $itemRef;
             var $items = $refList.children('li');
             index = index || $items.length;
-            itemData.identifier = qtiTestHelper.getIdentifier('item', config.identifiers);
+            itemData.identifier = qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentItemRef', 'item');
             itemData.index = index + 1;
             $itemRef = $(templates.itemref(itemData));
             if(index > 0){

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -37,7 +37,6 @@ function($, _, __, hider, feedback, actions, testPartView, templates, qtiTestHel
     function testView (creatorContext) {
         var modelOverseer = creatorContext.getModelOverseer();
         var testModel = modelOverseer.getModel();
-        var config = modelOverseer.getConfig();
 
         actions.properties($('.test-creator-test > h1'), 'test', testModel, propHandler);
         testParts();
@@ -153,13 +152,13 @@ function($, _, __, hider, feedback, actions, testPartView, templates, qtiTestHel
                     var testPartIndex = $('.testpart').length;
                     cb({
                         'qti-type' : 'testPart',
-                        identifier : qtiTestHelper.getIdentifier('testPart', config.identifiers),
+                        identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'testPart'),
                         index  : testPartIndex,
                         navigationMode : 0,
                         submissionMode : 0,
                         assessmentSections : [{
                             'qti-type' : 'assessmentSection',
-                            identifier : qtiTestHelper.getIdentifier('assessmentSection',  config.identifiers),
+                            identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection', 'section'),
                             title : 'Section 1',
                             index : 0,
                             sectionParts : []

--- a/views/js/controller/creator/views/testpart.js
+++ b/views/js/controller/creator/views/testpart.js
@@ -112,7 +112,7 @@ function($, _, actions, sectionView, templates, qtiTestHelper){
                     var sectionIndex = $('.section', $testPart).length;
                     cb({
                         'qti-type' : 'assessmentSection',
-                        identifier : qtiTestHelper.getIdentifier('assessmentSection',  config.identifiers),
+                        identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection'),
                         title : 'Section ' + (sectionIndex + 1),
                         index : 0,
                         sectionParts : []

--- a/views/js/test/creator/helpers/qtiTest/sample.json
+++ b/views/js/test/creator/helpers/qtiTest/sample.json
@@ -1,0 +1,490 @@
+{
+  "qti-type": "assessmentTest",
+  "identifier": "t1",
+  "title": "Test+4",
+  "toolName": "tao",
+  "toolVersion": "3.3.0-sprint74",
+  "outcomeDeclarations": [{
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_TOTAL",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_TOTAL_MAX",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "SCORE_RATIO",
+    "cardinality": 0,
+    "baseType": 3
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_ALL",
+    "cardinality": 0,
+    "baseType": 1
+  }, {
+    "qti-type": "outcomeDeclaration",
+    "views": [],
+    "interpretation": "",
+    "longInterpretation": "",
+    "normalMaximum": false,
+    "normalMinimum": false,
+    "masteryValue": false,
+    "identifier": "PASS_ALL_RENDERING",
+    "cardinality": 0,
+    "baseType": 0
+  }],
+  "timeLimits": {
+    "qti-type": "timeLimits",
+    "allowLateSubmission": false
+  },
+  "testParts": [{
+    "qti-type": "testPart",
+    "identifier": "tp1",
+    "navigationMode": 1,
+    "submissionMode": 0,
+    "preConditions": [],
+    "branchRules": [],
+    "itemSessionControl": {
+      "qti-type": "itemSessionControl",
+      "maxAttempts": 0,
+      "showFeedback": false,
+      "allowReview": true,
+      "showSolution": false,
+      "allowComment": false,
+      "validateResponses": false,
+      "allowSkipping": true
+    },
+    "timeLimits": {
+      "qti-type": "timeLimits",
+      "allowLateSubmission": false
+    },
+    "assessmentSections": [{
+      "qti-type": "assessmentSection",
+      "title": "Section+1",
+      "visible": true,
+      "keepTogether": true,
+      "sectionParts": [{
+        "qti-type": "assessmentItemRef",
+        "href": "http://bertaodev/tao.rdf#i1523545264529670",
+        "categories": [],
+        "variableMappings": [],
+        "weights": [{
+          "identifier": "WEIGHT",
+          "value": 1,
+          "qti-type": "weight"
+        }],
+        "templateDefaults": [],
+        "identifier": "item-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 0,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "index": 0,
+        "isLinear": false,
+        "timeLimits": {
+          "maxTime": 0,
+          "minTime": 0,
+          "allowLateSubmission": false,
+          "qti-type": "timeLimits"
+        }
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://bertaodev/tao.rdf#i1523545266796682",
+        "categories": [],
+        "variableMappings": [],
+        "weights": [{
+          "identifier": "WEIGHT",
+          "value": 1,
+          "qti-type": "weight"
+        }],
+        "templateDefaults": [],
+        "identifier": "item-2",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 0,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "index": 1,
+        "isLinear": false,
+        "timeLimits": {
+          "maxTime": 0,
+          "minTime": 0,
+          "allowLateSubmission": false,
+          "qti-type": "timeLimits"
+        }
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://bertaodev/tao.rdf#i1523545265978076",
+        "categories": [],
+        "variableMappings": [],
+        "weights": [],
+        "templateDefaults": [],
+        "identifier": "item-3",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 0,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "index": 2,
+        "isLinear": false
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://bertaodev/tao.rdf#i1523545264514667",
+        "categories": [],
+        "variableMappings": [],
+        "weights": [],
+        "templateDefaults": [],
+        "identifier": "item-4",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 0,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "index": 3,
+        "isLinear": false
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://bertaodev/tao.rdf#i1523545265478473",
+        "categories": [],
+        "variableMappings": [],
+        "weights": [],
+        "templateDefaults": [],
+        "identifier": "item-5",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 0,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "index": 4,
+        "isLinear": false
+      }, {
+        "qti-type": "assessmentItemRef",
+        "href": "http://bertaodev/tao.rdf#i1523545266327579",
+        "categories": [],
+        "variableMappings": [],
+        "weights": [],
+        "templateDefaults": [],
+        "identifier": "item-6",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 0,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "index": 5,
+        "isLinear": false
+      }],
+      "identifier": "ts1",
+      "required": true,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 0,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 0
+    }],
+    "testFeedbacks": [],
+    "index": 0
+  }],
+  "outcomeProcessing": {
+    "qti-type": "outcomeProcessing",
+    "outcomeRules": [{
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_TOTAL",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "SCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": [],
+          "excludeCategories": [],
+          "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+        }],
+        "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "SCORE_TOTAL_MAX",
+      "expression": {
+        "qti-type": "sum",
+        "minOperands": 1,
+        "maxOperands": -1,
+        "acceptedCardinalities": [0, 1, 2],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "testVariables",
+          "variableIdentifier": "MAXSCORE",
+          "baseType": -1,
+          "weightIdentifier": "",
+          "sectionIdentifier": "",
+          "includeCategories": [],
+          "excludeCategories": [],
+          "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+        }],
+        "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+      }
+    }, {
+      "qti-type": "outcomeCondition",
+      "outcomeIf": {
+        "qti-type": "outcomeIf",
+        "expression": {
+          "qti-type": "isNull",
+          "minOperands": 1,
+          "maxOperands": 1,
+          "acceptedCardinalities": [5],
+          "acceptedBaseTypes": [12],
+          "expressions": [{
+            "qti-type": "variable",
+            "identifier": "SCORE_TOTAL_MAX",
+            "weightIdentifier": "",
+            "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+          }],
+          "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+        },
+        "outcomeRules": [{
+          "qti-type": "setOutcomeValue",
+          "identifier": "SCORE_RATIO",
+          "expression": {
+            "qti-type": "baseValue",
+            "baseType": 3,
+            "value": 0,
+            "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+          }
+        }]
+      },
+      "outcomeElseIfs": [],
+      "outcomeElse": {
+        "qti-type": "outcomeElse",
+        "outcomeRules": [{
+          "qti-type": "setOutcomeValue",
+          "identifier": "SCORE_RATIO",
+          "expression": {
+            "qti-type": "divide",
+            "minOperands": 2,
+            "maxOperands": 2,
+            "acceptedCardinalities": [0],
+            "acceptedBaseTypes": [2, 3],
+            "expressions": [{
+              "qti-type": "variable",
+              "identifier": "SCORE_TOTAL",
+              "weightIdentifier": "",
+              "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+            }, {
+              "qti-type": "variable",
+              "identifier": "SCORE_TOTAL_MAX",
+              "weightIdentifier": "",
+              "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+            }],
+            "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+          }
+        }]
+      }
+    }, {
+      "qti-type": "setOutcomeValue",
+      "identifier": "PASS_ALL",
+      "expression": {
+        "qti-type": "gte",
+        "minOperands": 2,
+        "maxOperands": 2,
+        "acceptedCardinalities": [0],
+        "acceptedBaseTypes": [2, 3],
+        "expressions": [{
+          "qti-type": "variable",
+          "identifier": "SCORE_RATIO",
+          "weightIdentifier": "",
+          "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+        }, {
+          "qti-type": "baseValue",
+          "baseType": 3,
+          "value": 0.5,
+          "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+        }],
+        "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+      }
+    }, {
+      "qti-type": "outcomeCondition",
+      "outcomeIf": {
+        "qti-type": "outcomeIf",
+        "expression": {
+          "qti-type": "match",
+          "minOperands": 2,
+          "maxOperands": 2,
+          "acceptedCardinalities": [4],
+          "acceptedBaseTypes": [4],
+          "expressions": [{
+            "qti-type": "variable",
+            "identifier": "PASS_ALL",
+            "weightIdentifier": "",
+            "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+          }, {
+            "qti-type": "baseValue",
+            "baseType": 1,
+            "value": true,
+            "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+          }],
+          "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+        },
+        "outcomeRules": [{
+          "qti-type": "setOutcomeValue",
+          "identifier": "PASS_ALL_RENDERING",
+          "expression": {
+            "qti-type": "baseValue",
+            "baseType": 0,
+            "value": "passed",
+            "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+          }
+        }]
+      },
+      "outcomeElseIfs": [],
+      "outcomeElse": {
+        "qti-type": "outcomeElse",
+        "outcomeRules": [{
+          "qti-type": "setOutcomeValue",
+          "identifier": "PASS_ALL_RENDERING",
+          "expression": {
+            "qti-type": "baseValue",
+            "baseType": 0,
+            "value": "not_passed",
+            "expressionClassNames": ["and", "anyN", "baseValue", "containerSize", "contains", "correct", "customOperator", "default", "delete", "divide", "durationGTE", "durationLT", "equal", "equalRounded", "fieldValue", "gcd", "lcm", "repeat", "gt", "gte", "index", "inside", "integerDivide", "integerModulus", "integerToFloat", "isNull", "lt", "lte", "mapResponse", "mapResponsePoint", "match", "mathOperator", "mathConstant", "max", "min", "member", "multiple", "not", "null", "numberCorrect", "numberIncorrect", "numberPresented", "numberResponded", "numberSelected", "or", "ordered", "outcomeMaximum", "outcomeMinimum", "patternMatch", "power", "product", "random", "randomFloat", "randomInteger", "round", "roundTo", "statsOperator", "stringMatch", "substring", "subtract", "sum", "testVariables", "truncate", "variable"]
+          }
+        }]
+      }
+    }]
+  },
+  "testFeedbacks": [],
+  "scoring": {
+    "modes": {
+      "none": {
+        "key": "none",
+        "label": "None",
+        "description": "No+outcome+processing.+Erase+the+existing+rules,+if+any.",
+        "qti-type": "none"
+      },
+      "custom": {
+        "key": "custom",
+        "label": "Custom",
+        "description": "Custom+outcome+processing.+No+changes+will+be+made+to+the+existing+rules.",
+        "qti-type": "custom"
+      },
+      "total": {
+        "key": "total",
+        "label": "Total+score",
+        "description": "The+score+will+be+processed+for+the+entire+test.+A+sum+of+all+SCORE+outcomes+will+be+computed,+the+result+will+take+place+in+the+SCORE_TOTAL+outcome.+If+the+category+option+is+set,+the+score+will+also+be+processed+per+categories,+and+each+results+will+take+place+in+the+SCORE_xxx+outcome,+where+xxx+is+the+name+of+the+category.",
+        "qti-type": "total"
+      },
+      "cut": {
+        "key": "cut",
+        "label": "Cut+score",
+        "description": "The+score+will+be+processed+for+the+entire+test.+A+sum+of+all+SCORE+outcomes+will+be+computed+and+divided+by+the+sum+of+MAX+SCORE,+the+result+will+be+compared+to+the+cut+score+(or+pass+ratio),+then+the+PASS_TOTAL+outcome+will+be+set+accordingly.+If+the+category+option+is+set,+the+score+will+also+be+processed+per+categories,+and+each+results+will+take+place+in+the+PASS_xxx+outcome,+where+xxx+is+the+name+of+the+category.",
+        "qti-type": "cut"
+      },
+      "qti-type": "modes"
+    },
+    "scoreIdentifier": "SCORE",
+    "weightIdentifier": "",
+    "cutScore": 0.5,
+    "categoryScore": false,
+    "outcomeProcessing": "cut",
+    "qti-type": "scoring"
+  }
+}

--- a/views/js/test/creator/helpers/qtiTest/test.js
+++ b/views/js/test/creator/helpers/qtiTest/test.js
@@ -19,8 +19,9 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'taoQtiTest/controller/creator/helpers/qtiTest'
-], function (qtiTestHelper) {
+    'taoQtiTest/controller/creator/helpers/qtiTest',
+    'json!taoQtiTest/test/creator/helpers/qtiTest/sample.json'
+], function (qtiTestHelper, sampleModel) {
     'use strict';
 
 
@@ -31,11 +32,348 @@ define([
         assert.equal(typeof qtiTestHelper, 'object', "The module exposes an object");
     });
 
-    QUnit.cases([{
-        title: 'idAvailableValidator'
-    }]).test('method ', function (data, assert) {
+    QUnit.cases([
+        { title: 'extractIdentifiers' },
+        { title: 'getIdentifiers' },
+        { title: 'getIdentifiersOf' },
+        { title: 'getAvailableIdentifier' },
+        { title: 'idAvailableValidator' }
+    ]).test('method ', function (data, assert) {
         QUnit.expect(1);
         assert.equal(typeof qtiTestHelper[data.title], 'function', 'The helper exposes a "' + data.title + '" method');
+    });
+
+    QUnit.module('identifiers');
+
+
+    QUnit.test('extract all identifiers', function(assert){
+        var identifiers;
+
+        QUnit.expect(2);
+
+        identifiers = qtiTestHelper.extractIdentifiers(sampleModel);
+
+        assert.ok(identifiers.length > 0, 'The identifiers are exported as an array');
+        assert.deepEqual(identifiers,[{
+            "identifier": "T1",
+            "originalIdentifier": "t1",
+            "type": "assessmentTest",
+            "label": "Test+4"
+        }, {
+            "identifier": "SCORE_TOTAL",
+            "originalIdentifier": "SCORE_TOTAL",
+            "type": "outcomeDeclaration",
+            "label": "SCORE_TOTAL"
+        }, {
+            "identifier": "SCORE_TOTAL_MAX",
+            "originalIdentifier": "SCORE_TOTAL_MAX",
+            "type": "outcomeDeclaration",
+            "label": "SCORE_TOTAL_MAX"
+        }, {
+            "identifier": "SCORE_RATIO",
+            "originalIdentifier": "SCORE_RATIO",
+            "type": "outcomeDeclaration",
+            "label": "SCORE_RATIO"
+        }, {
+            "identifier": "PASS_ALL",
+            "originalIdentifier": "PASS_ALL",
+            "type": "outcomeDeclaration",
+            "label": "PASS_ALL"
+        }, {
+            "identifier": "PASS_ALL_RENDERING",
+            "originalIdentifier": "PASS_ALL_RENDERING",
+            "type": "outcomeDeclaration",
+            "label": "PASS_ALL_RENDERING"
+        }, {
+            "identifier": "TP1",
+            "originalIdentifier": "tp1",
+            "type": "testPart",
+            "label": "tp1"
+        }, {
+            "identifier": "TS1",
+            "originalIdentifier": "ts1",
+            "type": "assessmentSection",
+            "label": "Section+1"
+        }, {
+            "identifier": "ITEM-1",
+            "originalIdentifier": "item-1",
+            "type": "assessmentItemRef",
+            "label": "item-1"
+        }, {
+            "identifier": "WEIGHT",
+            "originalIdentifier": "WEIGHT",
+            "type": "weight",
+            "label": "WEIGHT"
+        }, {
+            "identifier": "ITEM-2",
+            "originalIdentifier": "item-2",
+            "type": "assessmentItemRef",
+            "label": "item-2"
+        }, {
+            "identifier": "WEIGHT",
+            "originalIdentifier": "WEIGHT",
+            "type": "weight",
+            "label": "WEIGHT"
+        }, {
+            "identifier": "ITEM-3",
+            "originalIdentifier": "item-3",
+            "type": "assessmentItemRef",
+            "label": "item-3"
+        }, {
+            "identifier": "ITEM-4",
+            "originalIdentifier": "item-4",
+            "type": "assessmentItemRef",
+            "label": "item-4"
+        }, {
+            "identifier": "ITEM-5",
+            "originalIdentifier": "item-5",
+            "type": "assessmentItemRef",
+            "label": "item-5"
+        }, {
+            "identifier": "ITEM-6",
+            "originalIdentifier": "item-6",
+            "type": "assessmentItemRef",
+            "label": "item-6"
+        }, {
+            "identifier": "SCORE_TOTAL",
+            "originalIdentifier": "SCORE_TOTAL",
+            "type": "setOutcomeValue",
+            "label": "SCORE_TOTAL"
+        }, {
+            "identifier": "SCORE_TOTAL_MAX",
+            "originalIdentifier": "SCORE_TOTAL_MAX",
+            "type": "setOutcomeValue",
+            "label": "SCORE_TOTAL_MAX"
+        }, {
+            "identifier": "SCORE_TOTAL_MAX",
+            "originalIdentifier": "SCORE_TOTAL_MAX",
+            "type": "variable",
+            "label": "SCORE_TOTAL_MAX"
+        }, {
+            "identifier": "SCORE_RATIO",
+            "originalIdentifier": "SCORE_RATIO",
+            "type": "setOutcomeValue",
+            "label": "SCORE_RATIO"
+        }, {
+            "identifier": "SCORE_RATIO",
+            "originalIdentifier": "SCORE_RATIO",
+            "type": "setOutcomeValue",
+            "label": "SCORE_RATIO"
+        }, {
+            "identifier": "SCORE_TOTAL",
+            "originalIdentifier": "SCORE_TOTAL",
+            "type": "variable",
+            "label": "SCORE_TOTAL"
+        }, {
+            "identifier": "SCORE_TOTAL_MAX",
+            "originalIdentifier": "SCORE_TOTAL_MAX",
+            "type": "variable",
+            "label": "SCORE_TOTAL_MAX"
+        }, {
+            "identifier": "PASS_ALL",
+            "originalIdentifier": "PASS_ALL",
+            "type": "setOutcomeValue",
+            "label": "PASS_ALL"
+        }, {
+            "identifier": "SCORE_RATIO",
+            "originalIdentifier": "SCORE_RATIO",
+            "type": "variable",
+            "label": "SCORE_RATIO"
+        }, {
+            "identifier": "PASS_ALL",
+            "originalIdentifier": "PASS_ALL",
+            "type": "variable",
+            "label": "PASS_ALL"
+        }, {
+            "identifier": "PASS_ALL_RENDERING",
+            "originalIdentifier": "PASS_ALL_RENDERING",
+            "type": "setOutcomeValue",
+            "label": "PASS_ALL_RENDERING"
+        }, {
+            "identifier": "PASS_ALL_RENDERING",
+            "originalIdentifier": "PASS_ALL_RENDERING",
+            "type": "setOutcomeValue",
+            "label": "PASS_ALL_RENDERING"
+        }], 'All identifiers have been extracted');
+    });
+
+    QUnit.test('extract only test, test parts and section identifiers', function(assert){
+        var identifiers;
+
+        QUnit.expect(2);
+
+        identifiers = qtiTestHelper.extractIdentifiers(sampleModel, ['assessmentTest', 'testPart', 'assessmentSection']);
+
+        assert.ok(identifiers.length > 0, 'The identifiers are exported as an array');
+        assert.deepEqual(identifiers,[{
+            "identifier": "T1",
+            "originalIdentifier": "t1",
+            "type": "assessmentTest",
+            "label": "Test+4"
+        }, {
+            "identifier": "TP1",
+            "originalIdentifier": "tp1",
+            "type": "testPart",
+            "label": "tp1"
+        }, {
+            "identifier": "TS1",
+            "originalIdentifier": "ts1",
+            "type": "assessmentSection",
+            "label": "Section+1"
+        }], 'All identifiers have been extracted');
+    });
+
+
+    QUnit.test('exclude outcome identifiers', function(assert){
+        var identifiers;
+
+        QUnit.expect(2);
+
+        identifiers = qtiTestHelper.extractIdentifiers(sampleModel, [], ['outcomeProcessing', 'outcomeDeclaration']);
+
+        assert.ok(identifiers.length > 0, 'The identifiers are exported as an array');
+        assert.deepEqual(identifiers,[{
+            "identifier": "T1",
+            "originalIdentifier": "t1",
+            "type": "assessmentTest",
+            "label": "Test+4"
+        }, {
+            "identifier": "TP1",
+            "originalIdentifier": "tp1",
+            "type": "testPart",
+            "label": "tp1"
+        }, {
+            "identifier": "TS1",
+            "originalIdentifier": "ts1",
+            "type": "assessmentSection",
+            "label": "Section+1"
+        }, {
+            "identifier": "ITEM-1",
+            "originalIdentifier": "item-1",
+            "type": "assessmentItemRef",
+            "label": "item-1"
+        }, {
+            "identifier": "WEIGHT",
+            "originalIdentifier": "WEIGHT",
+            "type": "weight",
+            "label": "WEIGHT"
+        }, {
+            "identifier": "ITEM-2",
+            "originalIdentifier": "item-2",
+            "type": "assessmentItemRef",
+            "label": "item-2"
+        }, {
+            "identifier": "WEIGHT",
+            "originalIdentifier": "WEIGHT",
+            "type": "weight",
+            "label": "WEIGHT"
+        }, {
+            "identifier": "ITEM-3",
+            "originalIdentifier": "item-3",
+            "type": "assessmentItemRef",
+            "label": "item-3"
+        }, {
+            "identifier": "ITEM-4",
+            "originalIdentifier": "item-4",
+            "type": "assessmentItemRef",
+            "label": "item-4"
+        }, {
+            "identifier": "ITEM-5",
+            "originalIdentifier": "item-5",
+            "type": "assessmentItemRef",
+            "label": "item-5"
+        }, {
+            "identifier": "ITEM-6",
+            "originalIdentifier": "item-6",
+            "type": "assessmentItemRef",
+            "label": "item-6"
+        }], 'All identifiers have been extracted');
+    });
+
+    QUnit.test('get all identifiers', function(assert){
+        var identifiers;
+
+        QUnit.expect(2);
+
+        identifiers = qtiTestHelper.getIdentifiers(sampleModel);
+
+        assert.ok(identifiers.length > 0, 'The identifiers are exported as an array');
+        assert.deepEqual(identifiers,[
+            "T1",
+            "SCORE_TOTAL",
+            "SCORE_TOTAL_MAX",
+            "SCORE_RATIO",
+            "PASS_ALL",
+            "PASS_ALL_RENDERING",
+            "TP1",
+            "TS1",
+            "ITEM-1",
+            "WEIGHT",
+            "ITEM-2",
+            "ITEM-3",
+            "ITEM-4",
+            "ITEM-5",
+            "ITEM-6"
+        ], 'All unique identifiers have been extracted');
+    });
+
+    QUnit.test('get test, parts, section and items identifiers', function(assert){
+        var identifiers;
+
+        QUnit.expect(2);
+
+        identifiers = qtiTestHelper.getIdentifiers(sampleModel, ['assessmentTest', 'testPart', 'assessmentSection', 'assessmentItemRef'] );
+
+        assert.ok(identifiers.length > 0, 'The identifiers are exported as an array');
+        assert.deepEqual(identifiers,[
+            "T1",
+            "TP1",
+            "TS1",
+            "ITEM-1",
+            "ITEM-2",
+            "ITEM-3",
+            "ITEM-4",
+            "ITEM-5",
+            "ITEM-6"
+        ], 'All unique identifiers have been extracted');
+    });
+
+    QUnit.test('get items identifiers', function(assert){
+        var identifiers;
+
+        QUnit.expect(2);
+
+        identifiers = qtiTestHelper.getIdentifiersOf(sampleModel, 'assessmentItemRef');
+
+        assert.ok(identifiers.length > 0, 'The identifiers are exported as an array');
+        assert.deepEqual(identifiers,[
+            "ITEM-1",
+            "ITEM-2",
+            "ITEM-3",
+            "ITEM-4",
+            "ITEM-5",
+            "ITEM-6"
+        ], 'All unique identifiers have been extracted');
+
+    });
+
+    QUnit.test('get items identifiers', function(assert){
+        var identifier;
+
+        QUnit.expect(4);
+
+        identifier = qtiTestHelper.getAvailableIdentifier(sampleModel, 'assessmentItemRef', 'item');
+        assert.equal(identifier, 'item-7', 'The ids item-1 to item-6 are already in use');
+
+        identifier = qtiTestHelper.getAvailableIdentifier(sampleModel, 'assessmentSection', 'section');
+        assert.equal(identifier, 'section-1', 'The 1st id is available');
+
+        identifier = qtiTestHelper.getAvailableIdentifier(sampleModel, 'testPart');
+        assert.equal(identifier, 'testPart-1', 'By default the suggestion is the qti type');
+
+        identifier = qtiTestHelper.getAvailableIdentifier(sampleModel, 'weight', 'WEIGHT');
+        assert.equal(identifier, 'WEIGHT-1');
+
     });
 
 
@@ -51,35 +389,24 @@ define([
         assert.equal(identifierValidator.name, 'testIdAvailable', 'The validator name is correct');
     });
 
-    QUnit.cases([{
-        ids : ['foo', 'bar'],
-        value: 'noz',
-        result : true
-    }, {
-        ids : ['foo', 'bar', 'foo'],
-        value: 'foo',
-        result : false
-    }]).asyncTest('idAvailableValidator validates by list', function (data, assert) {
-        QUnit.expect(1);
-        qtiTestHelper.idAvailableValidator(data.ids).validate(data.value, function(result){
-            assert.equal(data.result, result);
-            QUnit.start();
-        });
-    });
-
     QUnit.asyncTest('idAvailableValidator validates by model', function (assert) {
         var modelOverseerMock = {
             getModel : function getModel(){
                 return {
                     identifier : 'foo',
+                    'qti-type' : 'assessmentTest',
                     testParts : [{
-                        identfier: 'bar',
+                        identifier: 'bar',
+                        'qti-type' : 'testPart'
                     }, {
-                        identfier: 'noz',
+                        identifier: 'noz',
+                        'qti-type' : 'testPart',
                         sections : [{
-                            identfier: 'bee',
+                            identifier: 'bee',
+                            'qti-type' : 'assessmentSection'
                         }, {
-                            identifier: 'foo'
+                            identifier: 'foo',
+                            'qti-type' : 'assessmentSection'
                         }]
                     }]
                 };
@@ -88,9 +415,13 @@ define([
 
         QUnit.expect(1);
 
-        qtiTestHelper.idAvailableValidator(null, modelOverseerMock).validate('foo', function(result){
+        qtiTestHelper.idAvailableValidator(modelOverseerMock).validate('foo', function(result){
             assert.ok(!result, 'The validator invalidate the value');
             QUnit.start();
         });
     });
+
+
+
+
 });


### PR DESCRIPTION
In order to fix the bug https://oat-sa.atlassian.net/browse/TAO-6163 
I have re-factored the way we handles identifiers within the test authoring. 
The QTI spec doesn't say much about identifiers unicity, so we agree with the qti-sdk team on the following rule : 
> only the following qti element needs unique identifiers across the test document : `'assessmentTest`,     `testPart`, `assessmentSection` and 'assessmentItemRef`

There also some check on the identifier but only to generate ids without the same names for convenience, but without strong validation.

The version is jumping to the next major since it's considered as a breaking change, even though we know the helper isn't used outside the test creator, semver rules are very explicit on the matter. 

The unit test has been extended only on the methods affected by the refactoring.