### PR TITLE
Feature/tao 6573 config based category presets

### DIFF
--- a/actions/class.Creator.php
+++ b/actions/class.Creator.php
@@ -46,8 +46,9 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule {
             }
             $this->setData('labels', json_encode(tao_helpers_Uri::encodeArray($labels, tao_helpers_Uri::ENCODE_ARRAY_KEYS)));
 
+            $runtimeConfig = $this->getRuntimeConfig();
             $categoriesPresetService = $this->getServiceManager()->get(TestCategoryPresetProvider::SERVICE_ID);
-            $this->setData('categoriesPresets', json_encode($categoriesPresetService->getPresets()));
+            $this->setData('categoriesPresets', json_encode($categoriesPresetService->getAvailablePresets($runtimeConfig)));
 
             $this->setData('loadUrl', _url('getTest', null, null, array('uri' => $testUri)));
             $this->setData('saveUrl', _url('saveTest', null, null, array('uri' => $testUri)));
@@ -59,7 +60,6 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule {
             $this->setData('identifierUrl', _url('getIdentifier', null, null, array('uri' => $testUri)));
 
             $guidedNavigation = false;
-            $runtimeConfig = $this->getRuntimeConfig();
             if( is_array($runtimeConfig) && isset($runtimeConfig['guidedNavigation']) ) {
                 $guidedNavigation = $runtimeConfig['guidedNavigation'];
             }
@@ -165,7 +165,7 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule {
     /**
      * Get the runtime config
      * @return array the configuration
-     */   
+     */
     protected function getRuntimeConfig()
     {
         $extension = $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');

--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '26.0.0',
+    'version'     => '26.1.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=15.2.0',

--- a/models/classes/QtiCategoryPresetProvider.php
+++ b/models/classes/QtiCategoryPresetProvider.php
@@ -60,7 +60,8 @@ class QtiCategoryPresetProvider implements TestCategoryPresetProviderInterface
                     'qtiCategory'   => 'x-tao-option-nextSection',
                     'description'   => __('Allow skipping of the current section.'),
                     'order'         => 400,
-                    'pluginId'      => 'nextSection'
+                    'pluginId'      => 'nextSection',
+                    'featureFlag'   => 'enable-allow-skipping'
                 ])
             ]
         );

--- a/models/classes/TestCategoryPreset.php
+++ b/models/classes/TestCategoryPreset.php
@@ -59,6 +59,12 @@ class TestCategoryPreset implements JsonSerializable
      */
     private $pluginId = '';
 
+    /**
+     * @var string $featureFlag - the name of a config flag,
+     * the preset will be deactivated based on this optional value.
+     */
+    private $featureFlag;
+
 
     /**
      * Create a test category preset
@@ -93,6 +99,9 @@ class TestCategoryPreset implements JsonSerializable
         if(isset($data['pluginId'])) {
             $this->pluginId = (string) $data['pluginId'];
         }
+        if(isset($data['featureFlag'])) {
+            $this->featureFlag = (string) $data['featureFlag'];
+        }
     }
 
     public function getId()
@@ -125,6 +134,11 @@ class TestCategoryPreset implements JsonSerializable
         return $this->pluginId;
     }
 
+    public function getFeatureFlag()
+    {
+        return isset($this->featureFlag) ? $this->featureFlag : false;
+    }
+
     /**
      * @see JsonSerializable::jsonSerialize
      */
@@ -145,7 +159,8 @@ class TestCategoryPreset implements JsonSerializable
             'qtiCategory' => $this->qtiCategory,
             'description' => $this->description,
             'order'       => $this->order,
-            'pluginId'    => $this->pluginId
+            'pluginId'    => $this->pluginId,
+            'featureFlag' => $this->featureFlag
         ];
     }
 

