### PR TITLE
Fix/tao 8362/connectivity error format

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.7.1',
+    'version'     => '33.7.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.7.1');
+        $this->skip('32.11.0', '33.7.2');
     }
 }

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -102,7 +102,7 @@ define([
                     }
                 })
                 .catch(function(error) {
-                    if (error.data && self.isConnectivityError(error.data)) {
+                    if (self.isConnectivityError(error)) {
                         self.setOffline('request');
                     }
                     return Promise.reject(error);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8362

Goes with https://github.com/oat-sa/tao-core-sdk-fe/pull/14

We should check the `error` object returned by `createError()` in `core/request`, and not `error.data` (seems to be a hangover from the previous implementation)