### PR TITLE
Breaking/ACTP-297/Refactor the keynavigation plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.14.0',
+    'version'     => '36.0.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '35.13.2',
+    'version'     => '35.14.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -109,8 +109,8 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'tags' => [ 'core', 'qti', 'required' ]
             ], [
                 'id' => 'keyNavigation',
-                'name' => 'Using key to navigate test runner',
-                'module' => 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation',
+                'name' => 'Keyboard Navigation',
+                'module' => 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/plugin',
                 'bundle' => 'taoQtiTest/loader/testPlugins.min',
                 'description' => 'Provide a way to navigate within the test runner with the keyboard',
                 'category' => 'content',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1982,7 +1982,7 @@ class Updater extends \common_ext_ExtensionUpdater
                 'tags' => [ 'core', 'qti' ]
             ]));
 
-            $this->setVersion('35.14.0');
+            $this->setVersion('36.0.0');
         }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1967,5 +1967,22 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('35.11.0', '35.13.2');
+
+        if ($this->isVersion('35.13.2')) {
+            $registry = PluginRegistry::getRegistry();
+            $registry->remove('taoQtiTest/runner/plugins/content/accessibility/keyNavigation');
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'keyNavigation',
+                'name' => 'Keyboard Navigation',
+                'module' => 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/plugin',
+                'bundle' => 'taoQtiTest/loader/testPlugins.min',
+                'description' => 'Provide a way to navigate within the test runner with the keyboard',
+                'category' => 'content',
+                'active' => true,
+                'tags' => [ 'core', 'qti' ]
+            ]));
+
+            $this->setVersion('35.14.0');
+        }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-0.18.0.tgz",
-      "integrity": "sha512-XyI1Ly1JhQKXYtqunsQgfOpDL4NyUPowC0lHrXa1Wghw3tsE785Jph31olC9+2eQLLI3lHbo7SN4247xnB8pCA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-1.0.0.tgz",
+      "integrity": "sha512-W3tZO3rdLQil0NqVIan8ul6tS0XJcrnNv9oyIdg8pV1nZe4zxK0CXMULVieuHtHRukbEZ/vTlavUKiLcr2VtlA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "0.18.0"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/ACTP-297/refactor-the-keynavigation-plugin"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#breaking/ACTP-297/refactor-the-keynavigation-plugin"
+    "@oat-sa/tao-test-runner-qti": "1.0.0"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/ACTP-297/refactor-the-keynavigation-plugin"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#breaking/ACTP-297/refactor-the-keynavigation-plugin"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/ACTP-297

Requires: 
 - [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/139

**Note:** Once the companion PR has been merged and published to NPM, the `package.json` file must be updated accordingly, and the lock file must be added as well.

This PR is a preparation for a refactoring on the `keyNavigation` plugin.
The main addition is the unit tests to secure the existing features. It also contains a visual playground to demo the available navigation modes.

Breaking change: In order to give more flexibility, the plugin has been split down into a component and a plugin using it. In other words, the location of the plugin has changed. This will allow wrapping the navigator into a hard-configured version for special use cases (the same as for the progress bar for instance). This will also ease the refactoring that will be completed with another PR. 
Previous location: `taoQtiTest/runner/plugins/content/accessibility/keyNavigation`
New location: `taoQtiTest/runner/plugins/content/accessibility/keyNavigation/plugin`

To test:
- Prepare a delivery
- Pass the test. It should work seamlessly. The keyboard navigation must still work.