### PR TITLE
Fix/tao 7714 informational item nowarning

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '30.5.3',
+    'version'     => '30.5.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=18.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1736,7 +1736,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('30.5.0');
         }
         
-       $this->skip('30.5.0', '30.5.3');
+       $this->skip('30.5.0', '30.5.4');
 
     }
 }

--- a/views/js/runner/plugins/navigation/next/linearNextItemWarning.js
+++ b/views/js/runner/plugins/navigation/next/linearNextItemWarning.js
@@ -140,6 +140,9 @@ define([
                 })
                 .before('move skip', function(e, type, scope) {
                     var context = testRunner.getTestContext();
+                    var map = testRunner.getTestMap();
+                    var item = mapHelper.getItemAt(map, context.itemPosition);
+
                     if (context.isLinear) {
                         // Do nothing if nextSection warning imminent:
                         if (scope === 'section' && context.options.nextSectionWarning) {
@@ -147,6 +150,10 @@ define([
                         }
                         // Do nothing if endOfPart warning imminent:
                         else if (context.options.nextPartWarning) {
+                            return;
+                        }
+                        // Do nothing if 'informational item':
+                        else if (item.informational) {
                             return;
                         }
                         // Show dialog if conditions met:

--- a/views/js/runner/plugins/navigation/next/linearNextItemWarning.js
+++ b/views/js/runner/plugins/navigation/next/linearNextItemWarning.js
@@ -26,9 +26,10 @@ define([
     'lodash',
     'i18n',
     'taoTests/runner/plugin',
+    'taoQtiTest/runner/helpers/map',
     'taoQtiTest/runner/helpers/currentItem',
     'taoQtiTest/runner/plugins/navigation/next/dialogConfirmNext'
-], function ($, _, __, pluginFactory, currentItemHelper, dialogConfirmNext){
+], function ($, _, __, pluginFactory, mapHelper, currentItemHelper, dialogConfirmNext){
     'use strict';
 
     /**

--- a/views/js/test/runner/plugins/navigation/next/linearNextItemWarning/test.html
+++ b/views/js/test/runner/plugins/navigation/next/linearNextItemWarning/test.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>LinearNextItemWarning - Test Runner Plugin test</title>
+    <base href="../../../../../../../../../tao/views/" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/runner/plugins/navigation/next/linearNextItemWarning.js"></script>
+    <script  type="text/javascript">
+        QUnit.config.autostart = false;
+        require(['/tao/ClientConfig/config'], function(){
+            require(['taoQtiTest/test/runner/plugins/navigation/next/linearNextItemWarning/test'], function(){
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/runner/plugins/navigation/next/linearNextItemWarning/test.js
+++ b/views/js/test/runner/plugins/navigation/next/linearNextItemWarning/test.js
@@ -29,12 +29,6 @@ define([
     var providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
-    // mock the item we will get (informational or not)
-    mapHelper.getItemAt = function(map, isInfo) {
-        return {
-            informational: isInfo
-        };
-    };
 
     /**
      * The following tests applies to all plugins
@@ -111,64 +105,79 @@ define([
      */
     QUnit.module('Behavior');
 
+    // No dialog expected
     QUnit.cases([
         {
             title: 'when the next part warning is set',
-            context: {
+            testContext: {
                 enableAllowSkipping: false,
                 allowSkipping: false,
                 options: {
                     nextPartWarning: true,
                     nextSectionWarning: false
                 }
+            },
+            item: {
+                informational: false
             }
         },
         {
             title: 'when the next section warning is set',
-            context: {
+            testContext: {
                 isLinear: true,
                 options: {
                     nextPartWarning: false,
                     nextSectionWarning: true
                 }
             },
-            scope: 'section'
+            scope: 'section',
+            item: {
+                informational: false
+            }
         },
         {
             title: 'when the item is informational',
-            context: {
+            testContext: {
                 isLinear: true,
                 options: {
                     nextPartWarning: false,
                     nextSectionWarning: false
-                },
-                position: true
+                }
+            },
+            item: {
+                informational: true
             }
         },
         {
             title: 'when the item is the last item',
-            context: {
+            testContext: {
                 isLinear: true,
                 options: {
                     nextPartWarning: false,
                     nextSectionWarning: false
                 },
                 isLast: true
+            },
+            item: {
+                informational: false
             }
         },
         {
             title: 'when the config setting is undefined',
-            context: {
+            testContext: {
                 options: {
                     nextPartWarning: false,
                     nextSectionWarning: false
                 },
                 isLinear: true
+            },
+            item: {
+                informational: false
             }
         },
         {
             title: 'when the config setting is explicitly false',
-            context: {
+            testContext: {
                 options: {
                     nextPartWarning: false,
                     nextSectionWarning: false
@@ -177,16 +186,22 @@ define([
             },
             testConfig: {
                 forceEnableLinearNextItemWarning: false
+            },
+            item: {
+                informational: false
             }
         },
         {
             title: 'when the test is not linear',
-            context: {
+            testContext: {
                 options: {
                     nextPartWarning: false,
                     nextSectionWarning: false
                 },
                 isLinear: false
+            },
+            item: {
+                informational: false
             }
         }
     ])
@@ -206,14 +221,17 @@ define([
                 config: caseData.testConfig
             };
         };
-
+        // mock the item we will get (informational or not)
+        mapHelper.getItemAt = function() {
+            return caseData.item;
+        };
 
         QUnit.expect(1);
 
         plugin
             .init()
             .then(function() {
-                runner.setTestContext(caseData.context);
+                runner.setTestContext(caseData.testContext);
 
                 // dialog would be instantiated *before* move occurs
                 runner.on('move', function() {
@@ -230,11 +248,12 @@ define([
             });
     });
 
+    // Dialog expected
     QUnit.cases([
         {
             title: 'when a next warning is needed',
             event: 'next',
-            context: {
+            testContext: {
                 isLinear: true,
                 options: {
                     nextPartWarning: false,
@@ -244,12 +263,15 @@ define([
             },
             testConfig: {
                 forceEnableLinearNextItemWarning: true
+            },
+            item: {
+                informational: false
             }
         },
         {
             title: 'when a skip warning is needed',
             event: 'skip',
-            context: {
+            testContext: {
                 isLinear: true,
                 options: {
                     nextPartWarning: false,
@@ -259,6 +281,9 @@ define([
             },
             testConfig: {
                 forceEnableLinearNextItemWarning: true
+            },
+            item: {
+                informational: false
             }
         }
     ])
@@ -287,7 +312,7 @@ define([
         plugin
             .init()
             .then(function() {
-                runner.setTestContext(caseData.context);
+                runner.setTestContext(caseData.testContext);
 
                 runner.on('disablenav', function() {
                     assert.ok(true, 'The dialog interrupted the move');

--- a/views/js/test/runner/plugins/navigation/next/linearNextItemWarning/test.js
+++ b/views/js/test/runner/plugins/navigation/next/linearNextItemWarning/test.js
@@ -1,0 +1,305 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+define([
+    'core/promise',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/runner/plugins/navigation/next/linearNextItemWarning',
+    'taoQtiTest/runner/helpers/map'
+], function(Promise, runnerFactory, providerMock, pluginFactory, mapHelper) {
+    'use strict';
+
+    var pluginApi;
+    var providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    // mock the item we will get (informational or not)
+    mapHelper.getItemAt = function(map, isInfo) {
+        return {
+            informational: isInfo
+        };
+    };
+
+    /**
+     * The following tests applies to all plugins
+     */
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', 3, function(assert) {
+        var runner = runnerFactory(providerName);
+
+        assert.equal(typeof pluginFactory, 'function', "The pluginFactory module exposes a function");
+        assert.equal(typeof pluginFactory(runner), 'object', "The plugin factory produces an instance");
+        assert.notStrictEqual(pluginFactory(runner), pluginFactory(runner), "The plugin factory provides a different instance on each call");
+    });
+
+
+    pluginApi = [{
+        name: 'init',
+        title: 'init'
+    }, {
+        name: 'render',
+        title: 'render'
+    }, {
+        name: 'finish',
+        title: 'finish'
+    }, {
+        name: 'destroy',
+        title: 'destroy'
+    }, {
+        name: 'trigger',
+        title: 'trigger'
+    }, {
+        name: 'getTestRunner',
+        title: 'getTestRunner'
+    }, {
+        name: 'getAreaBroker',
+        title: 'getAreaBroker'
+    }, {
+        name: 'getConfig',
+        title: 'getConfig'
+    }, {
+        name: 'setConfig',
+        title: 'setConfig'
+    }, {
+        name: 'getState',
+        title: 'getState'
+    }, {
+        name: 'setState',
+        title: 'setState'
+    }, {
+        name: 'show',
+        title: 'show'
+    }, {
+        name: 'hide',
+        title: 'hide'
+    }, {
+        name: 'enable',
+        title: 'enable'
+    }, {
+        name: 'disable',
+        title: 'disable'
+    }];
+
+    QUnit
+        .cases(pluginApi)
+        .test('plugin API ', 1, function(data, assert) {
+            var runner = runnerFactory(providerName);
+            var timer = pluginFactory(runner);
+            assert.equal(typeof timer[data.name], 'function', 'The pluginFactory instances expose a "' + data.name + '" function');
+        });
+
+
+    /**
+     * Specific tests for this plugin
+     */
+    QUnit.module('Behavior');
+
+    QUnit.cases([
+        {
+            title: 'when the next part warning is set',
+            context: {
+                enableAllowSkipping: false,
+                allowSkipping: false,
+                options: {
+                    nextPartWarning: true,
+                    nextSectionWarning: false
+                }
+            }
+        },
+        {
+            title: 'when the next section warning is set',
+            context: {
+                isLinear: true,
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: true
+                }
+            },
+            scope: 'section'
+        },
+        {
+            title: 'when the item is informational',
+            context: {
+                isLinear: true,
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: false
+                },
+                position: true
+            }
+        },
+        {
+            title: 'when the item is the last item',
+            context: {
+                isLinear: true,
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: false
+                },
+                isLast: true
+            }
+        },
+        {
+            title: 'when the config setting is undefined',
+            context: {
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: false
+                },
+                isLinear: true
+            }
+        },
+        {
+            title: 'when the config setting is explicitly false',
+            context: {
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: false
+                },
+                isLinear: true
+            },
+            testConfig: {
+                forceEnableLinearNextItemWarning: false
+            }
+        },
+        {
+            title: 'when the test is not linear',
+            context: {
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: false
+                },
+                isLinear: false
+            }
+        }
+    ])
+    .asyncTest('No dialog is triggered ', function(caseData, assert) {
+        var runner = runnerFactory(providerName);
+        var plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        // mock test store init
+        runner.getTestStore = function() {
+            return {
+                setVolatile: function() {}
+            };
+        };
+        // mock config
+        runner.getTestData = function() {
+            return {
+                config: caseData.testConfig
+            };
+        };
+
+
+        QUnit.expect(1);
+
+        plugin
+            .init()
+            .then(function() {
+                runner.setTestContext(caseData.context);
+
+                // dialog would be instantiated *before* move occurs
+                runner.on('move', function() {
+                    assert.ok(true, 'The move took place without interruption');
+                    runner.destroy();
+                    QUnit.start();
+                    return Promise.reject();
+                });
+                runner.trigger('move', 'next', caseData.scope);
+            })
+            .catch(function(err) {
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.cases([
+        {
+            title: 'when a next warning is needed',
+            event: 'next',
+            context: {
+                isLinear: true,
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: false
+                },
+                isLast: false
+            },
+            testConfig: {
+                forceEnableLinearNextItemWarning: true
+            }
+        },
+        {
+            title: 'when a skip warning is needed',
+            event: 'skip',
+            context: {
+                isLinear: true,
+                options: {
+                    nextPartWarning: false,
+                    nextSectionWarning: false
+                },
+                isLast: false
+            },
+            testConfig: {
+                forceEnableLinearNextItemWarning: true
+            }
+        }
+    ])
+    .asyncTest('Dialog will be triggered ', function(caseData, assert) {
+        var runner = runnerFactory(providerName);
+        var plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        // mock test store init
+        runner.getTestStore = function() {
+            return {
+                getStore: function() {
+                    return Promise.reject();
+                },
+                setVolatile: function() {}
+            };
+        };
+        // mock config
+        runner.getTestData = function() {
+            return {
+                config: caseData.testConfig
+            };
+        };
+
+        QUnit.expect(1);
+
+        plugin
+            .init()
+            .then(function() {
+                runner.setTestContext(caseData.context);
+
+                runner.on('disablenav', function() {
+                    assert.ok(true, 'The dialog interrupted the move');
+                    runner.destroy();
+                    QUnit.start();
+                });
+                runner.trigger('move', caseData.event);
+
+            })
+            .catch(function(err) {
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+});


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7714

Added an if-statement to bypass the linearNextItemWarning dialog if the item is informational.
This works with the 'Informational Item Usage' choice in Test authoring. The Test Part must be in linear mode.

As a reminder, this TR plugin is inactive by default (activated only for Infosign), so you may need to activate it in `config/taoTests/test_runner_plugin_registry.conf.php` and set the `force-enable-linear-next-item-warning` setting in `config/taoQtiTest/testRunner.conf.php`