### PR TITLE
Fix/tao 7173 calculator show error

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '29.4.2',
+    'version'     => '29.4.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=18.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1683,6 +1683,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('26.1.2');
         }
 
-        $this->skip('26.1.2', '29.4.2');
+        $this->skip('26.1.2', '29.4.3');
     }
 }

--- a/views/js/runner/plugins/tools/calculator.js
+++ b/views/js/runner/plugins/tools/calculator.js
@@ -152,7 +152,9 @@ define([
                 }).on('hide', function () {
                     self.trigger('close');
                     self.button.turnOff();
-                }).show();
+                }).after('render', function() {
+                    this.show();
+                });
             }
 
             /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-7173

Fix another issue inside the calculator plugin: the new version of the calculator uses defered init, so it cannot be shown immediately. The call to `show()` api have to be deferred too.