### PR TITLE
move checkbox template from ui

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.6.2',
+    'version'     => '33.6.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.6.2');
+        $this->skip('32.11.0', '33.6.3');
     }
 }

--- a/views/js/runner/plugins/navigation/next/dialogConfirmNext.js
+++ b/views/js/runner/plugins/navigation/next/dialogConfirmNext.js
@@ -23,7 +23,7 @@ define([
     'lodash',
     'i18n',
     'ui/dialog',
-    'tpl!ui/dialog/tpl/checkbox'
+    'tpl!taoQtiTest/runner/plugins/navigation/next/tpl/checkbox'
 ], function ($, _, __, dialog, checkboxTpl) {
     'use strict';
 

--- a/views/js/runner/plugins/navigation/next/tpl/checkbox.tpl
+++ b/views/js/runner/plugins/navigation/next/tpl/checkbox.tpl
@@ -1,0 +1,5 @@
+<label for="{{id}}">
+    <input type="checkbox" id="{{id}}" name="{{id}}" {{#if checked}}checked{{/if}} />
+    <span class="icon-checkbox"></span>
+    {{text}}
+</label>


### PR DESCRIPTION
DialogConfirmNext plugin depended on `ui/dialog/tpl/checkbox` what was moved. This related template is duplication to this project.

JIRA: https://oat-sa.atlassian.net/browse/NEX-90