### PR TITLE
[TAO-7935] WK-1281 PG - TCiaB - highlighter behavior for touchscreen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.9.0',
+    'version'     => '32.9.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1787,6 +1787,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.8.0');
         }
 
-        $this->skip('32.8.0', '32.9.0');
+        $this->skip('32.8.0', '32.9.1');
     }
 }

--- a/views/js/runner/plugins/tools/highlighter/highlighter.js
+++ b/views/js/runner/plugins/tools/highlighter/highlighter.js
@@ -33,7 +33,7 @@ define([
     highlighterFactory
 ) {
     'use strict';
-    var prevSelection;
+    var prevSelection = [];
     var selection;
 
     if (!window.getSelection) throw new Error('Browser does not support getSelection()');


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-7935
 
Do not discard selection on touchend during highlighting
Allow do clear highlighted node by clicking on it
Change cursor when  highlighting is activated
  
#### How to test
- Run delivery as a test taker on touchscreen device with enabled highlighting tool
- Activate highlighting tool and start selecting the text
- After triggering selection you should be allowed to resize it

- Run delivery as a test taker with enabled highlighting tool
- Highlight some text 
- After click on highlighted text it should be cleared

- Run delivery as a test taker on desktop browser with enabled highlighting tool
- After activating highlighting tool cursor above test item should be changed to marker icon

#### Dependencies
   
Requires :
 - [ ] https://github.com/oat-sa/tao-core/pull/2069
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1264