### PR TITLE
Fix/TAO-8318/remove feedback in case terminated session

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.6.1',
+    'version'     => '33.6.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.6.1');
+        $this->skip('32.11.0', '33.6.2');
     }
 }

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -105,9 +105,6 @@ define([
                     if (error.data && self.isConnectivityError(error.data)) {
                         self.setOffline('request');
                     }
-                    if (error instanceof Error) { //in case status 200 OK ans response.success:false we don't have Error
-                        feedback().error(error);
-                    }
                     return Promise.reject(error);
                 });
             };

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -105,7 +105,9 @@ define([
                     if (error.data && self.isConnectivityError(error.data)) {
                         self.setOffline('request');
                     }
-                    feedback().error(error);
+                    if (error instanceof Error) { //in case status 200 OK ans response.success:false we don't have Error
+                        feedback().error(error);
+                    }
                     return Promise.reject(error);
                 });
             };


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8318

Added condition to cover the case when in catch we get a response, not Error
https://github.com/oat-sa/tao-core-sdk-fe/blob/de027f48faf88411bb276289fcc9ca720f9cf123/src/core/request.js#L187-L189