### PR TITLE
fix/TAO-7845/browser-zoom-behavior-for-touchscreen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.8.2',
+    'version'     => '32.8.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1787,6 +1787,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.8.0');
         }
 
-        $this->skip('32.8.0', '32.8.2');
+        $this->skip('32.8.0', '32.8.3');
     }
 }

--- a/views/js/runner/plugins/templates/button.tpl
+++ b/views/js/runner/plugins/templates/button.tpl
@@ -1,5 +1,5 @@
 <li data-control="{{control}}" class="small btn-info action{{#if className}} {{className}}{{/if}}" title="{{title}}">
-    <a class="li-inner" onclick="return false">
+    <a class="li-inner" href="#" onclick="return false">
         {{#if icon}}<span class="icon icon-{{icon}}{{#unless text}} no-label{{/unless}}"></span>{{/if}}
         {{#if text}}<span class="text">{{text}}</span>{{/if}}
     </a>

--- a/views/js/runner/plugins/templates/button.tpl
+++ b/views/js/runner/plugins/templates/button.tpl
@@ -1,5 +1,5 @@
 <li data-control="{{control}}" class="small btn-info action{{#if className}} {{className}}{{/if}}" title="{{title}}">
-    <a class="li-inner" href="#">
+    <a class="li-inner" onclick="return false">
         {{#if icon}}<span class="icon icon-{{icon}}{{#unless text}} no-label{{/unless}}"></span>{{/if}}
         {{#if text}}<span class="text">{{text}}</span>{{/if}}
     </a>


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7845

**This is a fix for the highlight button.**

**Steps to reproduce:** 
Zoom to highest resolution > turn on/off the highlighter > control always goes to the top of the screen.

How to test on touch devices: 

- open https://act-test.taocloud.org
- find delivery http://localhost/tao.rdf#i1503426381071581600217278 (_just type this in the search box in the delivery_) or anyone else with button _highlighter_.
- open delivery via lti (http://ltiapps.net/test/tc.php)
- Zoom to highest resolution > turn on/off the highlighter > control always goes to the top of the screen.

This is because href = "#" leads to the beginning of the document.
for this, it is necessary to prohibit clicking on the link for the button.