### PR TITLE
Fix/sass config override

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.1.1',
+    'version'     => '34.1.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1903,6 +1903,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '34.1.1');
+        $this->skip('34.0.0', '34.1.2');
     }
 }

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -1,27 +1,61 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technologies SA;
+ */
+
+const path = require('path');
+
+/**
+ * configure the extension sass compilation
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ *
+ * @param {Object} grunt - the grunt object (by convention)
+ */
 module.exports = function(grunt) {
     'use strict';
 
-    var root    = grunt.option('root') + '/taoQtiTest/views/';
-    var pluginDir = root + 'js/runner/plugins/';
+    const sassConfig = grunt.config('sass') || {};
+    const root       = path.join(grunt.option('root'), 'x/taoQtiTest/views/');
+    const runnerScssPath = path.join(root, 'node_modules/@oat-sa/tao-test-runner-qti/scss');
 
     grunt.config.merge({
         sass : {
-            options: {
-                includePaths : [ root + 'node_modules/@oat-sa/tao-test-runner-qti/scss' ]
-            },
             taoqtitest: {
+                options: {
+                    includePaths : [
+                        ...sassConfig.options.includePaths,
+                        runnerScssPath
+                    ]
+                },
                 files : [
-                    { dest : root + 'css/creator.css', src : root + 'scss/creator.scss' },
-                    { dest : root + 'css/test-runner.css', src : root + 'scss/test-runner.scss' },
-                    { dest : root + 'css/new-test-runner.css', src : root + 'node_modules/@oat-sa/tao-test-runner-qti/scss/new-test-runner.scss'},
-                    { dest : pluginDir + 'controls/timer/component/css/countdown.css', src : pluginDir + 'controls/timer/component/scss/countdown.scss'},
-                    { dest : pluginDir + 'controls/timer/component/css/timerbox.css', src : pluginDir + 'controls/timer/component/scss/timerbox.scss'}
+                    {
+                        dest : path.join(root, 'css/creator.css'),
+                        src : path.join(root, 'scss/creator.scss')
+                    }, {
+                        dest : path.join(root, 'css/test-runner.css'),
+                        src : path.join(root, 'scss/test-runner.scss')
+                    }, {
+                        dest : path.join(root, 'css/new-test-runner.css'),
+                        src : path.join(runnerScssPath, 'new-test-runner.scss')                    },
                 ]
             },
         },
         watch : {
             taoqtitestsass : {
-                files : [root + 'scss/**/*.scss', pluginDir + '**/*.scss'],
+                files : [path.join(root, 'scss/**/*.scss')],
                 tasks : ['sass:taoqtitest'],
                 options : {
                     debounceDelay : 1000

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
     'use strict';
 
     const sassConfig = grunt.config('sass') || {};
-    const root       = path.join(grunt.option('root'), 'x/taoQtiTest/views/');
+    const root       = path.join(grunt.option('root'), '/taoQtiTest/views/');
     const runnerScssPath = path.join(root, 'node_modules/@oat-sa/tao-test-runner-qti/scss');
 
     grunt.config.merge({


### PR DESCRIPTION
Ensure the `includePaths` options is defined at the correct level (the task and not the overriding the main config)
Remove unused entries
Reformat and use `path.join` instead of concats