### PR TITLE
Fix/tao 7173 typo in option

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '29.4.1',
+    'version'     => '29.4.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=18.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1683,6 +1683,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('26.1.2');
         }
 
-        $this->skip('26.1.2', '29.4.1');
+        $this->skip('26.1.2', '29.4.2');
     }
 }

--- a/views/js/runner/plugins/tools/calculator.js
+++ b/views/js/runner/plugins/tools/calculator.js
@@ -106,7 +106,7 @@ define([
                 // - x-tao-option-calculator
                 // - x-tao-option-calculator-bodmas
                 // - x-tao-option-calculator-scientific
-                return !!options.calculator || !!options.calculatorBodma || !!options.calculatorScientific;
+                return !!options.calculator || !!options.calculatorBodmas || !!options.calculatorScientific;
             }
 
             /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-7173

Fix a trivial issue on the calculator plugin: with my PR to integrate the scientific version of the calculator, the option name for the BODMAS version has been truncated... :(

