### PR TITLE
Feature/bosa 47 update api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Here is a list of known category options:
 | `x-tao-option-nextSection` | Enable the next section button |
 | `x-tao-option-nextSectionWarning` | Enable the next section button, display a confirm message |
 | `x-tao-proctored-auto-pause` | Enable autopause before entering the next section |
+
+
+REST API
+========
+
+[QTI Test REST API](https://openapi.taotesting.com/viewer/?url=https://raw.githubusercontent.com/oat-sa/extension-tao-testqti/master/doc/swagger.json)

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -10,7 +10,9 @@
         "http"
     ],
     "produces": [
-        "application/json"
+        "application/json",
+        "application/xml",
+        "text/xml"
     ],
     "basePath": "/",
     "tags": [

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -17,6 +17,10 @@
         {
             "name": "test",
             "description": "Operations about tests"
+        },
+        {
+            "name": "export",
+            "description": "Operations about test export"
         }
     ],
     "paths": {
@@ -35,6 +39,7 @@
                             "type": "object",
                             "required": [
                                 "success",
+                                "version",
                                 "data"
                             ],
                             "properties": {


### PR DESCRIPTION
- BOSA-47 feat(readme): add a link to REST API
- BOSA-47 fix(open-api): add a missing `export` tag description
- BOSA-47 fix(open-api): add a missing required `version` property in a response to `exportQtiPackage`