### PR TITLE
Possible fix for the problem with wrong timestamps for current timed …

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '29.7.1',
+    'version'     => '29.7.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=18.0.0',

--- a/models/classes/runner/time/QtiTimeConstraint.php
+++ b/models/classes/runner/time/QtiTimeConstraint.php
@@ -220,20 +220,20 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
                     ];
                 }
 
-                if (!is_null($this->getTimer())) {
-                    if (!isset($timer)) {
-                        $timer = $this->getTimer();
+                if (!is_null($this->getTimer()) && isset($timer)) {
+                    $lastTimestamp = $timer->getLastTimestamp([$identifier]);
+                    if ($lastTimestamp) {
+                        $firstTimestamp = $timer->getFirstTimestamp([$identifier]);
+                        $diffInSeconds = $lastTimestamp - $firstTimestamp;
+
+                        if (!isset($maxTimeSeconds)) {
+                            $maxTimeSeconds = $this->durationToMs($maxTime);
+                        }
+
+                        $maxTimeRemaining = $maxTimeSeconds - $diffInSeconds;
+                    } else {
+                        $maxTimeRemaining = $this->durationToMs($maxTimeRemaining);
                     }
-
-                    $lastTimestamp = $timer->getLastRegisteredTimestamp();
-                    $firstTimestamp = $timer->getFirstTimestamp([]);
-                    $diffInSeconds = $lastTimestamp - $firstTimestamp;
-
-                    if (!isset($maxTimeSeconds)) {
-                        $maxTimeSeconds = $this->durationToMs($maxTime);
-                    }
-
-                    $maxTimeRemaining = $maxTimeSeconds - $diffInSeconds;
                 } else {
                     $maxTimeRemaining = $this->durationToMs($maxTimeRemaining);
                 }

--- a/models/classes/runner/time/QtiTimeConstraint.php
+++ b/models/classes/runner/time/QtiTimeConstraint.php
@@ -220,24 +220,6 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
                     ];
                 }
 
-                if (!is_null($this->getTimer()) && isset($timer)) {
-                    $lastTimestamp = $timer->getLastTimestamp([$identifier]);
-                    if ($lastTimestamp) {
-                        $firstTimestamp = $timer->getFirstTimestamp([$identifier]);
-                        $diffInSeconds = $lastTimestamp - $firstTimestamp;
-
-                        if (!isset($maxTimeSeconds)) {
-                            $maxTimeSeconds = $this->durationToMs($maxTime);
-                        }
-
-                        $maxTimeRemaining = $maxTimeSeconds - $diffInSeconds;
-                    } else {
-                        $maxTimeRemaining = $this->durationToMs($maxTimeRemaining);
-                    }
-                } else {
-                    $maxTimeRemaining = $this->durationToMs($maxTimeRemaining);
-                }
-
                 /** @var TimerLabelFormatterService $labelFormatter */
                 $labelFormatter = ServiceManager::getServiceManager()->get(TimerLabelFormatterService::SERVICE_ID);
                 return [
@@ -249,7 +231,7 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
                     'minTime'             => $this->durationToMs($minTime),
                     'minTimeRemaining'    => $this->durationToMs($minTimeRemaining),
                     'maxTime'             => $this->durationToMs($maxTime),
-                    'maxTimeRemaining'    => $maxTimeRemaining,
+                    'maxTimeRemaining'    => $this->durationToMs($maxTimeRemaining),
                 ];
             }
         }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1694,6 +1694,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('29.7.0');
         }
 
-        $this->skip('29.7.0', '29.7.1');
+        $this->skip('29.7.0', '29.7.2');
     }
 }


### PR DESCRIPTION
~~Now the `firstTimestamp` and `lastTimestamp` values should be more accurate as they are taken from the timeline by the identifier of current `source`

**Not to be merged yet! Just a possible solution to share**~~

Can be merged.

Code removal was needed - it was unneeded in case of `client` timer as the timer values come from browser, and also unneeded in case of `server` timer - values are re-calculated in another place