### PR TITLE
Act 210 syncronize duration and timer plugins

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '25.11.1',
+    'version'     => '25.11.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=15.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1671,6 +1671,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('25.10.1');
         }
 
-        $this->skip('25.10.1', '25.11.1');
+        $this->skip('25.10.1', '25.11.2');
     }
 }

--- a/views/js/runner/plugins/controls/timer/plugin.js
+++ b/views/js/runner/plugins/controls/timer/plugin.js
@@ -169,7 +169,12 @@ define([
                                     .catch(handleError);
                             }
                         })
-                        .on('enableitem renderitem', function(){
+                        .on('enableitem', function(){
+                            if(self.timerbox){
+                                self.timerbox.start();
+                            }
+                        })
+                        .after('renderitem', function(){
                             if(self.timerbox){
                                 self.timerbox.start();
                             }


### PR DESCRIPTION
Client time duration sent to server to build timeLines is unsynchronized with timers on client side.
On my local environment it takes 1003 microseconds average deviation between `on('renderitem')` and `after(renderitem)` per move, so after 10 moves difference between server and client timers <10 seconds.

Duration plugin uses `after(renderitem)` event to start stopwatch:
https://github.com/oat-sa/extension-tao-testqti/blob/master/views/js/runner/plugins/controls/duration/duration.js#L114