### PR TITLE
Fix/ncc 176/timers dont expire after securit pause

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -777,18 +777,14 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
 
         try {
             $this->checkSecurityToken();
-
-            $serviceContext = $this->getServiceContext();
-
-            if (!$this->getRunnerService()->isTerminated($serviceContext)) {
-                $this->endItemTimer();
-            }
-
-            $serviceContext = $this->getRunnerService()->initServiceContext($serviceContext);
+            $serviceContext = $this->getRunnerService()->initServiceContext($this->getServiceContext());
 
             $response = [
                 'success' => $this->getRunnerService()->pause($serviceContext),
             ];
+
+            $this->getRunnerService()->persist($serviceContext);
+
         } catch (common_Exception $e) {
             $response = $this->getErrorResponse($e);
             $code = $this->getErrorCode($e);

--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '36.7.1',
+    'version'     => '36.7.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=23.9.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1985,6 +1985,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('36.0.0');
         }
 
-        $this->skip('36.0.0', '36.7.1');
+        $this->skip('36.0.0', '36.7.2');
     }
 }


### PR DESCRIPTION
According to https://oat-sa.atlassian.net/browse/NCC-176

Reverted part of https://oat-sa.atlassian.net/browse/ACTP-245 (PR https://github.com/oat-sa/extension-tao-testqti/pull/1644) so that timers keep ticking after a security pause has occurred

To be backported for 36.6.3

