### PR TITLE
Replace missing file in test by existing file

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.8.4',
+    'version'     => '35.8.5',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1957,6 +1957,6 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('35.6.0');
         }
-        $this->skip('35.6.0', '35.8.4');
+        $this->skip('35.6.0', '35.8.5');
     }
 }

--- a/test/integration/QtiPackageExportTest.php
+++ b/test/integration/QtiPackageExportTest.php
@@ -105,7 +105,7 @@ class QtiPackageExportTest extends RestTestRunner
     public function testExportQtiPackage()
     {
         //create test resource based on qti package zip
-        $testFile = __DIR__ . '/samples/archives/QTI 2.2/exportWithoutLongPaths/multiple_items_with_ms.zip';
+        $testFile = __DIR__ . '/samples/archives/QTI 2.2/exportWithoutLongPaths/test_with_long_path_and_shared_stimulus.zip';
         //create temporary subclass
         $class = TestsService::singleton()->getRootclass()->createSubClass(uniqid('test-exporter', true));
         //Importing test form zip file into temporary subclass


### PR DESCRIPTION
Due to missing file error, I replace the test that was imported in the integration test method by the existing test.  

This fixes PR: https://github.com/oat-sa/extension-tao-testqti/pull/1661

Task:
https://oat-sa.atlassian.net/browse/MEE-9

Performed integration test on installed tao instance