### PR TITLE
Fix/tao 7635 fix module case

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '32.11.1',
+    'version'     => '32.11.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '32.11.1');
+        $this->skip('32.11.0', '32.11.2');
     }
 }

--- a/views/js/runner/navigator/offlineNavigator.js
+++ b/views/js/runner/navigator/offlineNavigator.js
@@ -20,7 +20,7 @@
  */
 define([
     'lodash',
-    'core/Promise',
+    'core/promise',
     'util/capitalize',
     'taoQtiTest/runner/services/offlineJumpTable',
     'taoQtiTest/runner/helpers/testContextBuilder'


### PR DESCRIPTION
case issue on the dependency `core/promise` : 

On a case sensitive system (Linux for example...) the URLs and files paths are case sensitive : 

Try to run 
```
cd tao/views/build
npx grunt connect:test qunit:single --test=/taoQtiTest/views/js/test/runner/navigator/offlineNavigator/test.html
```

Without this fix the test is stuck.