### PR TITLE
Fix/actp 235/allow to redefine item categories in test map

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.10.0',
+    'version'     => '35.10.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -32,6 +32,7 @@ use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\time\QtiTimeConstraint;
+use qtism\data\AssessmentItemRef;
 use qtism\data\NavigationMode;
 use qtism\data\QtiComponent;
 use qtism\runtime\tests\AssessmentTestSession;
@@ -259,7 +260,7 @@ class QtiRunnerMap extends ConfigurableService implements RunnerMap
                         'answered' => ($itemSession) ? TestRunnerUtils::isItemCompleted($routeItem, $itemSession) : in_array($itemId, $previouslySeenItems),
                         'flagged' => $extendedStorage->getItemFlag($session->getSessionId(), $itemId),
                         'viewed' => ($itemSession) ? $itemSession->isPresented() : in_array($itemId, $previouslySeenItems),
-                        'categories' => $itemRef->getCategories()->getArrayCopy()
+                        'categories' => $this->getAvailableCategories($itemRef),
                     ];
 
                     if ($checkInformational) {
@@ -479,5 +480,14 @@ class QtiRunnerMap extends ConfigurableService implements RunnerMap
             $label = $item->getLabel();
         }
         return $label;
+    }
+
+    /**
+     * @param AssessmentItemRef $itemRef
+     * @return array
+     */
+    protected function getAvailableCategories(AssessmentItemRef $itemRef)
+    {
+        return array_unique($itemRef->getCategories()->getArrayCopy());
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1958,6 +1958,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('35.6.0');
         }
 
-        $this->skip('35.6.0', '35.10.0');
+        $this->skip('35.6.0', '35.10.1');
     }
 }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/ACTP-235

At the moment test runner FE checks available categories (test taker tools) based on a test map, instead of a test context as it was before. To be able to control TT tools via LTI parameters in custom extensions we need possibility to redefine item categories when we build test map during test init request.