### PR TITLE
Fix/tao 7306/more csrf protection

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.0.0',
+    'version'     => '33.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.0.0');
+        $this->skip('32.11.0', '33.0.1');
     }
 }

--- a/views/js/provider/testItems.js
+++ b/views/js/provider/testItems.js
@@ -73,7 +73,8 @@ define([
              * @returns {Promise} that resolves with the classes
              */
             getItems : function getItems(params){
-                return request(config.getItems.url, params);
+                // force tokenised request
+                return request(config.getItems.url, params, 'GET', {}, true, false);
             },
 
             /**


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-7306

After the merge of https://github.com/oat-sa/extension-tao-testqti/pull/1465 yesterday it was discovered that the request to `getItems` was not CSRF-tokenised, breaking the test authoring tool.

This fix adds the necessary `noToken = false` param to the `request` function.