### PR TITLE
TAO-7629 broken qtitest

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.3.0',
+    'version'     => '32.3.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=18.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1777,6 +1777,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.1.0');
         }
 
-        $this->skip('32.1.0', '32.3.0');
+        $this->skip('32.1.0', '32.3.1');
     }
 }

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -74,7 +74,7 @@ function($, _, __, hider, feedback, actions, testPartView, templates, qtiTestHel
             var $cutScoreLine = $('.test-cut-score', $view);
             var $weightIdentifierLine = $('.test-weight-identifier', $view);
             var $descriptions = $('.test-outcome-processing-description', $view);
-            var $generate = $('[data-action='generate-outcomes']', $view);
+            var $generate = $('[data-action="generate-outcomes"]', $view);
             var $title = $('.test-creator-test > h1 [data-bind=title]');
             var scoringState = JSON.stringify(testModel.scoring);
 
@@ -86,7 +86,7 @@ function($, _, __, hider, feedback, actions, testPartView, templates, qtiTestHel
                 hider.toggle($categoryScoreLine, noOptions);
                 hider.toggle($weightIdentifierLine, noOptions);
                 hider.hide($descriptions);
-                hider.show($descriptions.filter('[data-key='' + scoring.outcomeProcessing + '']'));
+                hider.show($descriptions.filter('[data-key="' + scoring.outcomeProcessing + '"]'));
 
                 if (scoringState !== newScoringState) {
                     /**


### PR DESCRIPTION
*related task* 
https://oat-sa.atlassian.net/browse/TAO-7629

*problem description*

When converting Unit tests to new version, wrong file was converted `views/js/controller/creator/views/test.js`, because of its actual  filename `test.js` which is not unit test source.