### PR TITLE
[TCA-521] Timer Correction - Introduce new central timer

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.8.1',
+    'version'     => '37.9.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2041,6 +2041,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('37.5.0');
         }
 
-        $this->skip('37.5.0', '37.8.1');
+        $this->skip('37.5.0', '37.9.0');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.3.1.tgz",
-      "integrity": "sha512-jeBYJquG/QEnhS3ylqQhLwbhvIIJLRGdVAI0JH5aFh5UoByq3+yd0boP1hXqTcXOybbGa13DHwgsafsLii3O5w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.4.0.tgz",
+      "integrity": "sha512-DyWtQHpLjf6CH+fa0g62ZZLGPwAL2b+syTNwhvWIwygmKJFpbJ6YNLC3FCa5js53BZ+mRAZGzHkkY1XcCx0dqA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.3.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#feature/TCA-521-introduce-central-timer"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#feature/TCA-521-introduce-central-timer"
+    "@oat-sa/tao-test-runner-qti": "2.4.0"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-521
 
Update package.json
  
#### How to test
 
**Note:** Currently the timer is not used anywhere, but you still can make some change to subscribe to the test runner `tick` event to check if it is working

`testRunner.on('tick', function(...args) { console.log(args); })`

- prepare an instance of TAO with taoAct extension
- prepare a delivery
- make some change to subscribe to `tick` test runner event
- execute the delivery as a test taker and check that event is triggered

Requires :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/202