### PR TITLE
Fix/nex 317/e2e longer timeout

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.6.1',
+    'version'     => '34.6.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1914,6 +1914,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '34.6.1');
+        $this->skip('34.3.0', '34.6.2');
     }
 }

--- a/views/js/e2e/runner/_setup/setupCommands.js
+++ b/views/js/e2e/runner/_setup/setupCommands.js
@@ -24,13 +24,13 @@ import base64Test from './base64QtiExampleTestPackage';
  * Setup Commands
  */
 Cypress.Commands.add('publishImportedTest', () => {
-    
+
     // Visit Tests page
     cy.visit(runnerUrls.testsPageUrl);
 
     // Wait until page gets loaded and root class gets selected
     cy.wait('@editClassLabel');
-    
+
     // Select test import
     cy.get(setupSelectors.testsPage.testImportbutton).click();
 
@@ -41,13 +41,13 @@ Cypress.Commands.add('publishImportedTest', () => {
     // force:true needed because of a known issue (https://github.com/abramenal/cypress-file-upload/issues/34)
     cy.get(setupSelectors.testsPage.fileInput).upload(
         {
-            fileContent: base64Test, 
-            fileName: 'e2eExampleTest.zip', 
+            fileContent: base64Test,
+            fileName: 'e2eExampleTest.zip',
             mimeType: 'application/zip'
-        }, 
-        { 
+        },
+        {
             subjectType: 'input',
-            force: true 
+            force: true
         }
     );
 
@@ -74,7 +74,7 @@ Cypress.Commands.add('publishImportedTest', () => {
 });
 
 Cypress.Commands.add('setDeliveryForGuests', () => {
-    
+
     // Go to Deliveries page
     cy.visit(runnerUrls.deliveriesPageUrl);
 

--- a/views/js/e2e/runner/_setup/setupCommands.js
+++ b/views/js/e2e/runner/_setup/setupCommands.js
@@ -55,7 +55,7 @@ Cypress.Commands.add('publishImportedTest', () => {
     cy.get(setupSelectors.testsPage.fileImportButton).click();
 
     // Wait until test import request finishes
-    cy.wait(['@testImportIndex', '@taskQueueWebApi', '@taskQueueWebApi'], { timeout: 5000 });
+    cy.wait(['@testImportIndex', '@taskQueueWebApi', '@taskQueueWebApi'], { timeout: 15000 });
 
     // Continue
     cy.get(setupSelectors.testsPage.feedbackContinueButton).click();


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-317

- Increase hardcoded timeout from 5s to 15s in Cypress command `publishImportedTest`, because command line test runner was timing out on it