### PR TITLE
Fix/tao 9730/offline navigator handle attempt

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.2.3',
+    'version'     => '35.2.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1970,6 +1970,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.2.0');
         }
 
-        $this->skip('35.2.0', '35.2.3');
+        $this->skip('35.2.0', '35.2.4');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.11.2.tgz",
-      "integrity": "sha512-ZAjNa4kcPEeHTaOQrMnpB3yQR0mydqrng0AgilDBxcPId+VVR1NPNAvwkYzj5jBZlYGIUamSgM6UkGnF76EI/A=="
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.12.1.tgz",
+      "integrity": "sha512-WyK/+ze0OCW+5O5Z16bw0eqXlyzVWKEfLnt5WtWaqTzxmDLzgd2E9zn4RhacgY0wvvkgSBEPxCM75RYGdl38oQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "0.11.2"
+    "@oat-sa/tao-test-runner-qti": "0.12.1"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9730
Related to: https://github.com/oat-sa/tao-test-runner-qti-fe/pull/94

Implemented handling of `textContext.attempt` in offlineNavigator
`attempt` now is stored in `itemStore`