### PR TITLE
Fix/nsa 97/extend jquery from core by plugins before pic is not loaded

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.6.3',
+    'version'     => '37.6.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2041,6 +2041,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('37.5.0');
         }
 
-        $this->skip('37.5.0', '37.6.3');
+        $this->skip('37.5.0', '37.6.4');
     }
 }

--- a/views/js/controller/runner/runner.js
+++ b/views/js/controller/runner/runner.js
@@ -23,6 +23,7 @@
  */
 define([
     'jquery',
+    'select2', // TODO: remove as soon as PCI stopped expose jQuery on window
     'lodash',
     'i18n',
     'context',
@@ -37,6 +38,7 @@ define([
     'css!taoQtiTestCss/new-test-runner'
 ], function (
     $,
+    select2,
     _,
     __,
     context,


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NSA-97
**Description:** This is a hot fix before implementing the proper solution.
The problem is PCI load and expose on the window they own version of jQuery.
In case of custom plugin (e.g. `select2` plugin is used for inline choice interaction) for interaction has lazy loading it will be installed to the wrong jQuery instance and interaction will not work
The proper solution would be to find the way how to wrap and use jQuery correctly in PCI.
[This wrapper](https://github.com/oat-sa/extension-tao-itemqti/blob/master/views/js/portableLib/jquery_2_1_1.js#L7) is not working 

**Requires:** ticket number or pull request that is also required
**How to test:**
Create test with 2 sections: the first section should contain `textReader` PCI. 
The second inline choice interaction.
When test tacker navigate to the second section the "inline choice interaction" should be rendered correctly