### PR TITLE
BOSA 72 - The modal feedback window can't be closed by clicking on the exit button

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '36.7.2',
+    'version'     => '36.7.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=23.9.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1985,6 +1985,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('36.0.0');
         }
 
-        $this->skip('36.0.0', '36.7.2');
+        $this->skip('36.0.0', '36.7.3');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-1.2.4.tgz",
-      "integrity": "sha512-SMixP6VY26bWT069aZz87+cLxx5Y0Gj9aCO5dLS1M2GvkZxGsBuXWGsWAzcDRg0PpMQn96s8zekXKpaJ2OXvlw=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-1.2.5.tgz",
+      "integrity": "sha512-mTVfxUEiIeIqC1a6paXL9gvMgwAQhVDpGH6v40h8MZRnI2tvfCl+Fz6Y0aBiSklimgYRyQG08uA2XNUDhlH+1Q=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/BOSA-72/modal-feedback-windows-cant-close"
+    "@oat-sa/tao-test-runner-qti": "1.2.5"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "1.2.4"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/BOSA-72/modal-feedback-windows-cant-close"
   }
 }


### PR DESCRIPTION
**Related to this PR**

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/160/files

**Related to**

https://oat-sa.atlassian.net/browse/BOSA-72

**Description**

While passing the delivery, the TT can't close the modal feedback window by a simple click on the exit button due to the button's inactivity. It's possible only with pressing the ESC button.

Preconditions:
Delivery with the modal feedback function activated inside the item;

STR:
1. Log in as a guest and choose the proper delivery;
2. Answer the item which has modal feedback activated inside;
3. Press the Next button

Actual result: 
1. The guest can choose the necessary delivery for the list;
2. The answer is given;
3. After clicking the button, the TT is shown the modal window which is impossible to close by the exit button. He can do it only by pressing the Esc button and move further.

Expected result: The modal feedback window can be closed both ways (Esc button on th keyboard and the Exit button on the window itself)

**Environment**

Env- demo
Platform - Windows 10
Browsers- All