### PR TITLE
Fix/prevent fe test to hang

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.6.1',
+    'version'     => '33.6.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.6.1');
+        $this->skip('32.11.0', '33.6.2');
     }
 }

--- a/views/js/test/runner/mocks/areaBrokerMock.js
+++ b/views/js/test/runner/mocks/areaBrokerMock.js
@@ -17,37 +17,35 @@
  */
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ * @author Christophe Noël <christophe@taotesting.com>
  */
 define([
     'jquery',
     'lodash',
-    'tao/test/ui/areaBroker/mock/areaBrokerMock',
+    'ui/areaBroker',
     'taoQtiTest/runner/ui/toolbox/toolbox'
-], function ($, _, areaBrokerMockFactory, toolboxFactory) {
+], function($, _, areaBrokerFactory, toolboxFactory) {
     'use strict';
 
     /**
-     * The mock
-     * @type {Object}
+     * A counter utilised to generate the mock identifiers
+     * @type {Number}
      */
-    var areaBroker;
+    let mockId = 0;
 
-    /**
-     * The list of default areas
-     * @type {String[]}
-     */
-    var defaultAreas = [
-        'content',      //where the content is renderer, for example an item
-        'toolbox',      //the place to add arbitrary tools, like a zoom, a comment box, etc.
-        'navigation',   //the navigation controls like next, previous, skip
-        'control',      //the control center of the test, progress, timers, etc.
-        'header',       //the area that could contains the test titles
-        'panel'         //a panel to add more advanced GUI (item review, navigation pane, etc.)
-    ];
+    const classes = {
+        areaBroker: 'area-broker-mock',
+        area: 'test-area'
+    };
+
+    const defaultContainerSelector = '#qunit-fixture';
 
     /**
      * Builds and returns a new areaBroker with dedicated areas.
-     * @param config.$brokerContainer - where to create the area broker - default to #qunit-fixture
+     * @param {Object} [config]
+     * @param {String} config.id - area broker id, will be used as a class on container
+     * @param {String[]} config.defaultAreas - mandatory areas to create
+     * @param {jQuery} config.$brokerContainer - where to create the area broker - default to #qunit-fixture
      * @param {String[]} config.areas - A list of areas to create, or...
      * @param {Object} config.mapping - ... a list of already created areas
      * @returns {areaBroker} - Returns the new areaBroker
@@ -55,15 +53,61 @@ define([
     function areaBrokerMock(config) {
 
         config = _.defaults(config || {}, {
-            defaultAreas: defaultAreas,
+            defaultAreas: [
+                'content', //where the content is renderer, for example an item
+                'toolbox', //the place to add arbitrary tools, like a zoom, a comment box, etc.
+                'navigation', //the navigation controls like next, previous, skip
+                'control', //the control center of the test, progress, timers, etc.
+                'header', //the area that could contains the test titles
+                'panel' //a panel to add more advanced GUI (item review, navigation pane, etc.)
+            ],
             id: 'test-runner'
         });
 
-        areaBroker = areaBrokerMockFactory(config);
+        const $areaBrokerDom = $('<div />')
+            .attr('id', `area-broker-mock-${mockId++}`)
+            .addClass(config.id || classes.areaBroker);
 
+
+        // Create all areas from scratch
+        if (!config.mapping) {
+            config.mapping = {};
+            if (!config.areas) {
+                config.areas = config.defaultAreas;
+            } else {
+                config.areas = _.keys(_.merge(_.object(config.areas), _.object(config.defaultAreas)));
+            }
+
+            _.forEach(config.areas, areaId => {
+                config.mapping[areaId] = $('<div />')
+                    .addClass('test-area')
+                    .addClass(areaId)
+                    .appendTo($areaBrokerDom);
+            });
+
+            // Create only missing areas
+        } else {
+            _.union(config.defaultAreas, (config.areas || [])).forEach( areaId => {
+                // create missing areas
+                if (!config.mapping[areaId]) {
+                    config.mapping[areaId] = $('<div />')
+                        .addClass('test-area')
+                        .addClass(areaId)
+                        .appendTo($areaBrokerDom);
+                }
+            });
+        }
+
+        if (!config.$brokerContainer) {
+            config.$brokerContainer = $(defaultContainerSelector);
+        }
+        config.$brokerContainer.append($areaBrokerDom);
+
+        const areaBroker = areaBrokerFactory(config.defaultAreas, $areaBrokerDom, config.mapping);
         areaBroker.setComponent('toolbox', toolboxFactory().init());
 
         return areaBroker;
+
     }
 
     return areaBrokerMock;

--- a/views/js/test/runner/plugins/navigation/dialogConfirmNext/test.js
+++ b/views/js/test/runner/plugins/navigation/dialogConfirmNext/test.js
@@ -124,7 +124,7 @@ define([
             assert.ok(!!modal.getDom().length, 'The dialogConfirm instance gets a DOM element');
             assert.equal(modal.getDom().parent().length, 1, 'The dialogConfirm box is rendered by default');
 
-            assert.equal(modal.getDom().find('button').length, 2, "The dialogConfirm box displays 2 buttons");
+            assert.equal(modal.getDom().find('.modal-body button').length, 2, "The dialogConfirm box displays 2 buttons");
             assert.equal(modal.getDom().find('button[data-control="ok"]').length, 1, "The dialogConfirm box displays a 'ok' button");
             assert.equal(modal.getDom().find('button[data-control="cancel"]').length, 1, "The dialogConfirm box displays a 'cancel' button");
 


### PR DESCRIPTION
Some tests were failing because they were relying on a dependency that has been moved away. 
This test brings back and merge the dependency in the given mock (see https://raw.githubusercontent.com/oat-sa/tao-core/0de64093b5e6ca6cf63227db79a11406d1f19dc6/views/js/test/core/areaBroker/mock/areaBrokerMock.js). 
I didn't change the logic of the mock (especially the behavior of the configuration) to quickly set the tests back on rails.

Please run the extension test suite  : 
```
cd tao/views/build
npx grunt connect:test taoqtitesttest
```