### PR TITLE
Act 210 store consumed timer value on client side

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '25.11.5',
+    'version'     => '25.11.6',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=15.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1671,6 +1671,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('25.10.1');
         }
 
-        $this->skip('25.10.1', '25.11.5');
+        $this->skip('25.10.1', '25.11.6');
     }
 }

--- a/views/js/runner/plugins/controls/timer/plugin.js
+++ b/views/js/runner/plugins/controls/timer/plugin.js
@@ -66,22 +66,9 @@ define([
                 var timers = timersFactory(timeConstraints, isLinear, config, extraTime);
                 return Promise.all(
                     _.map(timers, function(timer){
-                        return timeStore.getItem(timer.id).then(function(savedTime){
-                            var total = timer.originalTime + timer.extraTime;
-                            var consumed;
-                            //first initialization
-                            if ((timer.remainingTime === timer.originalTime || timer.remainingTime === 0) && !savedTime) {
-                                timer.remainingTime = timer.originalTime + timer.extraTime;
-                            }
-
-                            //apply the remainingTime from the store
-                            if (_.isNumber(savedTime) && savedTime >= 0 && config.restoreTimerFromClient) {
-                                timer.remainingTime = savedTime;
-                            }
-                            consumed = total - timer.remainingTime;
-                            //apply the extraTime
-                            if(_.isNumber(timer.extraTime) && timer.extraTime > 0){
-                                timer.remainingWithoutExtraTime = consumed > timer.originalTime ? 0 : timer.originalTime - consumed;
+                        return timeStore.getItem(timer.id).then(function(savedConsumedTime){
+                            if (_.isNumber(savedConsumedTime) && savedConsumedTime >= 0 && config.restoreTimerFromClient) {
+                                timer.remainingTime = timer.originalTime + timer.extraTime - savedConsumedTime;
                             }
                         });
                     })
@@ -92,7 +79,7 @@ define([
             };
 
             /**
-             * Save timer values into the store
+             * Save consumed time values into the store
              * @param {store} timeStore - where the values are saved
              * @param {Object[]} timers - the timers to save
              * @return {Promise} resolves once saved
@@ -100,7 +87,7 @@ define([
             this.saveTimers = function saveTimers(timeStore, timers){
                 return Promise.all(
                     _.map(timers, function(timer){
-                        return timeStore.setItem(timer.id, timer.remainingTime);
+                        return timeStore.setItem(timer.id, timer.total - timer.remainingTime);
                     })
                 );
             };

--- a/views/js/runner/plugins/controls/timer/timers.js
+++ b/views/js/runner/plugins/controls/timer/timers.js
@@ -136,16 +136,12 @@ define([
 
             timer.type = type;
 
-            //to stay backward compatible, the "max" timers ids are just the source
-            if(type === 'max'){
-                timer.id  = constraintData.source;
-            } else {
-                timer.id  = type + '-' + constraintData.scope + '-' + constraintData.source;
-            }
             if(type === 'min'){
+                timer.id  = type + '-' + constraintData.scope + '-' + constraintData.source;
                 timer.originalTime  = constraintData.minTime * precision;
                 timer.remainingTime = constraintData.minTimeRemaining * precision;
             } else {
+                timer.id  = constraintData.source;
                 timer.originalTime  = constraintData.maxTime * precision;
                 timer.remainingTime = constraintData.maxTimeRemaining * precision;
             }

--- a/views/js/runner/plugins/controls/timer/timers.js
+++ b/views/js/runner/plugins/controls/timer/timers.js
@@ -129,12 +129,14 @@ define([
              * @property {Number} extraTime - additional time, in ms
              * @property {Number} originalTime - the starting value of the timer, never changes, in ms.
              * @property {Number} remainingTime - current value, in ms.
+             * @property {Number} remainingWithoutExtraTime - remaining time without extra time, in ms.
+             * @property {Number} total - total time (original time + extra time), in ms.
              */
             var timer  = _.pick(constraintData, ['label', 'scope', 'source', 'extraTime', 'qtiClassName']);
 
             timer.type = type;
 
-            //to stay backward comaptible, the "max" timers ids are just the source
+            //to stay backward compatible, the "max" timers ids are just the source
             if(type === 'max'){
                 timer.id  = constraintData.source;
             } else {
@@ -147,13 +149,17 @@ define([
                 timer.originalTime  = constraintData.maxTime * precision;
                 timer.remainingTime = constraintData.maxTimeRemaining * precision;
             }
+
+            timer.remainingWithoutExtraTime = timer.remainingTime;
             if(timer.extraTime > 0){
-                timer.extraTime = timer.extraTime * precision;
+                timer.extraTime = extraTime.total * precision;
             }
+
+            timer.total = timer.originalTime + (extraTime.total * precision);
+
             if (extraTime) {
                 timer.remainingTime += extraTime.remaining * precision;
             }
-
             //TODO supports warnings for other types
             if (type === 'max' && _.isArray(constraintsWarnings[timer.scope])) {
                 timer.warnings = constraintsWarnings[timer.scope];


### PR DESCRIPTION
We need to store on client side not remaining time but consumed time otherwise we also need to store which extra time values has been applied.
In Nccer there is ability to add/remove extra time not only during start of session but on the fly (by proctor).