### PR TITLE
Fix/tao 6175 item state restored twice

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '25.3.0',
+    'version'     => '25.3.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=14.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1870,6 +1870,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('25.2.0');
         }
 
-        $this->skip('25.2.0', '25.3.0');
+        $this->skip('25.2.0', '25.3.1');
     }
 }

--- a/views/js/runner/provider/qti.js
+++ b/views/js/runner/provider/qti.js
@@ -589,15 +589,10 @@ define([
                     reject(err);
                 })
                 .on('init', function(){
-                    var options = {};
-                    if(itemData.state){
-                        this.setState(itemData.state);
-                        options.state = itemData.state;//official ims portable element requires state information during rendering
-                    }
-                    if(itemData.portableElements){
-                        options.portableElements = itemData.portableElements;
-                    }
-                    this.render(self.getAreaBroker().getContentArea(), options);
+                    var itemContainer        = self.getAreaBroker().getContentArea();
+                    var itemRenderingOptions = _.pick(itemData, ['state', 'portableElements']);
+
+                    this.render(itemContainer, itemRenderingOptions);
                 })
                 .on('render', function(){
 


### PR DESCRIPTION
The state was restored twice on rendering but most interactions does state replacement but the GraphicGapMatch.