### PR TITLE
Ipad iOS issue with autofocus

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.0.3',
+    'version'     => '33.0.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.0.3');
+        $this->skip('32.11.0', '33.0.4');
     }
 }

--- a/views/js/runner/plugins/content/accessibility/focusOnFirstField.js
+++ b/views/js/runner/plugins/content/accessibility/focusOnFirstField.js
@@ -29,6 +29,15 @@ define([
     'use strict';
 
     /**
+     * Check if client uses the iOS device.
+     *
+     * @returns {*|boolean}
+     */
+    function isIOSDevice() {
+        return /(iPhone|iPad)/i.test(navigator.userAgent)
+    }
+
+    /**
      * Returns the configured plugin
      */
     return pluginFactory({
@@ -41,23 +50,29 @@ define([
         init: function init() {
             var self = this;
 
-            this.getTestRunner()
-                .after('renderitem', function() {
-                    var $input = self.getAreaBroker().getContentArea().find('.qti-itemBody')
-                        .find('input, textarea, select')
-                        .not(':input[type=button], :input[type=submit], :input[type=reset]')
-                        .first();
-                    var $cke = $input.closest('.qti-interaction').find('.cke');
+            /**
+             * When an Item loaded - if we set focus on any input then ipad set focus to keyboard, so windows lose focus
+             * and we get error message for the test in the fullscreen mode
+             */
+            if (!isIOSDevice()) {
+                this.getTestRunner()
+                    .after('renderitem', function() {
+                        var $input = self.getAreaBroker().getContentArea().find('.qti-itemBody')
+                            .find('input, textarea, select')
+                            .not(':input[type=button], :input[type=submit], :input[type=reset]')
+                            .first();
+                        var $cke = $input.closest('.qti-interaction').find('.cke');
 
-                    if($cke.length) {
-                        _.delay(function() {
-                            ckEditor.instances[$cke.attr('id').replace(/^cke_/, '')].focus();
-                        }, 100);
-                    }
-                    else {
-                        $input.focus();
-                    }
-                });
+                        if($cke.length) {
+                            _.delay(function() {
+                                ckEditor.instances[$cke.attr('id').replace(/^cke_/, '')].focus();
+                            }, 100);
+                        }
+                        else {
+                            $input.focus();
+                        }
+                    });
+            }
         }
     });
 });

--- a/views/js/runner/plugins/content/accessibility/focusOnFirstField.js
+++ b/views/js/runner/plugins/content/accessibility/focusOnFirstField.js
@@ -51,8 +51,9 @@ define([
             var self = this;
 
             /**
-             * When an Item loaded - if we set focus on any input then ipad set focus to keyboard, so windows lose focus
-             * and we get error message for the test in the fullscreen mode
+             * When an Item is loaded - if we set the focus on any input then the ipad sets the focus on the
+             * keyboard, so the windows lose focus
+             * and we get an error message for the test in fullscreen mode
              */
             if (!isIOSDevice()) {
                 this.getTestRunner()


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8161
NFER - launching assessments on iPad iOS using Safari not working properly

When an Item is loaded - if we set the focus on any input then the iPad sets the focus on the keyboard, so the windows lose focus and we get an error message for the test in fullscreen mode

- [ ]  we need to check other mobile devices. (android works well)