### PR TITLE
Update @oat-sa/tao-test-runner-qti to 0.10.2-4

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '34.12.0.2',
+    'version'     => '34.12.0.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1936,5 +1936,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             }
             $this->setVersion('34.12.0.2');
         }
+
+        $this->skip('34.12.0.2', '34.12.0.3');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "0.10.2-3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.10.2-3.tgz",
-      "integrity": "sha512-D6ZGetDh5uU0QJcy/SZ9KKb3uub8oo4KVF1MXRzHyVtM/KWb59icSNc1U0c5nbv5xBoYsm151Y0yNJ9+laZy1A=="
+      "version": "0.10.2-4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.10.2-4.tgz",
+      "integrity": "sha512-Zdq+BW1syVQ2NwP1Zv0CB5kKSeX6sHjTDUa2FRQ2H9MNAXsQM2f580gy8D11PJZ+L3sdXDqslQ/jlF20lDDy6A=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "0.10.2-3"
+    "@oat-sa/tao-test-runner-qti": "0.10.2-4"
   }
 }


### PR DESCRIPTION
Backport https://github.com/oat-sa/tao-test-runner-qti-fe/pull/78

Version 34.12.0.3

**Release notes :**
- [Fix] [TAO-9666](https://oat-sa.atlassian.net/browse/TAO-9666) Check if online before resolve offlineAction [#78](https://github.com/oat-sa/tao-test-runner-qti-fe/pull/78)