--- a/models/classes/TestCategoryPreset.php
+++ b/models/classes/TestCategoryPreset.php
@@ -136,7 +136,7 @@ class TestCategoryPreset implements JsonSerializable
 
     public function getFeatureFlag()
     {
-        return isset($this->featureFlag) ? $this->featureFlag : false;
+        return (string) $this->featureFlag;
     }
 
     /**

--- a/models/classes/TestCategoryPresetProvider.php
+++ b/models/classes/TestCategoryPresetProvider.php
@@ -137,9 +137,9 @@ class TestCategoryPresetProvider extends ConfigurableService
      */
     private function isPresetAvailable(TestCategoryPreset $preset, $config = [])
     {
-        if(!is_null($preset)) {
+        if (!is_null($preset)) {
             $flag = $preset->getFeatureFlag();
-            if(is_string($flag) && isset($config[$flag]) && $config[$flag] != true){
+            if ($flag && isset($config[$flag]) && $config[$flag] != true) {
                 return true;
             }
         }

--- a/models/classes/TestCategoryPresetProvider.php
+++ b/models/classes/TestCategoryPresetProvider.php
@@ -115,12 +115,7 @@ class TestCategoryPresetProvider extends ConfigurableService
                 $presetGroup['presets'] = array_filter(
                     $presetGroup['presets'],
                     function($preset) use ($config) {
-                        $flag = $preset->getFeatureFlag();
-                        if(is_string($flag) && isset($config[$flag]) && $config[$flag] != true){
-                            return false;
-                        }
-
-                        return true;
+                        return !$this->isPresetAvailable($preset, $config);
                     }
                 );
 
@@ -131,6 +126,24 @@ class TestCategoryPresetProvider extends ConfigurableService
             }
         }
         return $presets;
+    }
+
+    /**
+     * Is a preset available according to a configuration (ie. based on it's featureFlag)
+     *
+     * @param TestCategoryPreset $preset the preset to test 
+     * @param array $config the configuration
+     * @return boolean true if available
+     */
+    private function isPresetAvailable(TestCategoryPreset $preset, $config = [])
+    {
+        if(!is_null($preset)) {
+            $flag = $preset->getFeatureFlag();
+            if(is_string($flag) && isset($config[$flag]) && $config[$flag] != true){
+                return true;
+            }
+        }
+        return false;
     }
 
     private function loadPresetFromProviders() {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1670,6 +1670,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('25.10.1');
         }
 
-        $this->skip('25.10.1', '26.0.0');
+        $this->skip('25.10.1', '26.1.0');
     }
 }

--- a/test/TestCategoryPresetProviderTest.php
+++ b/test/TestCategoryPresetProviderTest.php
@@ -242,9 +242,9 @@ class TestCategoryPresetProviderTest extends TaoPhpUnitTestRunner
 
 
     /**
-     * Providers data sets to test the getAvailablePresets method
-     * @return array the list of data sets 
-     */ 
+     * Provides data sets to test the "getAvailablePresets" method
+     * @return array the list of data sets
+     */
     public function presetsConfigDataProvider()
     {
         $preset1 = TestCategoryPreset::fromArray([
@@ -344,7 +344,7 @@ class TestCategoryPresetProviderTest extends TaoPhpUnitTestRunner
     }
 
     /**
-     * Test the method getAvailable presets
+     * Test the method "getAvailablePresets"
      *
      * @dataProvider presetsConfigDataProvider
      */

--- a/test/TestCategoryPresetProviderTest.php
+++ b/test/TestCategoryPresetProviderTest.php
@@ -350,8 +350,6 @@ class TestCategoryPresetProviderTest extends TaoPhpUnitTestRunner
      */
     public function testGetAvailablePresets($allPresets, $config, $result)
     {
-
-
         $plugin = $this->prophesize(PluginModule::class);
         $plugin->isActive()->willReturn(true);
 


### PR DESCRIPTION
 **Related to :** 
 - https://oat-sa.atlassian.net/browse/TAO-6573
 - https://oat-sa.atlassian.net/browse/TAO-6355 

### Feature 

The list of "Tools" in the test creator links to categories are generated by the service `\oat\taoQtiTest\models\TestCategoryPresetProvider`. I've added a new method `getAvailablePresets` (in order to keep backward compat) that let's you retrieve the list of category presets but, this time, based on a configuration.
This let's you define for each preset the linked feature flag. If a preset has the field `featureFlag => "enable-foo"`, the preset will be available only if the configuration contains the flag `"enable-foo" => true`.

So in order to achieve our goal, I've added the field  `'featureFlag' => 'enable-allow-skipping'` to the `Section skipping` preset, so if the configuration contains this flag and this flag is `false` we filter out the preset. 

I've added this mechanism since there are other presets that could be linked to the configuration.

### How to test

 - Run the unit test : `taoQtiTest/test/TestCategoryPresetProviderTest.php`
 - Change the value of `enable-allow-skipping` in `config/taoQtiTest/testRunner.conf.php`
 - Check within the _test creator_  :arrow_right:  _section  properties_ :arrow_right: _Test Navigation_ :  the `Section skipping` option should displayed based on the value of the config.