### PR TITLE
Fix/udi 155/test authoring actions

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '36.6.0',
+    'version'     => '36.6.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1985,6 +1985,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('36.0.0');
         }
 
-        $this->skip('36.0.0', '36.6.0');
+        $this->skip('36.0.0', '36.6.1');
     }
 }

--- a/views/js/controller/creator/templates/itemref.tpl
+++ b/views/js/controller/creator/templates/itemref.tpl
@@ -1,5 +1,5 @@
 <li id='{{identifier}}' data-uri='{{href}}' class='itemref'>
-    <span class='title truncate'>{{{dompurify label}}}
+    <span class='title truncate'>{{{dompurify label}}}</span>
     <div class="actions">
         <div class="tlb">
             <div class="tlb-top">


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/UDI-155

Fix broken markup where `<div class="actions"> ` appeared inside `<span class='title truncate'>`
And then here
https://github.com/oat-sa/extension-tao-testqti/blob/f9b2fe9399c6a6585c6e8200b20e081c38668992/views/js/controller/creator/views/section.js#L160-L161
`actions` were removed

How to test:

1. Go to an old test
2. See that all items have actions
