### PR TITLE
Fix/tao 9218/linereader mask

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.14.0',
+    'version'     => '34.14.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1916,6 +1916,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '34.14.0');
+        $this->skip('34.3.0', '34.14.1');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "0.10.3",
-      "resolved": "github:oat-sa/tao-test-runner-qti-fe#bdb8d3cc32f9670a11ff417ef49faf6ba3299d1b"
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.10.4.tgz",
+      "integrity": "sha512-vtjAzbkoC4oketLshZ9wWF+9s69gzwVntrrwVL2dr7JnpJ4Vpvy3CdJTV5DmxmEC4E2IgfOIjWPRyTrtIpV5NA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "0.10.3"
+    "@oat-sa/tao-test-runner-qti": "0.10.4"
   }
 }


### PR DESCRIPTION
**Task:** [TAO-9218](https://oat-sa.atlassian.net/browse/TAO-9218)
**Description:** masking zone inside lineReader plugin is impossible to move on IPads only.

**reproduce:**
open test/plugins/tools/lineReader/compoundMask/test.html unit test and try playground section on iPad. 
Try to move masking area with its handle pictogram - it is not moving.
(problem is visible only on iPad physical device)

**what was made:** 
some events dispatched were rewritten to modern "pointer events".

**NPM release: ** [#52](https://github.com/oat-sa/tao-test-runner-qti-fe/pull/52)