### PR TITLE
Fix/end test timer fatal error

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.0.0',
+    'version'     => '32.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=18.0.0',

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -224,6 +224,8 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
      *
      * @param float $duration The client duration, or null to force server duration to be used as client duration
      * @param $timestamp
+     * @throws \oat\taoTests\models\runner\time\InvalidStorageException
+     * @throws \oat\taoTests\models\runner\time\TimeException
      */
     public function endItemTimer($duration = null, $timestamp = null)
     {
@@ -231,7 +233,13 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
             $timestamp = microtime(true);
         }
         $timer = $this->getTimer();
-        $tags = $this->getItemTags($this->getCurrentRouteItem());
+        $currentItem = $this->getCurrentRouteItem();
+
+        if ($currentItem) {
+            $tags = $this->getItemTags($currentItem);
+        } else {
+            $tags = [];
+        }
 
         $timer->end($tags, $timestamp);
 
@@ -424,7 +432,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     {
         return $this->buildTimeConstraints($places, true);
     }
-    
+
     /**
      * Get the regular time constraints running for the current testPart or/and current assessmentSection
      * or/and assessmentItem, without taking care of the extra time.
@@ -474,7 +482,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     public function submitItemResults(AssessmentItemSession $itemSession, $occurrence = 0)
     {
         $itemRef = $itemSession->getAssessmentItem();
-        
+
         // Ensure that specific results from adaptive placeholders are not recorded.
         $catService = ServiceManager::getServiceManager()->get(CatService::SERVICE_ID);
         if (!$catService->isAdaptivePlaceholder($itemRef)) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1759,6 +1759,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('30.7.0');
         }
 
-        $this->skip('30.7.0', '32.0.0');
+        $this->skip('30.7.0', '32.0.1');
     }
 }


### PR DESCRIPTION
I found a lot of such messages in the act log:
```
{
    "level": "proxy_fcgi:error",
    "pid": "3173:tid 140165695653632",
    "client": "10.0.10.15:4996",
    "message": "AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to oat\\\\taoQtiTest\\\\models\\\\runner\\\\session\\\\TestSession::getItemTags() must be an instance of qtism\\\\runtime\\\\tests\\\\RouteItem, boolean given, called in /var/www/html/tao/taoQtiTest/models/classes/runner/session/TestSession.php on line 234 and defined in /var/www/html/tao/taoQtiTest/models/classes/runner/session/TestSession.php:149\\nStack trace:\\n#0 /var/www/html/tao/taoQtiTest/models/classes/runner/session/TestSession.php(234): oat\\\\taoQtiTest\\\\models\\\\runner\\\\session\\\\TestSession->getItemTags(false)\\n#1 /var/www/html/tao/taoQtiTest/models/classes/runner/QtiRunnerService.php(1802): oat\\\\taoQtiTest\\\\models\\\\runner\\\\session\\\\TestSession->endItemTimer(1727.298, 1552351531.135)\\n#2 /var/www/html/tao/taoQtiTest/models/classes/runner/RunnerParamParserTrait.php(120): oat\\\\taoQtiTest\\\\models\\\\runner\\\\QtiRunnerService->endTimer(Object(oat\\\\taoQtiTest\\\\models\\\\runner\\\\QtiRunnerServiceContext), 1727.298, 1552351531.135)\\n#3 /var/www/html/tao/taoQtiTest/models/classes/runner/sy...\\n'",
    "instance_id": "i-0e3c1a56db2c3e069",
    "stack": "usact02dee",
    "host_type": "taocloud/ws/delivery"
}
```