### PR TITLE
Fix/actp 297/bundling issue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '36.6.1',
+    'version'     => '36.6.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1985,6 +1985,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('36.0.0');
         }
 
-        $this->skip('36.0.0', '36.6.1');
+        $this->skip('36.0.0', '36.6.2');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-1.2.3.tgz",
-      "integrity": "sha512-W5NjdgoJq0Bt6ZV/UBs4+2Zx+0bzBix6oprrgco5yzg2wZlrTfOZdKHUOKyUrHAY3YH6jCRcB81joJTbnPqMPw=="
+      "version": "1.2.4",
+      "resolved": "github:oat-sa/tao-test-runner-qti-fe#18632d70d3cfbb6a267f78befaba58e4489d346f"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "1.2.3"
+    "@oat-sa/tao-test-runner-qti": "1.2.4"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/ACTP-297

Update `@oat-sa/tao-test-runner-qti` to the version `1.2.4`.

The version `1.2.0` was containing a ghost file due to a build issue.