### PR TITLE
[TAO-8713] NFERlightweight: Passing a test with an offline test runner leads to different and incorrect displaying of the final test score

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.6.1.1',
+    'version'     => '33.6.1.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.6.1.1');
+        $this->skip('32.11.0', '33.6.1.2');
     }
 }

--- a/views/js/runner/proxy/cache/actionStore.js
+++ b/views/js/runner/proxy/cache/actionStore.js
@@ -63,11 +63,11 @@ define([
              * @param {Object} params - the action parameters
              * @returns {Promise} resolves when the action is stored
              */
-            push: function push(action, params) {
+            push: function push(action, params, timestamp) {
                 return loadStore().then(function(actionStore) {
                     actionQueue.push({
                         action : action,
-                        timestamp : Date.now(),
+                        timestamp : timestamp || Date.now(),
                         parameters : params
                     });
                     return actionStore.setItem(storeKey, actionQueue);

--- a/views/js/runner/proxy/offline/proxy.js
+++ b/views/js/runner/proxy/offline/proxy.js
@@ -297,7 +297,7 @@ define([
                             if (self.isConnectivityError(err)) {
                                 self.setOffline('communicator');
                                 _.forEach(actions, function (action) {
-                                    self.actionStore.push(action.action, action.parameters);
+                                    self.actionStore.push(action.action, action.parameters, action.timestamp);
                                 });
                             }
 
@@ -330,7 +330,7 @@ define([
                         .flush()
                         .then(function(actions) {
                             _.forEach(actions, function (action) {
-                                self.actionStore.push(action.action, action.parameters);
+                                self.actionStore.push(action.action, action.parameters, action.timestamp);
                             });
 
                             return actions;


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8713
 
While passing the test with offline test runner without internet connection, if test taker will download test data then it will cause reset of test taker action timestamp

#### How to test
- Run delivery as a test taker with offline test runner
- Break the connection
- At the end of the test download the test data
- Restore the connection and finish the test
- Check that data with correct timestamp sent to /taoQtiTest/OfflineRunner/messages endpoint   