### PR TITLE
Fix/tao 6288 revert timer label change on install

### DIFF
--- a/config/default/TimerLabelFormatter.conf.php
+++ b/config/default/TimerLabelFormatter.conf.php
@@ -18,5 +18,5 @@
  */
 
 return new \oat\taoQtiTest\models\runner\time\TimerLabelFormatterService([
-   \oat\taoQtiTest\models\runner\time\TimerLabelFormatterService::OPTION_DEFAULT_TIMER_LABEL => 'timer_name_translation_token'
+   \oat\taoQtiTest\models\runner\time\TimerLabelFormatterService::OPTION_DEFAULT_TIMER_LABEL => ''
 ]);

--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '27.0.1',
+    'version'     => '27.0.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=16.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1682,6 +1682,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('26.1.2');
         }
 
-        $this->skip('26.1.2', '27.0.1');
+        $this->skip('26.1.2', '27.0.2');
     }
 }


### PR DESCRIPTION
@ionutpad reverted the change in the update script (https://github.com/oat-sa/extension-tao-testqti/pull/1346) but forgot to do it at install. 

Might be worth checking if this impact the customer that requested that functionnality, probably the defaut config with the timer label configuration needs to be copied to the NCSBN extension? Otherwise they will have a regression on re-install. 