### PR TITLE
Fix/tao 8315/disable csrf for messages

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -957,13 +957,13 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
      */
     public function messages()
     {
-        // close the PHP session to prevent session overwriting and loss of security token for secured queries
-        session_write_close();
-
         $code = 200;
 
         try {
-            //$this->checkSecurityToken(); // should be on, but disabled as temporary fix for TAO-8315
+            $this->checkSecurityToken();
+
+            // close the PHP session to prevent session overwriting and loss of security token for secured queries
+            session_write_close();
 
             $input = \taoQtiCommon_helpers_Utils::readJsonPayload();
             if (!$input) {

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -388,6 +388,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
         }
 
         try {
+            $this->checkSecurityToken();
 
             if (!$this->getRunnerService()->getTestConfig()->getConfigValue('itemCaching.enabled')) {
                 \common_Logger::w("Attempt to disclose the next items without the configuration");
@@ -962,6 +963,8 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
         $code = 200;
 
         try {
+            //$this->checkSecurityToken(); // should be on, but disabled as temporary fix for TAO-8315
+
             $input = \taoQtiCommon_helpers_Utils::readJsonPayload();
             if (!$input) {
                 $input = [];

--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return array(
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',
         'taoTests'   => '>=8.3.0',
-        'tao'        => '>=34.0.0',
+        'tao'        => '>=35.1.1',
         'generis'    => '>=7.12.1',
         'taoDelivery' => '>=11.0.0',
         'taoItems'   => '>=6.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.0.4',
+    'version'     => '33.0.5',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.0.4');
+        $this->skip('32.11.0', '33.0.5');
     }
 }


### PR DESCRIPTION
Issue: https://oat-sa.atlassian.net/browse/TAO-8315

Related PR: https://github.com/oat-sa/tao-core/pull/2117

The short term fix for this bug will be to disable CSRF tokens for the "messages" feature used by some customers.

On the backend it was found that `checkSecurityToken()` was missing in 2 methods which should normally have it. It has been re-added.

However, until the token issue is fully understood, tokens will be turned off for messages, thus the call in `messsages()` is commented for now.

Should be tested in the Test Runner on ACT and NFER envs.