### PR TITLE
Fix/tao 9435/wrong remaining time on proctor scr

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -794,7 +794,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
                 $this->endItemTimer();
             }
 
-            $this->getRunnerService()->initServiceContext($serviceContext);
+            $serviceContext = $this->getRunnerService()->initServiceContext($serviceContext);
 
             $response = [
                 'success' => $this->getRunnerService()->pause($serviceContext),

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -787,13 +787,18 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
         try {
             $this->checkSecurityToken();
-            $serviceContext = $this->getRunnerService()->initServiceContext($this->getServiceContext());
+
+            $serviceContext = $this->getServiceContext();
+
+            if (!$this->getRunnerService()->isTerminated($serviceContext)) {
+                $this->endItemTimer();
+            }
+
+            $this->getRunnerService()->initServiceContext($serviceContext);
 
             $response = [
                 'success' => $this->getRunnerService()->pause($serviceContext),
             ];
-
-            $this->getRunnerService()->persist($serviceContext);
 
         } catch (common_Exception $e) {
             $response = $this->getErrorResponse($e);

--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.2.3',
+    'version'     => '35.2.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -143,11 +143,6 @@ class QtiRunnerServiceContext extends RunnerServiceContext
      */
     public function init()
     {
-        // code borrowed from the previous implementation, maybe obsolete...
-        /** @var SessionStateService $sessionStateService */
-        $sessionStateService = $this->getServiceManager()->get(SessionStateService::SERVICE_ID);
-        $sessionStateService->resumeSession($this->getTestSession());
-
         $this->retrieveItemIndex();
     }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1970,6 +1970,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.2.0');
         }
 
-        $this->skip('35.2.0', '35.2.3');
+        $this->skip('35.2.0', '35.2.4');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.13.0.tgz",
-      "integrity": "sha512-8vsacln5zNoyTtEiRpvOjtMysm1FPZtXowW9kBwIIdUG6ZKUTWh0KlNKTgkG6ZcRvvXg1eJSBSaO0+/g7yluDQ=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.13.1.tgz",
+      "integrity": "sha512-TTmtli5j4Kshj8rLdiZ91gphKMOaLW16ADW0Alnc/sVPOfKPSrQJojGhPUql7e9+uVCvounefl7fhBWCfp7mdw=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "0.13.0"
+    "@oat-sa/tao-test-runner-qti": "0.13.1"
   }
 }


### PR DESCRIPTION
Necessary changes to save current item duration when assessment is paused. 
 
Related to : https://oat-sa.atlassian.net/browse/TAO-9435

Updated controller action `pause`, to end the current timer interval when `itemDuration` is provided in the request payload.
Removed code that resumes paused delivery execution when qti runner context is initialized.
 
#### Steps to reproduce
 - Launch an assessment.
 - Go to timed section.
 - In the assessment that I used max time is 00:55:00
 - On item 1, let the timer run down for a few mins.
 - I paused the test when remaining time was 00:52:20
 - The proctor screen, click pause, select a category, sub-category and add description. Click on OK.
 - Notice that remaining time on proctor screen is now 00:55:00.
  
#### Scenarios to test
 
1) Configure a delivery that requires proctoring and has `Security plugins` enabled. Launch it with test taker, create out of focus event by f.e. navigating to another browser tab or another application. Refresh the delivery execution list on proctor screen, notice that test session remaining time matches the time on the client side.

2) Configure a delivery that requires proctoring. Launch it with test taker. Navigate to proctor screen and pause the test, wait for the client side to detect the pause. Refresh the delivery execution list on proctor screen, notice that test session remaining time is correctly reduced.
  
#### Dependencies
 
   
Companion PR :
 - [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/93
