### PR TITLE
[TAO-7016] NFER-16 Disconnected: file save at end of test

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.7.3',
+    'version'     => '33.7.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.7.3');
+        $this->skip('32.11.0', '33.7.4');
     }
 }

--- a/views/js/runner/proxy/offline/proxy.js
+++ b/views/js/runner/proxy/offline/proxy.js
@@ -323,7 +323,8 @@ define([
                     content: JSON.stringify({
                         timestamp: timestamp,
                         testData: testData,
-                        actionQueue: actions
+                        actionQueue: actions,
+                        testConfig: self.requestConfig,
                     })
                 };
             };

--- a/views/js/test/runner/proxy/offline/proxy/test.js
+++ b/views/js/test/runner/proxy/offline/proxy/test.js
@@ -1590,4 +1590,66 @@ define([
         });
     });
 
+    QUnit.test('offlineProxy.prepareDownload', function(assert) {
+        var ready = assert.async();
+        var initConfig = {
+            testDefinition: 'http://tao.dev/mockTestDefinition#123',
+            testCompilation: 'http://tao.dev/mockTestCompilation#123',
+            serviceCallId: 'http://tao.dev/mockServiceCallId#123',
+            bootstrap: {
+                serviceController: 'MockRunner',
+                serviceExtension: 'MockExtension',
+                communication: {
+                    enabled: false,
+                    type: 'mock',
+                    extension: 'MockRunner',
+                    controller: 'MockCommunicator',
+                    action: 'messages',
+                    service: null,
+                    params: {
+                        interval: 30,
+                        timeout: 30
+                    }
+                }
+            }
+        };
+        var testData = { title: 'testTitle' };
+        var actions = 'testActions';
+
+        var proxy;
+
+        assert.expect(3);
+
+        proxyFactory.registerProvider('qtiServiceProxy', qtiServiceProxy);
+
+        $.mockjax({
+            url: '/init*',
+            responseText: {
+                success: true
+            }
+        });
+
+        proxy = proxyFactory('qtiServiceProxy', initConfig);
+
+        proxy.install(new collections.Map([['testData', testData]]));
+
+        proxy.init().then(function() {
+            var downloadDataContent = JSON.parse(proxy.prepareDownload(actions).content);
+
+            assert.deepEqual(downloadDataContent.testData, testData, 'Should include test data in download data');
+            assert.deepEqual(downloadDataContent.actionQueue, actions, 'Should include actions in download data');
+            assert.deepEqual(
+                downloadDataContent.testConfig,
+                {
+                    serviceCallId: initConfig.serviceCallId,
+                    testCompilation: initConfig.testCompilation,
+                    testDefinition: initConfig.testDefinition
+                },
+                'Should include request config in download data'
+            );
+
+            ready();
+        });
+    });
+
 });


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-7016
 
Add missing data to json file which can be downloaded and later exported if there is no connection during delivery execution in offline mode 
 
#### How to test

- Prepare tao instance with NFER extension enabled
- Switch test runner to "offline mode" with command : php index.php "oat\taoQtiTest\scripts\install\SetOfflineTestRunnerConfig"
- Login as a test taker and start delivery execution
- After the delivery page fully loaded, disabled internet connection in browser dev tools network tab
- Finish the delivery in offline mode, the modal window with countdown and download results option will appear  
- Wait until countdown is finished and download test results
- Login into backoffice and navigate to "Tools" -> "Upload offline test completion"
- Import test results and check that it was added to delivery execution results
