### PR TITLE
Fix/tao 8950/inject version

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.9.2',
+    'version'     => '34.9.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1916,7 +1916,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '34.9.2');
+        $this->skip('34.3.0', '34.9.3');
 
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1896,7 +1896,9 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('33.10.2');
         }
 
-        if ($this->isVersion('33.10.2')) {
+        $this->skip('33.10.2', '33.10.3');
+
+        if ($this->isVersion('33.10.3')) {
             $assetService = $this->getServiceManager()->get(AssetService::SERVICE_ID);
             $taoTestRunnerQtiDir = $assetService->getJsBaseWww('taoQtiTest') . 'node_modules/@oat-sa/tao-test-runner-qti/dist';
             $clientLibRegistry = ClientLibRegistry::getRegistry();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8950

After the backport of TAO-8950 in sprint 106, we need to inject the hotfix version in the history, to allow later update.