### PR TITLE
Fix/tao 8692 linereader top line

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.1.2',
+    'version'     => '34.1.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1903,6 +1903,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '34.1.2');
+        $this->skip('34.0.0', '34.1.3');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-LLF3ujByQgUqIjzdDxchT1q+EPYnykt2pibiwyIkOw1hB4Bz2SSoQrHnNInG/tM+/bPi/LlcxqNugEVp41MWLg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.2.1.tgz",
-      "integrity": "sha512-bWXF2Fv3mAaB4J27+7xlUYV+ZuPhPW8yetnZ5vmaCqVSyyV/oRcPFrp/pB5J7XMANYUOGmwgtVZG2kOONsM0tg=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.2.2.tgz",
+      "integrity": "sha512-FrmovyQmeL2liAKGmkxXaugY5fKlNxYP46tM4reYePGFVwMPhTmbRzLPGY7oVIW30l9EroMPJY+Q0CxDVRGdgw=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "^0.2.0",
-    "@oat-sa/tao-test-runner-qti": "^0.2.1"
+    "@oat-sa/tao-test-runner-qti": "^0.2.2"
   }
 }


### PR DESCRIPTION
**task** 
https://oat-sa.atlassian.net/browse/TAO-8692

**description**
User was enabled to see very first line of text with a help of line reader, because "line reader" plugin had a margin between its header and transparent part of it.

**solution**
It was decided to remove that margin and allow users to move transparent mask upper. (see screenshot)

![2019-07-22_15-58-07](https://user-images.githubusercontent.com/2877242/61634253-9ae23300-ac99-11e9-8664-784347a17327.png)

**related SDK release** https://github.com/oat-sa/tao-test-runner-qti-fe/releases/tag/0.2.2

