### PR TITLE
TAO 4866 - Max Attempts accept any range of numbers and decimals

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.0.3',
+    'version'     => '37.0.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=23.9.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1997,6 +1997,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('37.0.2');
         }
 
-        $this->skip('37.0.2', '37.0.3');
+        $this->skip('37.0.2', '37.0.4');
     }
 }

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -81,7 +81,9 @@
                     <label for="testpart-max-attempts">{{__ 'Max Attempts'}}</label>
                 </div>
                 <div class="col-6">
-                    <input name="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="1" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                    <input name="testpart-max-attempts"
+                        type="number" data-increment="1" data-min="0" min="0"
+                        max="151" value="1" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
                 </div>
                 <div class="col-1 help">
                     <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/TAO-4866

**Description**

1. Go to Tests page, create a Test and click on 'Authoring' tab.
2. Click on the gear symbol that is located to the right the name of the test-part.
3. Open Item Session Control.
4. Enter a decimal value in the field 'Max Attempts' (for example 0.1).
5. Enter a large number in the field 'Max Attempts' (for example 10 000 000 000 000).

Actual result: The field 'Max Attempts' is acceptable for decimal and doesn't have a restriction for the entered number (the number '10 000 000 000' is acceptable).
Expected result: The field 'Max Attempts' is not acceptable for decimal and has a restriction for the entered number.

Note: The bug is reproduced for the field  ‘Max Attempts’ in Section Properties and in Item Reference Properties.

**Where happens?**

All browsers

**AC's**

Look here too: https://oat-sa.atlassian.net/browse/TAO-5075

`Expected result: Only values greater than 0 and less 152 can be saved. Decimal values should be round up and replaced with integer values.`

Instead of round, maybe better disable it