### PR TITLE
update the provider with a wrong bundle

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.10.1',
+    'version'     => '33.10.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1883,6 +1883,13 @@ class Updater extends \common_ext_ExtensionUpdater {
                     ]
                 ])
             );
+            if ($providerRegistry->isRegistered('taoQtiTest/runner/proxy/qtiServiceProxy')) {
+                $registeredProxy = $providerRegistry->get('taoQtiTest/runner/proxy/qtiServiceProxy');
+                $registeredProxy['bundle'] = 'taoQtiTest/loader/taoQtiTestRunner.min';
+                $providerRegistry->register(
+                    TestProvider::fromArray($registeredProxy)
+                );
+            }
             $this->setVersion('33.10.2');
         }
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1861,5 +1861,29 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('33.10.0', '33.10.1');
+
+        if( $this->isVersion('33.10.1') ) {
+
+            $providerRegistry = ProviderRegistry::getRegistry();
+            $providerRegistry->remove('taoQtiTest/runner/provider/qti');
+            $providerRegistry->register(
+                TestProvider::fromArray([
+                    'id' => 'qti',
+                    'module' => 'taoQtiTest/runner/provider/qti',
+                    'bundle' => 'taoQtiTest/loader/qtiTestRunner.min',
+                    'position' => null,
+                    'name' => 'QTI runner',
+                    'description' => 'QTI implementation of the test runner',
+                    'category' => 'runner',
+                    'active' => true,
+                    'tags' => [
+                        'core',
+                        'qti',
+                        'runner'
+                    ]
+                ])
+            );
+            $this->setVersion('33.10.2');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1870,7 +1870,7 @@ class Updater extends \common_ext_ExtensionUpdater {
                 TestProvider::fromArray([
                     'id' => 'qti',
                     'module' => 'taoQtiTest/runner/provider/qti',
-                    'bundle' => 'taoQtiTest/loader/qtiTestRunner.min',
+                    'bundle' => 'taoQtiTest/loader/taoQtiTestRunner.min',
                     'position' => null,
                     'name' => 'QTI runner',
                     'description' => 'QTI implementation of the test runner',


### PR DESCRIPTION
It appears that the previous provider configuration for the runner did not use the correct bundle name. 
So when updating from a previous version and in production mode, the test runner doesn't initialize correclty