### PR TITLE
Fix/wrong version tao test runner qti

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '36.6.2',
+    'version'     => '36.6.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=20.0.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1985,6 +1985,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('36.0.0');
         }
 
-        $this->skip('36.0.0', '36.6.2');
+        $this->skip('36.0.0', '36.6.3');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -11,7 +11,8 @@
     },
     "@oat-sa/tao-test-runner-qti": {
       "version": "1.2.4",
-      "resolved": "github:oat-sa/tao-test-runner-qti-fe#18632d70d3cfbb6a267f78befaba58e4489d346f"
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-1.2.4.tgz",
+      "integrity": "sha512-SMixP6VY26bWT069aZz87+cLxx5Y0Gj9aCO5dLS1M2GvkZxGsBuXWGsWAzcDRg0PpMQn96s8zekXKpaJ2OXvlw=="
     }
   }
 }


### PR DESCRIPTION
The last update contained a wrong link in package-lock.json.

When installing using `npm ci`, the package was taken from GitHub instead of NPM.
With this PR, it should now go to NPM instead.
