### PR TITLE
Changed test compilation version to 2.2.

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -212,7 +212,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
     public function fromJson($json)
     {
-        $doc = new XmlDocument('2.1');
+        $doc = new XmlDocument('2.2');
         $converter = new taoQtiTest_models_classes_QtiTestConverter($doc);
         $converter->fromJson($json);
         return $doc;
@@ -867,7 +867,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
     public function getDoc(core_kernel_classes_Resource $test)
     {
 
-        $doc = new XmlDocument('2.1');
+        $doc = new XmlDocument('2.2');
         $doc->loadFromString($this->getQtiTestFile($test)->read());
         return $doc;
     }


### PR DESCRIPTION
Does this resolve the Manual Scoring GapText issue?