### PR TITLE
Fix/actp 235/reindex categories array after removing duplicates

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.13.0',
+    'version'     => '35.13.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -488,6 +488,6 @@ class QtiRunnerMap extends ConfigurableService implements RunnerMap
      */
     protected function getAvailableCategories(AssessmentItemRef $itemRef)
     {
-        return array_unique($itemRef->getCategories()->getArrayCopy());
+        return array_values(array_unique($itemRef->getCategories()->getArrayCopy()));
     }
 }

--- a/models/classes/runner/map/QtiRunnerMap.php
+++ b/models/classes/runner/map/QtiRunnerMap.php
@@ -260,7 +260,7 @@ class QtiRunnerMap extends ConfigurableService implements RunnerMap
                         'answered' => ($itemSession) ? TestRunnerUtils::isItemCompleted($routeItem, $itemSession) : in_array($itemId, $previouslySeenItems),
                         'flagged' => $extendedStorage->getItemFlag($session->getSessionId(), $itemId),
                         'viewed' => ($itemSession) ? $itemSession->isPresented() : in_array($itemId, $previouslySeenItems),
-                        'categories' => $this->getAvailableCategories($itemRef),
+                        'categories' => array_values($this->getAvailableCategories($itemRef)),
                     ];
 
                     if ($checkInformational) {
@@ -488,6 +488,6 @@ class QtiRunnerMap extends ConfigurableService implements RunnerMap
      */
     protected function getAvailableCategories(AssessmentItemRef $itemRef)
     {
-        return array_values(array_unique($itemRef->getCategories()->getArrayCopy()));
+        return array_unique($itemRef->getCategories()->getArrayCopy());
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1966,6 +1966,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('35.11.0');
         }
 
-        $this->skip('35.11.0', '35.13.0');
+        $this->skip('35.11.0', '35.13.1');
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/ACTP-235

After removing duplicates in the list of available categories/tools in the test map sometimes there are gaps in indexes. FE test runner cannot handle this case and disable all categories/tools. As a fix we have to to re-index array with enabled categories/tools.
![test_map_categories](https://user-images.githubusercontent.com/42937157/75263346-230b5680-57ee-11ea-9440-bdef97be0b96.png)


**How to test:** Create a test with all test taker tools activated. Publish delivery from this test and run this delivery via Test Center or as a guest (not using LTI). 
**Without this change:** Test taker tools are not enabled. 
**With this change:** All test taker tools activated in test authoring are enabled in the test runner. 