### PR TITLE
Fix/si 328/metadata export not working with taskqueue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.11.0',
+    'version'     => '32.11.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/models/classes/export/metadata/TestExporter.php
+++ b/models/classes/export/metadata/TestExporter.php
@@ -60,13 +60,6 @@ class TestExporter extends ConfigurableService implements TestMetadataExporter
     protected $assessmentUri;
 
     /**
-     * Item data extracted from assessment
-     *
-     * @var array
-     */
-    protected $assessmentItemData = [];
-
-    /**
      * @param string $uri
      * @return string
      * @throws \common_exception_Error
@@ -101,33 +94,33 @@ class TestExporter extends ConfigurableService implements TestMetadataExporter
      */
     protected function getAssessmentData()
     {
-        if (empty($this->assessmentItemData)) {
-            $xml = \taoQtiTest_models_classes_QtiTestService::singleton()->getDoc($this->getResource($this->assessmentUri));
-            $testPartCollection = $xml->getDocumentComponent()->getComponentsByClassName(self::TEST_PART);
+        $xml = \taoQtiTest_models_classes_QtiTestService::singleton()->getDoc($this->getResource($this->assessmentUri));
+        $testPartCollection = $xml->getDocumentComponent()->getComponentsByClassName(self::TEST_PART);
 
-            /** @var TestPart $testPart */
-            foreach ($testPartCollection as $testPart) {
-                $sectionCollection = $testPart->getAssessmentSections();
-                /** @var AssessmentSection $section */
-                foreach ($sectionCollection as $section) {
-                    $itemCollection = $section->getComponentsByClassName(self::TEST_ITEM);
-                    $order = 1;
-                    /** @var AssessmentItemRef $item */
-                    foreach ($itemCollection as $item) {
-                        $this->assessmentItemData[$item->getIdentifier()] = [
-                            self::ITEM_URI     => $item->getHref(),
-                            self::TEST_PART    => $testPart->getIdentifier(),
-                            self::TEST_SECTION => $section->getIdentifier(),
-                            self::ITEM_SHUFFLE => is_null($section->getOrdering()) ? 0 : (int)$section->getOrdering()->getShuffle(),
-                            self::ITEM_ORDER   => $order,
-                        ];
-                        $order++;
-                    }
+        $assessmentItemData = [];
+
+        /** @var TestPart $testPart */
+        foreach ($testPartCollection as $testPart) {
+            $sectionCollection = $testPart->getAssessmentSections();
+            /** @var AssessmentSection $section */
+            foreach ($sectionCollection as $section) {
+                $itemCollection = $section->getComponentsByClassName(self::TEST_ITEM);
+                $order = 1;
+                /** @var AssessmentItemRef $item */
+                foreach ($itemCollection as $item) {
+                    $assessmentItemData[$item->getIdentifier()] = [
+                        self::ITEM_URI     => $item->getHref(),
+                        self::TEST_PART    => $testPart->getIdentifier(),
+                        self::TEST_SECTION => $section->getIdentifier(),
+                        self::ITEM_SHUFFLE => is_null($section->getOrdering()) ? 0 : (int)$section->getOrdering()->getShuffle(),
+                        self::ITEM_ORDER   => $order,
+                    ];
+                    $order++;
                 }
             }
         }
 
-        return $this->assessmentItemData;
+        return $assessmentItemData;
     }
 
     /**
@@ -149,9 +142,9 @@ class TestExporter extends ConfigurableService implements TestMetadataExporter
     {
         if (!$this->itemExporter) {
             $this->itemExporter = $this->getServiceLocator()->get(SimpleExporter::SERVICE_ID);
-            if ($this->hasOption(self::OPTION_FILE_NAME)) {
-                $this->itemExporter->setOption(ItemExporter::OPTION_FILE_LOCATION, $this->getOption(self::OPTION_FILE_NAME));
-            }
+        }
+        if ($this->hasOption(self::OPTION_FILE_NAME)) {
+            $this->itemExporter->setOption(ItemExporter::OPTION_FILE_LOCATION, $this->getOption(self::OPTION_FILE_NAME));
         }
 
         return $this->itemExporter;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1796,5 +1796,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $extension->setConfig('testRunner', $config);
             $this->setVersion('32.11.0');
         }
+
+        $this->skip('32.11.0', '32.11.1');
     }
 }


### PR DESCRIPTION
To test it:
- enable task queue on local env;
- try to export test metadata for _at least_ **two** different tests;
- files should be different;
- profit