### PR TITLE
Update test-runner

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.8.2',
+    'version'     => '37.8.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2041,6 +2041,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('37.5.0');
         }
 
-        $this->skip('37.5.0', '37.8.2');
+        $this->skip('37.5.0', '37.8.3');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.3.1.tgz",
-      "integrity": "sha512-jeBYJquG/QEnhS3ylqQhLwbhvIIJLRGdVAI0JH5aFh5UoByq3+yd0boP1hXqTcXOybbGa13DHwgsafsLii3O5w=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.3.2.tgz",
+      "integrity": "sha512-SqStpsR0T8P2bx7NbgehYj20pUekjUbdyciicTYvX3vaE96YmF9mTs3fxalH7K4JrYfkmjSj+wc9xhWDeAHmZg=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-483/review-tabs-incorrectly-announced"
+    "@oat-sa/tao-test-runner-qti": "2.3.2"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.3.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-483/review-tabs-incorrectly-announced"
   }
 }


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-483

**Description**
Fix: set "aria-selected" only for the active tab

**How to test**
1. as a user start a test
2. enable JAWS
3. navigate to All / Unanswered / Flagged tabs
4. set focus to each tab, listen to SR's announcements

It should announce "selected" only for the tab in active state.

#### Dependencies 

Requires :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/203