### PR TITLE
Fix/tao 7305/repair offline proxy unittests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.0.2',
+    'version'     => '33.0.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.0.2');
+        $this->skip('32.11.0', '33.0.3');
     }
 }

--- a/views/js/test/runner/navigator/offlineNavigator/test.js
+++ b/views/js/test/runner/navigator/offlineNavigator/test.js
@@ -157,7 +157,7 @@ define([
                 .catch(function(err) {
                     assert.equal(err.message, 'Invalid navigation action');
                 })
-                .finally(function() {
+                .then(function() {
                     done();
                 });
 

--- a/views/js/test/runner/proxy/offline/proxy/test.html
+++ b/views/js/test/runner/proxy/offline/proxy/test.html
@@ -18,6 +18,15 @@
         //load the config
         require(['/tao/ClientConfig/config'], function(){
 
+            // mock Client Config data:
+            requirejs.config({
+                "config": {
+                    "core/tokenHandler" : {
+                        tokens: ['token1', 'token2', 'token3', 'token4', 'token5']
+                    },
+                }
+            });
+
             //load the test
             require(['taoQtiTest/test/runner/proxy/offline/proxy/test'], function(){
 
@@ -30,5 +39,6 @@
 <body>
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
+<div id="feedback-box"></div>
 </body>
 </html>

--- a/views/js/test/runner/proxy/offline/proxy/test.js
+++ b/views/js/test/runner/proxy/offline/proxy/test.js
@@ -181,7 +181,7 @@ define([
                         .catch(function(err) {
                             assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                         })
-                        .finally(function() {
+                        .then(function() {
                             if (caseData.sendToken) {
                                 tokenHandler.getToken().then(function(storedToken) {
                                     assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -388,7 +388,7 @@ define([
                 .catch(function(err) {
                     assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                 })
-                .finally(function() {
+                .then(function() {
                     if (caseData.sendToken) {
                         tokenHandler.getToken().then(function(storedToken) {
                             assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -514,7 +514,7 @@ define([
                     .catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -640,7 +640,7 @@ define([
                     .catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -1158,7 +1158,7 @@ define([
                 }).catch(function(err) {
                     assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                 })
-                .finally(function() {
+                .then(function() {
                     if (caseData.sendToken) {
                         tokenHandler.getToken().then(function(storedToken) {
                             assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -1425,7 +1425,7 @@ define([
                     }).catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         tokenHandler.getToken().then(function(storedToken) {
                             assert.equal(storedToken, '4567-post-init', 'The proxy must not update the security token');
 

--- a/views/js/test/runner/proxy/qtiServiceProxy/test.js
+++ b/views/js/test/runner/proxy/qtiServiceProxy/test.js
@@ -177,7 +177,7 @@ define([
                         .catch(function(err) {
                             assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                         })
-                        .finally(function() {
+                        .then(function() {
                             if (caseData.sendToken) {
                                 tokenHandler.getToken().then(function(storedToken) {
                                     assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -384,7 +384,7 @@ define([
                 .catch(function(err) {
                     assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                 })
-                .finally(function() {
+                .then(function() {
                     if (caseData.sendToken) {
                         tokenHandler.getToken().then(function(storedToken) {
                             assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -510,7 +510,7 @@ define([
                     .catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -637,7 +637,7 @@ define([
                     .catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -776,7 +776,7 @@ define([
                 .catch(function(err) {
                     assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                 })
-                .finally(function() {
+                .then(function() {
                     if (caseData.sendToken) {
                         tokenHandler.getToken().then(function(storedToken) {
                             assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -915,7 +915,7 @@ define([
                     .catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -1050,7 +1050,7 @@ define([
                     }).catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -1187,7 +1187,7 @@ define([
                     }).catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -1330,7 +1330,7 @@ define([
                     }).catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         if (caseData.sendToken) {
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, caseData.receiveToken, 'The proxy must update the security token');
@@ -1467,7 +1467,7 @@ define([
                     }).catch(function(err) {
                         assert.ok(!caseData.success, 'The proxy has thrown an error! #' + err);
                     })
-                    .finally(function() {
+                    .then(function() {
                         tokenHandler.getToken().then(function(storedToken) {
                             assert.equal(storedToken, '4567-post-init', 'The proxy must not update the security token');
 


### PR DESCRIPTION
I rewrote only the failing tests in `runner/proxy/offline/proxy/test.js`, to match the style of `runner/proxy/qtiServiceProxy/test.js` (which they were originally copied from). This was mostly another copy-and-paste job, but I paid close attention that I did not change what was being tested, only the order of operations.

This was needed because some of these tests were not using the updated way of calling `tokenHandler`, which now returns a token wrapped in a Promise.

To test: `npx grunt connect:dev taoqtitesttest` or `npx grunt connect:test:keepalive` and browse through to it.