### PR TITLE
BSA-126 fix: expose item properties as test-item categories in a list-lookup authoring mode

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.11.4',
+    'version'     => '37.11.5',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/creator/ListItemLookup.php
+++ b/models/classes/creator/ListItemLookup.php
@@ -66,17 +66,17 @@ class ListItemLookup extends ConfigurableService implements ItemLookup
             $limit
         );
 
-        $nodeIds = [];
-        foreach ($result['nodes'] as $node) {
-            if ($node['type'] === 'instance') {
-                $nodeIds[] = $node['uri'];
-            }
-        }
+        $nodeIds = array_map(
+            static function (array $node): string {
+                return $node['uri'];
+            },
+            $result['nodes']
+        );
 
         $accessible = $this->getPermissionHelper()->filterByPermission($nodeIds, PermissionInterface::RIGHT_READ);
 
         foreach ($result['nodes'] as $i => &$node) {
-            if ($node['type'] === 'instance' && !in_array($node['uri'], $accessible)) {
+            if (!in_array($node['uri'], $accessible, true)) {
                 unset($result['nodes'][$i]);
                 $result['total']--;
 

--- a/models/classes/creator/ListItemLookup.php
+++ b/models/classes/creator/ListItemLookup.php
@@ -22,11 +22,12 @@
 namespace oat\taoQtiTest\models\creator;
 
 use core_kernel_classes_Class;
+use oat\generis\model\data\permission\PermissionHelper;
 use oat\generis\model\data\permission\PermissionInterface;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\resources\ListResourceLookup;
-use oat\generis\model\data\permission\PermissionHelper;
+use oat\taoItems\model\CategoryService;
 
 /**
  * Look up items and format them as a flat list
@@ -38,14 +39,6 @@ class ListItemLookup extends ConfigurableService implements ItemLookup
     use OntologyAwareTrait;
 
     public const SERVICE_ID = 'taoQtiTest/CreatorItems/list';
-
-    /**
-     * Get the ListResourceLookup
-     */
-    protected function getListResourceLookupService()
-    {
-        return $this->getServiceLocator()->get(ListResourceLookup::SERVICE_ID);
-    }
 
     /**
      * Retrieve QTI Items for the given parameters.
@@ -82,14 +75,32 @@ class ListItemLookup extends ConfigurableService implements ItemLookup
 
         $accessible = $this->getPermissionHelper()->filterByPermission($nodeIds, PermissionInterface::RIGHT_READ);
 
-        foreach ($result['nodes'] as $i => $node) {
+        foreach ($result['nodes'] as $i => &$node) {
             if ($node['type'] === 'instance' && !in_array($node['uri'], $accessible)) {
                 unset($result['nodes'][$i]);
                 $result['total']--;
+
+                continue;
             }
+
+            $node['categories'] = $this->getCategoryService()->getItemCategories($this->getResource($node['uri']));
         }
 
         return $result;
+    }
+
+    /**
+     * Get the ListResourceLookup
+     */
+    protected function getListResourceLookupService()
+    {
+        return $this->getServiceLocator()->get(ListResourceLookup::SERVICE_ID);
+    }
+
+    private function getCategoryService(): CategoryService
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(CategoryService::SERVICE_ID);
     }
 
     private function getPermissionHelper(): PermissionHelper

--- a/models/classes/creator/TreeItemLookup.php
+++ b/models/classes/creator/TreeItemLookup.php
@@ -82,7 +82,6 @@ class TreeItemLookup extends ConfigurableService implements ItemLookup
             return $treeData;
         }
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         $readableResourcesMap = $this->getSecureResourceService()->getAllChildren($root);
 
         $treeData[0]['children'] = array_filter(
@@ -108,10 +107,12 @@ class TreeItemLookup extends ConfigurableService implements ItemLookup
     private function formatTreeData(array $treeData): array
     {
         foreach ($treeData as &$item) {
-            $item['categories'] = $this->getCategoryService()->getItemCategories(
-                new core_kernel_classes_Resource($item['uri'])
-            );
-            if (isset($item['children'])) {
+            if ($item['type'] === 'instance') {
+                $item['categories'] = $this->getCategoryService()->getItemCategories(
+                    new core_kernel_classes_Resource($item['uri'])
+                );
+            }
+            elseif (isset($item['children'])) {
                 $item['children'] = $this->formatTreeData($item['children']);
             }
         }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2060,6 +2060,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('37.10.2');
         }
 
-        $this->skip('37.10.2', '37.11.4');
+        $this->skip('37.10.2', '37.11.5');
     }
 }

--- a/test/unit/models/classes/creator/ListItemLookupTest.php
+++ b/test/unit/models/classes/creator/ListItemLookupTest.php
@@ -3,6 +3,9 @@
 namespace oat\taoQtiTest\test\unit\models\classes\creator;
 
 use core_kernel_classes_Class;
+use core_kernel_classes_Resource as RdfResource;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\data\permission\PermissionHelper;
 use oat\generis\model\data\permission\PermissionInterface;
 use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
@@ -11,9 +14,9 @@ use oat\oatbox\user\User;
 use oat\tao\model\resources\ListResourceLookup;
 use oat\tao\model\resources\ResourceLookup;
 use oat\taoDacSimple\model\PermissionProvider;
+use oat\taoItems\model\CategoryService;
 use oat\taoQtiTest\models\creator\ListItemLookup;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use oat\generis\model\data\permission\PermissionHelper;
 
 /**
  * This program is free software; you can redistribute it and/or
@@ -40,6 +43,9 @@ class ListItemLookupTest extends TestCase
     /** @var array */
     private $permissions = [];
 
+    /** @var PermissionHelper */
+    private $permissionHelper;
+
     /** @var User|MockObject */
     private $userMock;
 
@@ -55,8 +61,11 @@ class ListItemLookupTest extends TestCase
     /** @var PermissionInterface|MockObject */
     private $permissionProviderMock;
 
-    /** @var PermissionHelper */
-    private $permissionHelper;
+    /** @var CategoryService|MockObject */
+    private $categoryServiceMock;
+
+    /** @var Ontology|MockObject */
+    private $ontologyMock;
 
     /** @var ServiceLocatorInterface */
     private $serviceLocatorMock;
@@ -75,12 +84,14 @@ class ListItemLookupTest extends TestCase
 
     public function initializeTestDoubles(): void
     {
+        $this->permissionHelper       = new PermissionHelper();
         $this->userMock               = $this->createMock(User::class);
         $this->rootMock               = $this->createMock(core_kernel_classes_Class::class);
         $this->sessionServiceMock     = $this->createMock(SessionService::class);
         $this->resourceLookupMock     = $this->createMock(ResourceLookup::class);
         $this->permissionProviderMock = $this->createMock(PermissionProvider::class);
-        $this->permissionHelper       = new PermissionHelper();
+        $this->categoryServiceMock    = $this->createMock(CategoryService::class);
+        $this->ontologyMock           = $this->createMock(Ontology::class);
     }
 
     public function initializeTestDoubleExpectancies(): void
@@ -108,9 +119,11 @@ class ListItemLookupTest extends TestCase
             ->method('get')
             ->willReturnMap(
                 [
+                    [Ontology::SERVICE_ID, $this->ontologyMock],
                     [SessionService::SERVICE_ID, $this->sessionServiceMock],
                     [ListResourceLookup::SERVICE_ID, $this->resourceLookupMock],
                     [PermissionInterface::SERVICE_ID, $this->permissionProviderMock],
+                    [CategoryService::SERVICE_ID, $this->categoryServiceMock],
                     [PermissionHelper::class, $this->permissionHelper],
                 ]
             );
@@ -130,12 +143,27 @@ class ListItemLookupTest extends TestCase
     {
         $this->resources = $resources;
 
-        $nodeIds = [];
+        $nodeIds       = [];
+        $resourceMap   = [];
+        $categoriesMap = [];
         foreach ($resources['nodes'] ?? [] as $node) {
             if ($node['type'] === 'instance') {
                 $nodeIds[] = $node['uri'];
             }
+
+            $resource = $this->createMock(RdfResource::class);
+
+            $resourceMap[]   = [$node['uri'], $resource];
+            $categoriesMap[] = [$resource, $node['categories']];
         }
+
+        $this->ontologyMock
+            ->method('getResource')
+            ->willReturnMap($resourceMap);
+
+        $this->categoryServiceMock
+            ->method('getItemCategories')
+            ->willReturnMap($categoriesMap);
 
         $this->permissionProviderMock
             ->expects(static::once())
@@ -171,8 +199,9 @@ class ListItemLookupTest extends TestCase
                 'expected'    => [
                     'nodes' => [
                         [
-                            'uri'  => 'http://child#1',
-                            'type' => 'instance',
+                            'uri'        => 'http://child#1',
+                            'type'       => 'instance',
+                            'categories' => ['child1_category'],
                         ],
                     ],
                     'total' => 1,
@@ -180,8 +209,9 @@ class ListItemLookupTest extends TestCase
                 'resources'   => [
                     'nodes' => [
                         [
-                            'uri'  => 'http://child#1',
-                            'type' => 'instance',
+                            'uri'        => 'http://child#1',
+                            'type'       => 'instance',
+                            'categories' => ['child1_category'],
                         ],
                     ],
                     'total' => 1,
@@ -194,12 +224,14 @@ class ListItemLookupTest extends TestCase
                 'expected'    => [
                     'nodes' => [
                         [
-                            'uri'  => 'http://child#2',
-                            'type' => 'instance',
+                            'uri'        => 'http://child#2',
+                            'type'       => 'instance',
+                            'categories' => ['child2_category'],
                         ],
                         [
-                            'uri'  => 'http://child#3',
-                            'type' => 'class',
+                            'uri'        => 'http://child#3',
+                            'type'       => 'class',
+                            'categories' => ['child3_category'],
                         ],
                     ],
                     'total' => 2,
@@ -207,16 +239,19 @@ class ListItemLookupTest extends TestCase
                 'resources'   => [
                     'nodes' => [
                         [
-                            'uri'  => 'http://child#1',
-                            'type' => 'instance',
+                            'uri'        => 'http://child#1',
+                            'type'       => 'instance',
+                            'categories' => ['child1_category'],
                         ],
                         [
-                            'uri'  => 'http://child#2',
-                            'type' => 'instance',
+                            'uri'        => 'http://child#2',
+                            'type'       => 'instance',
+                            'categories' => ['child2_category'],
                         ],
                         [
-                            'uri'  => 'http://child#3',
-                            'type' => 'class',
+                            'uri'        => 'http://child#3',
+                            'type'       => 'class',
+                            'categories' => ['child3_category'],
                         ],
                     ],
                     'total' => 3,

--- a/test/unit/models/classes/creator/ListItemLookupTest.php
+++ b/test/unit/models/classes/creator/ListItemLookupTest.php
@@ -147,9 +147,7 @@ class ListItemLookupTest extends TestCase
         $resourceMap   = [];
         $categoriesMap = [];
         foreach ($resources['nodes'] ?? [] as $node) {
-            if ($node['type'] === 'instance') {
-                $nodeIds[] = $node['uri'];
-            }
+            $nodeIds[] = $node['uri'];
 
             $resource = $this->createMock(RdfResource::class);
 
@@ -200,7 +198,6 @@ class ListItemLookupTest extends TestCase
                     'nodes' => [
                         [
                             'uri'        => 'http://child#1',
-                            'type'       => 'instance',
                             'categories' => ['child1_category'],
                         ],
                     ],
@@ -210,7 +207,6 @@ class ListItemLookupTest extends TestCase
                     'nodes' => [
                         [
                             'uri'        => 'http://child#1',
-                            'type'       => 'instance',
                             'categories' => ['child1_category'],
                         ],
                     ],
@@ -225,13 +221,7 @@ class ListItemLookupTest extends TestCase
                     'nodes' => [
                         [
                             'uri'        => 'http://child#2',
-                            'type'       => 'instance',
                             'categories' => ['child2_category'],
-                        ],
-                        [
-                            'uri'        => 'http://child#3',
-                            'type'       => 'class',
-                            'categories' => ['child3_category'],
                         ],
                     ],
                     'total' => 2,
@@ -240,18 +230,11 @@ class ListItemLookupTest extends TestCase
                     'nodes' => [
                         [
                             'uri'        => 'http://child#1',
-                            'type'       => 'instance',
                             'categories' => ['child1_category'],
                         ],
                         [
                             'uri'        => 'http://child#2',
-                            'type'       => 'instance',
                             'categories' => ['child2_category'],
-                        ],
-                        [
-                            'uri'        => 'http://child#3',
-                            'type'       => 'class',
-                            'categories' => ['child3_category'],
                         ],
                     ],
                     'total' => 3,

--- a/test/unit/models/classes/creator/TreeItemLookupTest.php
+++ b/test/unit/models/classes/creator/TreeItemLookupTest.php
@@ -134,7 +134,6 @@ class TreeItemLookupTest extends TestCase
                 'expected'            => [
                     [
                         'uri'        => 'http://root',
-                        'categories' => [],
                         'children'   => [
                             [
                                 'uri'        => 'http://child#1',
@@ -163,7 +162,6 @@ class TreeItemLookupTest extends TestCase
                 'expected'            => [
                     [
                         'uri'        => 'http://root',
-                        'categories' => [],
                         'children'   => [
                             [
                                 'uri'        => 'http://child#2',
@@ -173,7 +171,6 @@ class TreeItemLookupTest extends TestCase
                             [
                                 'uri'        => 'http://child#3',
                                 'type'       => 'class',
-                                'categories' => [],
                             ],
                         ],
                     ],


### PR DESCRIPTION
[BSA-126](https://oat-sa.atlassian.net/browse/BSA-126) fix: expose item properties as test-item categories in a list-lookup authoring mode
[BSA-126](https://oat-sa.atlassian.net/browse/BSA-126) fix(performance): do not try reading `categories` of a `class` as only `instance` one can be set

Not directly related to the bug report, but the list view mode didn't expose any properties as categories at all. This PR fixes it.

Related to [`taoItems #402`](https://github.com/oat-sa/extension-tao-item/pull/402).