### PR TITLE
Updater script fix.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.6.1',
+    'version'     => '35.6.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => array(
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1986,7 +1986,8 @@ class Updater extends \common_ext_ExtensionUpdater {
                 'tags'        => [  ]
             ]));
 
-            $this->setVersion('35.6.1');
-      }
+            $this->setVersion('35.6.0');
+        }
+        $this->skip('35.6.0', '35.6.2');
     }
 }


### PR DESCRIPTION
Fixed version bump. The bug occurred due to a mistype.  
Moved version bump outside the block scope.