### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.15.0',
+    'version'     => '35.0.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.14.6',
+    'version'     => '34.15.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return array(
         'taoQtiItem' => '>=20.0.2',
         'taoTests'   => '>=13.2.0',
         'tao'        => '>=38.5.0',
-        'generis'    => '>=7.12.1',
+        'generis'    => '>=12.5.0',
         'taoDelivery' => '>=13.3.0',
         'taoItems'   => '>=6.0.0',
     ),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1916,6 +1916,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '34.15.0');
+        $this->skip('34.3.0', '35.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1916,6 +1916,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '34.14.6');
+        $this->skip('34.3.0', '34.15.0');
     }
 }

--- a/test/integration/TestModelTest.php
+++ b/test/integration/TestModelTest.php
@@ -22,6 +22,7 @@ namespace oat\taoQtiTest\test\integration;
 
 use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\taoQtiTest\models\TestModelService;
+use oat\generis\test\MockObject;
 
 class TestModelTest extends GenerisPhpUnitTestRunner
 {
@@ -29,7 +30,7 @@ class TestModelTest extends GenerisPhpUnitTestRunner
      *
      * @author Lionel Lecaque, lionel@taotesting.com
      * @param string $uri
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     private function getResourceMock($uri)
     {

--- a/test/integration/runner/communicator/QtiCommunicationServiceTest.php
+++ b/test/integration/runner/communicator/QtiCommunicationServiceTest.php
@@ -25,6 +25,7 @@ use oat\taoQtiTest\models\runner\communicator\QtiCommunicationService;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use qtism\runtime\tests\AssessmentTestSession;
 use qtism\runtime\tests\AssessmentTestSessionState;
+use oat\generis\test\MockObject;
 
 /**
  * Class QtiCommunicationServiceTest
@@ -208,7 +209,7 @@ class QtiCommunicationServiceTest extends GenerisPhpUnitTestRunner
 
     /**
      * @param $sessionState
-     * @return QtiRunnerServiceContext|\PHPUnit_Framework_MockObject_MockObject test session mock
+     * @return QtiRunnerServiceContext|MockObject test session mock
      */
     private function getQtiRunnerServiceContext($sessionState)
     {

--- a/test/unit/models/classes/runner/OfflineQtiRunnerServiceTest.php
+++ b/test/unit/models/classes/runner/OfflineQtiRunnerServiceTest.php
@@ -6,17 +6,17 @@ use oat\generis\test\TestCase;
 use oat\taoQtiTest\models\runner\OfflineQtiRunnerService;
 use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class OfflineQtiRunnerServiceTest extends TestCase
 {
     /** @var OfflineQtiRunnerService */
     private $offlineQtiRunnerService;
 
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerServiceMock;
 
-    /** @var RunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var RunnerServiceContext|MockObject */
     private $serviceContextMock;
 
     /**

--- a/test/unit/models/classes/runner/TestDefinitionSerializerServiceTest.php
+++ b/test/unit/models/classes/runner/TestDefinitionSerializerServiceTest.php
@@ -24,6 +24,7 @@ use oat\oatbox\filesystem\File;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\TestDefinitionSerializerService;
 use tao_models_classes_service_StorageDirectory;
+use oat\generis\test\MockObject;
 
 class TestDefinitionSerializerServiceTest extends TestCase
 {
@@ -91,19 +92,19 @@ class TestDefinitionSerializerServiceTest extends TestCase
     /** @var TestDefinitionSerializerService */
     private $testDefinitionSerializerService;
 
-    /** @var \tao_models_classes_service_FileStorage|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \tao_models_classes_service_FileStorage|MockObject */
     private $fileStorageServiceMock;
 
-    /** @var tao_models_classes_service_StorageDirectory|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var tao_models_classes_service_StorageDirectory|MockObject */
     private $directoryMock;
 
-    /** @var File|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var File|MockObject */
     private $indexFileMock;
 
-    /** @var File|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var File|MockObject */
     private $fileMock;
 
-    /** @var QtiRunnerServiceContext|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
     public function setUp ()

--- a/test/unit/models/classes/runner/synchronisation/action/ExitTestTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/ExitTestTest.php
@@ -26,17 +26,17 @@ use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\synchronisation\action\ExitTest;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class ExitTestTest extends TestCase
 {
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerService;
 
-    /** @var QtiRunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
-    /** @var TestSession|PHPUnit_Framework_MockObject_MockObject */
+    /** @var TestSession|MockObject */
     private $testSession;
 
     protected function setUp()

--- a/test/unit/models/classes/runner/synchronisation/action/MoveTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/MoveTest.php
@@ -29,23 +29,23 @@ use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\synchronisation\action\Move;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 use qtism\runtime\tests\Route;
 use qtism\runtime\tests\RouteItem;
 use qtism\data\ExtendedAssessmentItemRef;
 
 class MoveTest extends TestCase
 {
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerService;
 
-    /** @var QtiRunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
-    /** @var TestSession|PHPUnit_Framework_MockObject_MockObject */
+    /** @var TestSession|MockObject */
     private $testSession;
 
-    /** @var EventManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventManager|MockObject */
     private $eventManager;
 
     protected function setUp()

--- a/test/unit/models/classes/runner/synchronisation/action/NextItemDataTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/NextItemDataTest.php
@@ -8,18 +8,18 @@ use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\synchronisation\action\NextItemData;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 use stdClass;
 
 class NextItemDataTest extends TestCase
 {
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerService;
 
-    /** @var QtiRunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
-    /** @var TestSession|PHPUnit_Framework_MockObject_MockObject */
+    /** @var TestSession|MockObject */
     private $testSession;
 
     protected function setUp()

--- a/test/unit/models/classes/runner/synchronisation/action/PauseTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/PauseTest.php
@@ -11,20 +11,20 @@ use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\synchronisation\action\Pause;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class PauseTest extends TestCase
 {
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerService;
 
-    /** @var QtiRunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
-    /** @var TestSession|PHPUnit_Framework_MockObject_MockObject */
+    /** @var TestSession|MockObject */
     private $testSession;
 
-    /** @var EventManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventManager|MockObject */
     private $eventManager;
 
     protected function setUp()

--- a/test/unit/models/classes/runner/synchronisation/action/SkipTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/SkipTest.php
@@ -28,20 +28,20 @@ use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\synchronisation\action\Skip;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class SkipTest extends TestCase
 {
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerService;
 
-    /** @var QtiRunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
-    /** @var TestSession|PHPUnit_Framework_MockObject_MockObject */
+    /** @var TestSession|MockObject */
     private $testSession;
 
-    /** @var EventManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventManager|MockObject */
     private $eventManager;
 
     protected function setUp()

--- a/test/unit/models/classes/runner/synchronisation/action/StoreTraceDataTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/StoreTraceDataTest.php
@@ -28,23 +28,23 @@ use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\synchronisation\action\StoreTraceData;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class StoreTraceDataTest extends TestCase
 {
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerService;
 
-    /** @var QtiRunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
-    /** @var TestSession|PHPUnit_Framework_MockObject_MockObject */
+    /** @var TestSession|MockObject */
     private $testSession;
 
-    /** @var EventManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventManager|MockObject */
     private $eventManager;
 
-    /** @var QtiRunnerMap|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerMap|MockObject */
     private $qtiRunnerMap;
 
     protected function setUp()

--- a/test/unit/models/classes/runner/synchronisation/action/TimeoutTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/TimeoutTest.php
@@ -28,21 +28,21 @@ use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\synchronisation\action\Timeout;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 use qtism\data\ExtendedAssessmentItemRef;
 
 class TimeoutTest extends TestCase
 {
-    /** @var QtiRunnerService|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerService|MockObject */
     private $qtiRunnerService;
 
-    /** @var QtiRunnerServiceContext|PHPUnit_Framework_MockObject_MockObject */
+    /** @var QtiRunnerServiceContext|MockObject */
     private $qtiRunnerServiceContext;
 
-    /** @var TestSession|PHPUnit_Framework_MockObject_MockObject */
+    /** @var TestSession|MockObject */
     private $testSession;
 
-    /** @var EventManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventManager|MockObject */
     private $eventManager;
 
     protected function setUp()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.