### PR TITLE
Feature/tao 6221 allow late submission

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -735,6 +735,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
         $ref   = $this->getRequestParameter('ref');
         $scope = $this->getRequestParameter('scope');
         $start = $this->hasRequestParameter('start');
+        $late = $this->hasRequestParameter('late');
 
         try {
             $this->checkSecurityToken();
@@ -749,7 +750,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
             $this->saveItemResponses();
 
-            $result = $this->getRunnerService()->timeout($serviceContext, $scope, $ref);
+            $result = $this->getRunnerService()->timeout($serviceContext, $scope, $ref, $late);
 
             $response = [
                 'success' => $result,

--- a/manifest.php
+++ b/manifest.php
@@ -38,11 +38,11 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '25.11.3',
+    'version'     => '25.12.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=15.2.0',
-        'taoTests'   => '>=7.9.0',
+        'taoTests'   => '>=7.10.0',
         'tao'        => '>=19.8.0',
         'generis'    => '>=6.14.0',
         'taoDelivery' => '>=9.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1671,6 +1671,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('25.10.1');
         }
 
-        $this->skip('25.10.1', '25.11.3');
+        $this->skip('25.10.1', '25.12.0');
     }
 }

--- a/views/js/runner/plugins/controls/timer/strategy/timeout.js
+++ b/views/js/runner/plugins/controls/timer/strategy/timeout.js
@@ -43,7 +43,7 @@ define([], function(){
                  */
                 complete : function complete(){
                     if(timer.qtiClassName && timer.source){
-                        return testRunner.timeout(timer.qtiClassName, timer.source);
+                        return testRunner.timeout(timer.qtiClassName, timer.source, timer);
                     }
                 }
             };

--- a/views/js/runner/plugins/controls/timer/timers.js
+++ b/views/js/runner/plugins/controls/timer/timers.js
@@ -132,8 +132,9 @@ define([
             var timer  = _.pick(constraintData, ['label', 'scope', 'source', 'extraTime', 'qtiClassName']);
 
             timer.type = type;
+            timer.allowLateSubmission = constraintData.allowLateSubmission;
 
-            //to stay backward comaptible, the "max" timers ids are just the source
+            //to stay backward compatible, the "max" timers ids are just the source
             if(type === 'max'){
                 timer.id  = constraintData.source;
             } else {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-6221

Requires: 
 - [ ] https://github.com/oat-sa/extension-tao-test/pull/243

Handle the `allowLateSubmission` option in the TestRunner.

The implemented behavior is:

GIVEN that late allow late submission option is enabled
WHEN the timer expire
THEN the test taker can still interact with the item he is currently displaying for an unlimited amount of time
AND the item response is saved when the test taker submit his response
AND the test taker is not able to move to any other item of the timed section (section, test part or test)