### PR TITLE
Fix/tao 7306/unit test for testitems

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.0.1',
+    'version'     => '33.0.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.0.1');
+        $this->skip('32.11.0', '33.0.2');
     }
 }

--- a/views/js/test/provider/testItems/test.html
+++ b/views/js/test/provider/testItems/test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Ui Test - Test Runner - Item Provider</title>
+        <base href="../../../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="comment.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoQtiTest/test/provider/testItems/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+        </div>
+    </body>
+</html>

--- a/views/js/test/provider/testItems/test.js
+++ b/views/js/test/provider/testItems/test.js
@@ -1,0 +1,150 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+define([
+    'jquery',
+    'core/promise',
+    'taoQtiTest/provider/testItems',
+    'lib/jquery.mockjax/jquery.mockjax'
+], function($, Promise, testItemProviderFactory) {
+    'use strict';
+
+    var api;
+    var mockConfig = {
+        getItemClasses : {
+            url : '//getItemClasses'
+        },
+        getItems : {
+            url : '//getItems'
+        },
+        getItemClassProperties : {
+            url : '//getItemClassProperties'
+        }
+    };
+    // a single instance will suffice for these tests as its state cannot change
+    var testItemProvider = testItemProviderFactory(mockConfig);
+
+    // prevent the AJAX mocks to pollute the logs
+    $.mockjaxSettings.logger = null;
+    $.mockjaxSettings.responseTime = 1;
+
+
+    QUnit.module('testItems');
+
+    QUnit.test('module', function(assert) {
+        assert.equal(typeof testItemProvider, 'object', 'The testItems module exposes an object');
+    });
+
+    api = [
+        {name: 'getItemClasses'},
+        {name: 'getItems'},
+        {name: 'getItemClassProperties'},
+    ];
+
+    QUnit
+        .cases.init(api)
+        .test('API ', function(data, assert) {
+            assert.equal(typeof testItemProvider[data.name], 'function', 'The testItems module exposes a "' + data.name + '" function');
+        });
+
+    QUnit.test('getItemClasses', function(assert) {
+        var ready = assert.async();
+        var theData = {a: 'a'};
+        var returnVal;
+
+        assert.expect(4);
+
+        $.mockjax({
+            url: mockConfig.getItemClasses.url,
+            response: function(settings) {
+                assert.equal(settings.url, mockConfig.getItemClasses.url, 'The provider has called the right service');
+                assert.notOk(settings.headers.hasOwnProperty('X-CSRF-Token'), 'No CSRF token is set in the request header');
+                this.responseText = JSON.stringify({ success: true, data: theData });
+            }
+        });
+
+        returnVal = testItemProvider.getItemClasses();
+
+        assert.ok(returnVal instanceof Promise, 'the getItemClasses method returns a Promise');
+        returnVal.then(function(classes) {
+            assert.deepEqual(classes, theData, 'The return value is correct');
+            ready();
+        });
+    });
+
+    QUnit.test('getItems', function(assert) {
+        var ready = assert.async();
+        var params = {
+            classUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
+            format: 'tree',
+            limit: 10
+        };
+        var itemList = [
+            {label: 'Item1'},
+            {label: 'Item2'}
+        ];
+        var returnVal;
+
+        assert.expect(6);
+
+        $.mockjax({
+            url: mockConfig.getItems.url,
+            response: function(settings) {
+                assert.equal(settings.url, mockConfig.getItems.url, 'The provider has called the right service');
+                assert.equal(settings.data, params, 'The correct params are in the request data');
+                assert.ok(settings.headers.hasOwnProperty('X-CSRF-Token'), 'A CSRF token is set in the request header');
+                assert.equal(typeof settings.headers['X-CSRF-Token'], 'string', 'The CSRF token is a string');
+                this.responseText = JSON.stringify({ success: true, data: itemList });
+            }
+        });
+
+        returnVal = testItemProvider.getItems(params);
+
+        assert.ok(returnVal instanceof Promise, 'the getItems method returns a Promise');
+        returnVal.then(function(items) {
+            assert.deepEqual(items, itemList, 'The return value is correct');
+            ready();
+        });
+    });
+
+    QUnit.test('getItemClassProperties', function(assert) {
+        var ready = assert.async();
+        var classUri = 'http://tao.example/some.rdf';
+        var theData = {b: 'b'};
+        var returnVal;
+
+        assert.expect(5);
+
+        $.mockjax({
+            url: mockConfig.getItemClassProperties.url,
+            response: function(settings) {
+                assert.equal(settings.url, mockConfig.getItemClassProperties.url, 'The provider has called the right service');
+                assert.deepEqual(settings.data, { classUri: classUri }, 'The correct params are in the request data');
+                assert.notOk(settings.headers.hasOwnProperty('X-CSRF-Token'), 'No CSRF token is set in the request header');
+                this.responseText = JSON.stringify({ success: true, data: theData });
+            }
+        });
+
+        returnVal = testItemProvider.getItemClassProperties(classUri);
+
+        assert.ok(returnVal instanceof Promise, 'the getItemClassProperties method returns a Promise');
+        returnVal.then(function(props) {
+            assert.deepEqual(props, theData, 'The return value is correct');
+            ready();
+        });
+    });
+});


### PR DESCRIPTION
(Not specifically related to, but discovered during:) https://oat-sa.atlassian.net/browse/TAO-7306

FE unit tests were missing for `taoQtiTest/provider/testItems.js`.

3 method tests have been added, covering endpoints, request parameters, request header tokens and return values.
