### PR TITLE
do not retrieve test session from DeliveryExecutionDeleteRequest

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.10.2',
+    'version'     => '37.10.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/ExtendedStateService.php
+++ b/models/classes/ExtendedStateService.php
@@ -296,11 +296,7 @@ class ExtendedStateService extends ConfigurableService implements DeliveryExecut
      */
     public function deleteDeliveryExecutionData(DeliveryExecutionDeleteRequest $request)
     {
-        if ($request->getSession() === null) {
-            $sessionId = $request->getDeliveryExecution()->getIdentifier();
-        } else {
-            $sessionId = $request->getSession()->getSessionId();
-        }
+        $sessionId = $request->getDeliveryExecution()->getIdentifier();
         $extendedState = $this->getExtendedState($sessionId);
         $extendedState->deleteDeliveryExecutionData($request);
 

--- a/models/classes/TestSessionService.php
+++ b/models/classes/TestSessionService.php
@@ -275,11 +275,7 @@ class TestSessionService extends ConfigurableService implements DeliveryExecutio
      */
     public function deleteDeliveryExecutionData(DeliveryExecutionDeleteRequest $request)
     {
-        if ($request->getSession() === null) {
-            $sessionId = $request->getDeliveryExecution()->getIdentifier();
-        } else {
-            $sessionId = $request->getSession()->getSessionId();
-        }
+        $sessionId = $request->getDeliveryExecution()->getIdentifier();
         try {
             $storage = $this->getTestSessionStorage($request->getDeliveryExecution(), false);
             if ($storage instanceof taoQtiTest_helpers_TestSessionStorage) {

--- a/models/classes/runner/time/QtiTimerFactory.php
+++ b/models/classes/runner/time/QtiTimerFactory.php
@@ -26,6 +26,7 @@ use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDelete;
 use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest;
 use oat\taoQtiTest\models\runner\StorageManager;
 use oat\taoQtiTest\models\runner\time\storageFormat\QtiTimeStorageJsonFormat;
+use oat\taoQtiTest\models\TestSessionService;
 use oat\taoTests\models\runner\time\Timer;
 use oat\taoTests\models\runner\time\TimerStrategyInterface;
 use oat\taoTests\models\runner\time\TimeStorage;
@@ -111,11 +112,7 @@ class QtiTimerFactory extends ConfigurableService implements DeliveryExecutionDe
      */
     public function deleteDeliveryExecutionData(DeliveryExecutionDeleteRequest $request)
     {
-        if ($request->getSession() === null) {
-            $sessionId = $request->getDeliveryExecution()->getIdentifier();
-        } else {
-            $sessionId = $request->getSession()->getSessionId();
-        }
+        $sessionId = $request->getDeliveryExecution()->getIdentifier();
         $timer = $this->getTimer($sessionId, $request->getDeliveryExecution()->getUserIdentifier());
         return $timer->delete();
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2059,5 +2059,7 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('37.10.2');
         }
+
+        $this->skip('37.10.2', '37.10.3');
     }
 }


### PR DESCRIPTION
This change is needed to get rid of dependecy of taoDelivery on taoQtiTest (do not use `AssessmentTestSession` in `\oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest`)

`\oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest::getSession()` method must be removed