### PR TITLE
Fix/tao 7192/fix timer time when unanswered

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '29.4.0',
+    'version'     => '29.4.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=18.0.0',

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -41,6 +41,8 @@ class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
     const TOOL_ITEM_THEME_SWITCHER = 'itemThemeSwitcher';
     const TOOL_ITEM_THEME_SWITCHER_KEY = 'taoQtiTest/runner/plugins/tools/itemThemeSwitcher/itemThemeSwitcher';
 
+    const TARGET_CLIENT = 'client';
+
     /**
      * The test runner config
      * @var array
@@ -103,7 +105,7 @@ class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
                     'target' => $target,
                     'resetAfterResume' => !empty($rawConfig['reset-timer-after-resume']),
                     'keepUpToTimeout' => !empty($rawConfig['keep-timer-up-to-timeout']),
-                    'restoreTimerFromClient' => $target === TimePoint::TARGET_CLIENT,
+                    'restoreTimerFromClient' => $target === self::TARGET_CLIENT,
                 ],
                 'enableAllowSkipping' => isset($rawConfig['enable-allow-skipping']) ? $rawConfig['enable-allow-skipping'] : false,
                 'enableValidateResponses' => isset($rawConfig['enable-validate-responses']) ? $rawConfig['enable-validate-responses'] : false,

--- a/models/classes/runner/time/QtiTimeConstraint.php
+++ b/models/classes/runner/time/QtiTimeConstraint.php
@@ -220,6 +220,24 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
                     ];
                 }
 
+                if (!is_null($this->getTimer())) {
+                    if (!isset($timer)) {
+                        $timer = $this->getTimer();
+                    }
+
+                    $lastTimestamp = $timer->getLastRegisteredTimestamp();
+                    $firstTimestamp = $timer->getFirstTimestamp([]);
+                    $diffInSeconds = $lastTimestamp - $firstTimestamp;
+
+                    if (!isset($maxTimeSeconds)) {
+                        $maxTimeSeconds = $this->durationToMs($maxTime);
+                    }
+
+                    $maxTimeRemaining = $maxTimeSeconds - $diffInSeconds;
+                } else {
+                    $maxTimeRemaining = $this->durationToMs($maxTimeRemaining);
+                }
+
                 /** @var TimerLabelFormatterService $labelFormatter */
                 $labelFormatter = ServiceManager::getServiceManager()->get(TimerLabelFormatterService::SERVICE_ID);
                 return [
@@ -231,7 +249,7 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
                     'minTime'             => $this->durationToMs($minTime),
                     'minTimeRemaining'    => $this->durationToMs($minTimeRemaining),
                     'maxTime'             => $this->durationToMs($maxTime),
-                    'maxTimeRemaining'    => $this->durationToMs($maxTimeRemaining),
+                    'maxTimeRemaining'    => $maxTimeRemaining,
                 ];
             }
         }

--- a/models/classes/runner/time/QtiTimer.php
+++ b/models/classes/runner/time/QtiTimer.php
@@ -209,7 +209,7 @@ class QtiTimer implements Timer, ExtraTime, \JsonSerializable
         $last = false;
 
         if ($length) {
-            $last = $points[$length - 1]->getTimestamp();
+            $last = end($points)->getTimestamp();
         }
         
         return $last;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1683,22 +1683,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('26.1.2');
         }
 
-        $this->skip('26.1.2', '29.4.0');
-
-        if ($this->isVersion('29.4.1')) {
-            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');
-            $config = $extension->getConfig('testRunner');
-
-            $currentTarget = $config['timer']['target'];
-
-            if ($currentTarget === 'client') {
-                $config['timer']['target'] = TimePoint::TARGET_CLIENT;
-            } else {
-                $config['timer']['target'] = TimePoint::TARGET_SERVER;
-            }
-            
-            $extension->setConfig('testRunner', $config);
-            $this->setVersion('29.4.1');
-        }
+        $this->skip('26.1.2', '29.4.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1682,6 +1682,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('26.1.2');
         }
 
-        $this->skip('26.1.2', '29.4.0');
+        $this->skip('26.1.2', '29.4.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -74,6 +74,7 @@ use oat\libCat\custom\EchoAdaptEngine;
 use oat\taoTests\models\runner\providers\ProviderRegistry;
 use oat\taoTests\models\runner\providers\TestProvider;
 use oat\taoQtiTest\models\compilation\CompilationService;
+use oat\taoTests\models\runner\time\TimePoint;
 
 /**
  *
@@ -1682,6 +1683,22 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('26.1.2');
         }
 
-        $this->skip('26.1.2', '29.4.1');
+        $this->skip('26.1.2', '29.4.0');
+
+        if ($this->isVersion('29.4.1')) {
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoQtiTest');
+            $config = $extension->getConfig('testRunner');
+
+            $currentTarget = $config['timer']['target'];
+
+            if ($currentTarget === 'client') {
+                $config['timer']['target'] = TimePoint::TARGET_CLIENT;
+            } else {
+                $config['timer']['target'] = TimePoint::TARGET_SERVER;
+            }
+            
+            $extension->setConfig('testRunner', $config);
+            $this->setVersion('29.4.1');
+        }
     }
 }


### PR DESCRIPTION
Fix for remaining time when an item was unanswered (page refresh or reported behaviour);

Steps to reproduce:
 - launch a test with time limit (optional: with security plugins);
 - spend a time on item without moving to next item;
 - refresh page (or loose a focus if launched with security plugins).

Without this fix:
timer time would be the same as on the start of this item.
With this fix:
timer time would be like it should be - time spent on item, without submitting, would also be taken into account.

=====================

Note: if the timer target is set to client it won't take into account timeRemainingValue from the backend