### PR TITLE
Act 210 fix timers with extra time

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '25.11.1',
+    'version'     => '25.11.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=15.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1671,6 +1671,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('25.10.1');
         }
 
-        $this->skip('25.10.1', '25.11.1');
+        $this->skip('25.10.1', '25.11.2');
     }
 }

--- a/views/js/runner/plugins/controls/timer/plugin.js
+++ b/views/js/runner/plugins/controls/timer/plugin.js
@@ -50,16 +50,19 @@ define([
          */
         install: function install() {
 
+            var testRunner = this.getTestRunner();
+
             /**
              * Load the timers, from the given timeConstraints and reading the current value in the store
              * @param {store} timeStore - where the values are read
-             * @param {Object[]} timeConstraints - the timeConstraints as given by the testContext
-             * @param {Boolean} isLinear - the timeConstraints as given by the testContext
              * @param {Object} config - the current config, especially for the warnings
-             * @param {Object} extraTime - as defined in the testContext
              * @return {Promise<Object[]>} the list of timers for the current context
              */
-            this.loadTimers = function loadTimers(timeStore, timeConstraints, isLinear, config, extraTime){
+            this.loadTimers = function loadTimers(timeStore, config){
+                var testContext = testRunner.getTestContext();
+                var timeConstraints = testContext.timeConstraints;
+                var isLinear = !!testContext.isLinear;
+                var extraTime = testContext.extraTime;
                 var timers = timersFactory(timeConstraints, isLinear, config, extraTime);
                 return Promise.all(
                     _.map(timers, function(timer){
@@ -103,7 +106,7 @@ define([
             };
 
             //define the "timer" store as "volatile" (removed on browser change).
-            this.getTestRunner().getTestStore().setVolatile(this.getName());
+            testRunner.getTestStore().setVolatile(this.getName());
         },
 
         /**
@@ -162,7 +165,7 @@ define([
                             var testContext = testRunner.getTestContext();
                             //update the timers before each item
                             if(self.timerbox && testContext.timeConstraints){
-                                return self.loadTimers(timeStore, testContext.timeConstraints, !!testContext.isLinear, config, testContext.extraTime)
+                                return self.loadTimers(timeStore, config)
                                     .then(function(timers){
                                         return self.timerbox.update(timers);
                                     })

--- a/views/js/runner/plugins/controls/timer/plugin.js
+++ b/views/js/runner/plugins/controls/timer/plugin.js
@@ -56,12 +56,10 @@ define([
              * @param {Object[]} timeConstraints - the timeConstraints as given by the testContext
              * @param {Boolean} isLinear - the timeConstraints as given by the testContext
              * @param {Object} config - the current config, especially for the warnings
+             * @param {Object} extraTime - as defined in the testContext
              * @return {Promise<Object[]>} the list of timers for the current context
              */
-            this.loadTimers = function loadTimers(timeStore, testContext, config){
-                var isLinear =  !!testContext.isLinear;
-                var timeConstraints = testContext.timeConstraints;
-                var extraTime = testContext.extraTime;
+            this.loadTimers = function loadTimers(timeStore, timeConstraints, isLinear, config, extraTime){
                 var timers = timersFactory(timeConstraints, isLinear, config, extraTime);
                 return Promise.all(
                     _.map(timers, function(timer){
@@ -164,7 +162,7 @@ define([
                             var testContext = testRunner.getTestContext();
                             //update the timers before each item
                             if(self.timerbox && testContext.timeConstraints){
-                                return self.loadTimers(timeStore, testContext, config)
+                                return self.loadTimers(timeStore, testContext.timeConstraints, !!testContext.isLinear, config, testContext.extraTime)
                                     .then(function(timers){
                                         return self.timerbox.update(timers);
                                     })

--- a/views/js/runner/plugins/controls/timer/timers.js
+++ b/views/js/runner/plugins/controls/timer/timers.js
@@ -85,9 +85,10 @@ define([
      * @param {Object} [config] - timers config
      * @param {Object[]} [config.warnings] - the warnings to apply to the timers (max only for now)
      * @param {Object[]} [config.warnings] - the warnings to apply to the timers (max only for now)
+     * @param {Object[]} extraTime - as defined in the testContext
      * @returns {timer[]} the timers
      */
-    return function getTimers(timeConstraints, isLinear, config){
+    return function getTimers(timeConstraints, isLinear, config, extraTime){
         var timers = {};
 
         /**
@@ -148,6 +149,9 @@ define([
             }
             if(timer.extraTime > 0){
                 timer.extraTime = timer.extraTime * precision;
+            }
+            if (extraTime) {
+                timer.remainingTime += extraTime.remaining * precision;
             }
 
             //TODO supports warnings for other types

--- a/views/js/runner/plugins/controls/timer/timers.js
+++ b/views/js/runner/plugins/controls/timer/timers.js
@@ -85,7 +85,7 @@ define([
      * @param {Object} [config] - timers config
      * @param {Object[]} [config.warnings] - the warnings to apply to the timers (max only for now)
      * @param {Object[]} [config.warnings] - the warnings to apply to the timers (max only for now)
-     * @param {Object[]} extraTime - as defined in the testContext
+     * @param {Object} extraTime - as defined in the testContext
      * @returns {timer[]} the timers
      */
     return function getTimers(timeConstraints, isLinear, config, extraTime){


### PR DESCRIPTION
Steps to reproduce issue:
1. launch test with 10 seconds timer and with `extended_time=2` lti parameter. Total time should be 20 seconds.
2. When on timer will be less than 10 seconds (main time is up, and user uses extended time) go to the next item. On new item timer will show 20+ seconds again.