### PR TITLE
Fix/tca 353/fix updater after backport

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '36.8.1',
+    'version'     => '36.8.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=23.9.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1985,6 +1985,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('36.0.0');
         }
 
-        $this->skip('36.0.0', '36.8.1');
+        $this->skip('36.0.0', '36.8.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1959,9 +1959,9 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('35.6.0');
         }
 
-        $this->skip('35.6.0', '35.10.2.1');
+        $this->skip('35.6.0', '35.10.2.2');
 
-        if ($this->isBetween('35.10.2', '35.10.2.1')) {
+        if ($this->isBetween('35.10.2', '35.10.2.2')) {
             $this->getServiceManager()->register(QtiTestUtils::SERVICE_ID, new QtiTestUtils([]));
             $this->setVersion('35.11.0');
         }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TCA-353

Problem: During update from backport release [v35.10.2.2](https://github.com/oat-sa/extension-tao-testqti/releases/tag/v35.10.2.2) to TAO sprint release there is an error in updater logs:

  

> Running extension update
>   generis already up to date
>   tao already up to date
>   taoOauth already up to date
>   taoLti already up to date
>   taoResultServer already up to date
>   taoOutcomeRds already up to date
>   taoDelivery already up to date
>   taoBackOffice already up to date
>   taoDacSimple already up to date
>   taoTestTaker already up to date
>   taoGroups already up to date
>   taoItems already up to date
>   taoMediaManager already up to date
>   taoTests already up to date
>   taoQtiItem already up to date
>   taoClientDiagnostic already up to date
>   ltiClientdiag already up to date
>   taoClientRestrict already up to date
>   taoQtiTest requires update from 35.10.2.2 to 36.7.1
>     Update of taoQtiTest exited with version 35.10.2.2
>   taoDeliveryRdf already up to date
>   taoPublishing already up to date
>   taoTestRunnerPlugins already up to date
>   taoOutcomeUi already up to date
>   taoMonitoring already up to date
>   ltiDeliveryProvider already up to date
>   taoQtiTestPreviewer already up to date
>   qtiItemPci already up to date
>   funcAcl already up to date
>   taoEventLog already up to date
>   taoProctoring already up to date
>   taoTestCenter already up to date
>   ltiProctoring already up to date
>   taoCe already up to date
>   taoTaskQueue already up to date
>   taoScheduler already up to date
>   Installed version of taoQtiTest 35.10.2.2 does not satisfy required >=36.0.0 for taoAct
>   Successfully updated 39 client translation bundles
>   Update ID : 5e8b853dcace1

To fix that we need to include version 35.10.2.2 in Updater.

How to test:
- Install TAO with instance with taoQtiTest v35.10.2.2
- Switch to develop and run taoUpdate