### PR TITLE
Fix/tao 7635/offline proxy component

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.10.0',
+    'version'     => '32.10.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1787,6 +1787,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.8.0');
         }
 
-        $this->skip('32.8.0', '32.10.0');
+        $this->skip('32.8.0', '32.10.1');
     }
 }

--- a/views/js/test/runner/branchRule/types/match/test.js
+++ b/views/js/test/runner/branchRule/types/match/test.js
@@ -20,18 +20,12 @@
  */
 define([
     'taoQtiTest/runner/branchRule/types/match',
-    'taoQtiTest/runner/proxy/offline/responseStore'
+    'taoQtiTest/runner/services/responseStore'
 ], function(
     matchBranchRuleFactory,
-    responseStore
+    responseStoreFactory
 ) {
     'use strict';
-
-    responseStore.addResponse('R1', 'test');
-    responseStore.addCorrectResponse('R1', ['test', 'foo', 'bar']);
-
-    responseStore.addResponse('R2', 'foo');
-    responseStore.addCorrectResponse('R2', ['a', 'b', 'c']);
 
     QUnit.test('it returns true if the matching is correct', function(assert) {
         var done = assert.async();
@@ -39,6 +33,13 @@ define([
             'variable': { '@attributes': { 'identifier': 'R1' } },
             'correct':  { '@attributes': { 'identifier': 'R1' } }
         };
+
+        var responseStore = responseStoreFactory();
+        responseStore.addResponse('R1', 'test');
+        responseStore.addCorrectResponse('R1', ['test', 'foo', 'bar']);
+
+        responseStore.addResponse('R2', 'foo');
+        responseStore.addCorrectResponse('R2', ['a', 'b', 'c']);
 
         matchBranchRuleFactory(branchRuleDefinition, null, null, null, responseStore)
             .validate()
@@ -57,6 +58,13 @@ define([
             'correct':  { '@attributes': { 'identifier': 'R1' } }
         };
 
+        var responseStore = responseStoreFactory();
+        responseStore.addResponse('R1', 'test');
+        responseStore.addCorrectResponse('R1', ['test', 'foo', 'bar']);
+
+        responseStore.addResponse('R2', 'foo');
+        responseStore.addCorrectResponse('R2', ['a', 'b', 'c']);
+
         matchBranchRuleFactory(branchRuleDefinition, null, null, null, responseStore)
             .validate()
             .then(function(result) {
@@ -74,6 +82,13 @@ define([
             'correct':  { '@attributes': { 'identifier': 'test' } }
         };
 
+        var responseStore = responseStoreFactory();
+        responseStore.addResponse('R1', 'test');
+        responseStore.addCorrectResponse('R1', ['test', 'foo', 'bar']);
+
+        responseStore.addResponse('R2', 'foo');
+        responseStore.addCorrectResponse('R2', ['a', 'b', 'c']);
+
         matchBranchRuleFactory(branchRuleDefinition, null, null, null, responseStore)
             .validate()
             .then(function(result) {
@@ -89,6 +104,13 @@ define([
             'variable': { '@attributes': { 'identifier': 'R2' } },
             'correct':  { '@attributes': { 'identifier': 'R2' } }
         };
+
+        var responseStore = responseStoreFactory();
+        responseStore.addResponse('R1', 'test');
+        responseStore.addCorrectResponse('R1', ['test', 'foo', 'bar']);
+
+        responseStore.addResponse('R2', 'foo');
+        responseStore.addCorrectResponse('R2', ['a', 'b', 'c']);
 
         matchBranchRuleFactory(branchRuleDefinition, null, null, null, responseStore)
             .validate()
@@ -106,6 +128,13 @@ define([
             'variable': { '@attributes': { 'identifier': 'R1' } },
             'correct':  { '@attributes': { 'identifier': 'R2' } }
         };
+
+        var responseStore = responseStoreFactory();
+        responseStore.addResponse('R1', 'test');
+        responseStore.addCorrectResponse('R1', ['test', 'foo', 'bar']);
+
+        responseStore.addResponse('R2', 'foo');
+        responseStore.addCorrectResponse('R2', ['a', 'b', 'c']);
 
         matchBranchRuleFactory(branchRuleDefinition, null, null, null, responseStore)
             .validate()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-7635

Fixing a broken unit test due to a last change in PR #1454.
The module `responseStore` was refactored, but the original version stayed till the end of the review, so the unit test were still working fine. As the obsolete version was removed, the test was failing then :(. I did not notice the unit test was using the obsolete version.