### PR TITLE
Feature/nex 19 valid runner proxy

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.7.4',
+    'version'     => '33.8.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -19,7 +19,9 @@
 
 namespace oat\taoQtiTest\scripts\update;
 
+
 use oat\oatbox\service\ServiceNotFoundException;
+use oat\tao\model\ClientLibConfigRegistry;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\taskQueue\TaskLogInterface;
@@ -1797,6 +1799,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.7.4');
+        $this->skip('32.11.0', '33.8.0');
+
     }
 }

--- a/views/js/runner/proxy/cache/proxy.js
+++ b/views/js/runner/proxy/cache/proxy.js
@@ -68,6 +68,8 @@ define([
      */
     return _.defaults({
 
+        name : 'precaching',
+
         /**
          * Installs the proxy
          */

--- a/views/js/runner/proxy/offline/proxy.js
+++ b/views/js/runner/proxy/offline/proxy.js
@@ -57,6 +57,8 @@ define([
      */
     return _.defaults({
 
+        name : 'offline',
+
         /**
          * Installs the proxy
          */

--- a/views/js/runner/proxy/qtiServiceProxy.js
+++ b/views/js/runner/proxy/qtiServiceProxy.js
@@ -39,6 +39,8 @@ define([
      */
     var qtiServiceProxy = {
 
+        name : 'qtiServiceProxy',
+
         /**
          * Installs the proxy
          */


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/NEX-19

Make the proxies to comply with the provider loading validation (they were loaded aside before)

Companion PR : 
 - [x] https://github.com/oat-sa/extension-tao-test/pull/289
 - [ ] https://github.com/oat-sa/extension-tao-testqti-previewer/pull/25
