### PR TITLE
TAO-8933 version bump

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.13.0',
+    'version'     => '34.13.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1916,6 +1916,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '34.13.0');
+        $this->skip('34.3.0', '34.13.1');
     }
 }


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/TAO-8933
After the previous changes were broken some parts of the keyNavigation:
 
#### Steps to reproduce and How to test
 - Goto the next item, then come back to the previous, you will see error message in the console (*reason*: keyNavigation creates on the page loading with the same unique id, so when you go back - keyNavigation tries to create the same id, *solution*: use `replace: true` parameter )
 - Check TAB button in the test runner: all active blocks should be in the queue.

### related NPM Release : [0.10.3](https://github.com/oat-sa/tao-test-runner-qti-fe/releases/tag/0.10.3)