### PR TITLE
Fix/tao 9561/allows connectivity plugin in offline

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.1.1',
+    'version'     => '35.1.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/install/SetOfflineTestRunnerConfig.php
+++ b/scripts/install/SetOfflineTestRunnerConfig.php
@@ -32,7 +32,6 @@ use oat\tao\model\modules\DynamicModule;
 class SetOfflineTestRunnerConfig extends \common_ext_action_InstallAction
 {
     private $unsupportedPlugins = [
-        'taoQtiTest/runner/plugins/controls/connectivity/connectivity',
         'taoTestRunnerPlugins/runner/plugins/connectivity/disconnectedTestSaver',
     ];
 

--- a/scripts/install/SetOfflineTestRunnerConfig.php
+++ b/scripts/install/SetOfflineTestRunnerConfig.php
@@ -32,6 +32,7 @@ use oat\tao\model\modules\DynamicModule;
 class SetOfflineTestRunnerConfig extends \common_ext_action_InstallAction
 {
     private $unsupportedPlugins = [
+        'taoTestRunnerPlugins/runner/plugins/security/autoPause',
         'taoTestRunnerPlugins/runner/plugins/connectivity/disconnectedTestSaver',
     ];
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1916,6 +1916,25 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '35.1.2');
+        $this->skip('34.3.0', '35.1.1');
+
+        if ($this->isVersion('35.1.1')) {
+            $providerRegistry = ProviderRegistry::getRegistry();
+            if ($providerRegistry->isRegistered('taoQtiTest/runner/proxy/offline/proxy')) {
+                $pluginRegistry = PluginRegistry::getRegistry();
+                $pluginRegistry->register(TestPlugin::fromArray([
+                    'id' => 'connectivity',
+                    'name' => 'Connectivity check',
+                    'module' => 'taoQtiTest/runner/plugins/controls/connectivity/connectivity',
+                    'bundle' => 'taoQtiTest/loader/testPlugins.min',
+                    'description' => 'Pause the test when the network loose the connection',
+                    'category' => 'controls',
+                    'active' => true,
+                    'tags' => [ 'core', 'technical' ]
+                ]));
+            }
+
+            $this->setVersion('35.1.2');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1916,6 +1916,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.3.0');
         }
 
-        $this->skip('34.3.0', '35.1.1');
+        $this->skip('34.3.0', '35.1.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1922,6 +1922,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $providerRegistry = ProviderRegistry::getRegistry();
             if ($providerRegistry->isRegistered('taoQtiTest/runner/proxy/offline/proxy')) {
                 $pluginRegistry = PluginRegistry::getRegistry();
+                $pluginRegistry->remove('taoTestRunnerPlugins/runner/plugins/security/autoPause');
                 $pluginRegistry->register(TestPlugin::fromArray([
                     'id' => 'connectivity',
                     'name' => 'Connectivity check',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9561

The connectivity plugin was disabled in offline mode, and this prevented the test runner to watch for reconnection.
The autoPause plugin was removed due to conflicts with offline mode.