### PR TITLE
hotfix: disable item before move

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '33.0.3.2',
+    'version'     => '33.0.3.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=19.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1797,6 +1797,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('32.11.0');
         }
 
-        $this->skip('32.11.0', '33.0.3.2');
+        $this->skip('32.11.0', '33.0.3.3');
     }
 }

--- a/views/js/runner/plugins/navigation/validateResponses.js
+++ b/views/js/runner/plugins/navigation/validateResponses.js
@@ -73,7 +73,8 @@ define([
                     return Promise.resolve();
                 }
 
-
+                self.trigger('disableitem');
+                
                 if ( isInteracting && testContext.enableValidateResponses &&  testContext.validateResponses) {
                     return new Promise(function (resolve, reject) {
                         if(_.size(currentItemHelper.getDeclarations(self)) === 0){


### PR DESCRIPTION
related issue: https://oat-sa.atlassian.net/browse/NFERSUP-25

1. Select all responses.
2. Press next button. validateResponses plugin passes validation
3. unselect one response while item is submitting

the problem is that we disable navigation when move event triggered but item interface is still active.