### PR TITLE
added log writer, to show real issue in the test-compilation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.2.3',
+    'version'     => '35.2.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/models/classes/class.QtiTestCompiler.php
+++ b/models/classes/class.QtiTestCompiler.php
@@ -327,6 +327,7 @@ class taoQtiTest_models_classes_QtiTestCompiler extends taoTests_models_classes_
             $itemReport = $this->compileItems($compiledDoc);
             $report->add($itemReport);
             if ($itemReport->getType() != common_report_Report::TYPE_SUCCESS) {
+                common_Logger::e($report->getMessage(), $report->getErrors());
                 $msg = 'Failed item compilation.';
                 $code = taoQtiTest_models_classes_QtiTestCompilationFailedException::ITEM_COMPILATION;
                 throw new taoQtiTest_models_classes_QtiTestCompilationFailedException($msg, $this->getResource(), $code);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1970,6 +1970,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.2.0');
         }
 
-        $this->skip('35.2.0', '35.2.3');
+        $this->skip('35.2.0', '35.2.4');
     }
 }


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TAO-9799
 
Added log-writer for the test compilation errors. To have opportunity to see real issue in the compilation process.
 
#### How to test
 
namespace that required by qti of the test could be removed or any of xml can be broken to see errors in the log file.