### PR TITLE
TAO-8933 key naviagtion problem solved

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.10.2.tgz",
-      "integrity": "sha512-raPSbPfHRNWLPucRh+KiCQs5U8pK0WJ/tn9QzkGjkuqmMGO360TqyASOdrm71BTz//HFWqgPd54uAyxvs+9t5w=="
+      "version": "0.10.3",
+      "resolved": "github:oat-sa/tao-test-runner-qti-fe#bdb8d3cc32f9670a11ff417ef49faf6ba3299d1b"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "0.10.2"
+    "@oat-sa/tao-test-runner-qti": "0.10.3"
   }
 }


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/TAO-8933
 
After the previous changes were broken some parts of the keyNavigation:
 
#### Steps to reproduce and How to test
 - Goto the next item, then come back to the previous, you will see error message in the console (*reason*: keyNavigation creates on the page loading with the same unique id, so when you go back - keyNavigation tries to create the same id, *solution*: use `replace: true` parameter )
 - Check TAB button in the test runner: all active blocks should be in the queue.

### related NPM Release : [0.10.3](https://github.com/oat-sa/tao-test-runner-qti-fe/releases/tag/0.10.3)