### PR TITLE
Fix/tao 7617/highlighter xinclude data

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.8.1',
+    'version'     => '32.8.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1787,6 +1787,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.8.0');
         }
 
-        $this->skip('32.8.0', '32.8.1');
+        $this->skip('32.8.0', '32.8.2');
     }
 }

--- a/views/js/runner/helpers/currentItem.js
+++ b/views/js/runner/helpers/currentItem.js
@@ -245,7 +245,7 @@ define([
             return _(interactions)
                 .values()
                 .filter(function(element) {
-                    return element.serial.indexOf('xinclude') === 0;
+                    return element.qtiClass === 'include';
                 })
                 .pluck('attributes')
                 .pluck('href')

--- a/views/js/test/runner/helpers/currentItem/test.js
+++ b/views/js/test/runner/helpers/currentItem/test.js
@@ -229,16 +229,16 @@ define([
             itemBdy: {
                 elements: {
                     first : {
-                        serial: 'xinclude_12345',
                         attributes: {
                             href: 'http://path/to/something.xml'
-                        }
+                        },
+                        qtiClass: 'include'
                     },
                     second : {
-                        serial: 'anotherelement',
                         attributes: {
                             href: 'http://path/to/something/else.xml'
-                        }
+                        },
+                        qtiClass: 'choiceInteraction'
                     }
                 }
             },


### PR DESCRIPTION
Additional post-release fix for https://oat-sa.atlassian.net/browse/TAO-7617

Due to differences in item compilation between dev and prod modes, the method of extracting `xinclude`s from the item data was failing on Spielplatz. This fix changes it to select them by their `qtiClass`, which does not vary. 