### PR TITLE
[TAO-7935] WK-1281 PG - TCiaB - highlighter behavior for touchscreen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.8.3',
+    'version'     => '32.9.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1787,6 +1787,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.8.0');
         }
 
-        $this->skip('32.8.0', '32.8.3');
+        $this->skip('32.8.0', '32.9.0');
     }
 }

--- a/views/js/runner/plugins/tools/highlighter/highlighter.js
+++ b/views/js/runner/plugins/tools/highlighter/highlighter.js
@@ -33,6 +33,7 @@ define([
     highlighterFactory
 ) {
     'use strict';
+    var prevSelection;
     var selection;
 
     if (!window.getSelection) throw new Error('Browser does not support getSelection()');
@@ -119,8 +120,6 @@ define([
         // so we store prev selection for this devices to be able
         // to use it after click on highlight button
         if (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream) {
-            var prevSelection;
-
             $(document).on('selectionchange', function() {
                 if (!isHighlighting) {
                     prevSelection = _.clone(getAllRanges(), true);

--- a/views/js/runner/plugins/tools/highlighter/highlighter.js
+++ b/views/js/runner/plugins/tools/highlighter/highlighter.js
@@ -95,15 +95,23 @@ define([
         var highlightHelper = highlighterFactory({
             className: options.className || 'txt-user-highlight',
             containerSelector: options.containerSelector || '.qti-itemBody',
-            containersBlackList: options.containersBlackList || []
+            containersBlackList: options.containersBlackList || [],
+            clearOnClick: true,
+        });
+
+        //add event to automatically highlight the recently made selection if needed
+        $(document).on('mouseup.highlighter', function() {
+            if (isHighlighting && !selection.isCollapsed) {
+                highlightHelper.highlightRanges(getAllRanges());
+                discardSelection();
+            }
         });
 
         //add event to automatically highlight the recently made selection if needed
         //added touch event (as from TAO-6578)
-        $(document).on('mouseup.highlighter touchend.highlighter', function() {
+        $(document).on('touchend.highlighter', function() {
             if (isHighlighting && !selection.isCollapsed) {
                 highlightHelper.highlightRanges(getAllRanges());
-                discardSelection();
             }
         });
 
@@ -142,8 +150,10 @@ define([
                 isHighlighting = bool;
                 if (isHighlighting) {
                     this.trigger('start');
+                    $(".qti-itemBody").toggleClass('highlighter-cursor', true);
                 } else {
                     this.trigger('end');
+                    $(".qti-itemBody").toggleClass('highlighter-cursor', false);
                 }
                 return this;
             },

--- a/views/js/runner/plugins/tools/highlighter/highlighter.js
+++ b/views/js/runner/plugins/tools/highlighter/highlighter.js
@@ -115,6 +115,19 @@ define([
             }
         });
 
+        // iOS devices clears selection after click on button,
+        // so we store prev selection for this devices to be able
+        // to use it after click on highlight button
+        if (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream) {
+            var prevSelection;
+
+            $(document).on('selectionchange', function() {
+                if (!isHighlighting) {
+                    prevSelection = _.clone(getAllRanges(), true);
+                }
+            });
+        }
+
         /**
          * The highlighter instance
          */
@@ -166,6 +179,11 @@ define([
                     if (!selection.isCollapsed) {
                         this.toggleHighlighting(true);
                         highlightHelper.highlightRanges(getAllRanges());
+                        this.toggleHighlighting(false);
+                        discardSelection();
+                    } else if (prevSelection[0] && !prevSelection[0].collapsed){
+                        this.toggleHighlighting(true);
+                        highlightHelper.highlightRanges(prevSelection);
                         this.toggleHighlighting(false);
                         discardSelection();
                     } else {


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-7935
 
Do not discard selection on touchend during highlighting
Allow do clear highlighted node by clicking on it
Change cursor when  highlighting is activated
  
#### How to test
- Run delivery as a test taker on touchscreen device with enabled highlighting tool
- Activate highlighting tool and start selecting the text
- After triggering selection you should be allowed to resize it

- Run delivery as a test taker with enabled highlighting tool
- Highlight some text 
- After click on highlighted text it should be cleared

- Run delivery as a test taker on desktop browser with enabled highlighting tool
- After activating highlighting tool cursor above test item should be changed to marker icon

#### Dependencies
   
Requires :
 - [ ] https://github.com/oat-sa/tao-core/pull/2069
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1264