### PR TITLE
Fix/BSA-106/section enable selection default state

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.8.1',
+    'version'     => '37.8.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2041,6 +2041,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('37.5.0');
         }
 
-        $this->skip('37.5.0', '37.8.1');
+        $this->skip('37.5.0', '37.8.2');
     }
 }

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -95,6 +95,10 @@ function(
             var $selectionSelect = $('[name=section-select]', $view);
             var $selectionWithRep = $('[name=section-with-replacement]', $view);
 
+            // sectionModel.selection will be filled by binded values from template section-props.tpl
+            // if sectionModel.selection from server response it has 'qti-type'
+            var isSelectionFromServer = !!(sectionModel.selection && sectionModel.selection['qti-type']);
+
             var switchSelection = function switchSelection(){
                 if($selectionSwitcher.prop('checked') === true){
                     $selectionSelect.incrementer('enable');
@@ -113,7 +117,7 @@ function(
                 }
             });
 
-            $selectionSwitcher.prop('checked', !!sectionModel.selection).trigger('change');
+            $selectionSwitcher.prop('checked', isSelectionFromServer).trigger('change');
 
             //listen for databinder change to update the test part title
             $title =  $('[data-bind=title]', $section);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/BSA-106

Was added check if exsist `sectionModel.selection['qti-type']` because sectionModel.selection is filled by binding from template.

How to test: 

1. Open a test in 'Authoring' mode
2. Click 'Section properties' (the gear icon in the section block)
3. Expand 'Selection' in 'Properties'
4. checkbox 'Enable selection' is unchecked by default
5. Check 'Enable selection' and change 'Select' or 'With Replacement'
6. Save and quit Authoring mode
7. Open the same test in 'Authoring' mode
8. Click Section properties (the gear icon in the section block)
9. Expand the 'Selection' in Test properties
10. Check values