### PR TITLE
[TAO-10298] Deckard: Timer doesn't countdown in timed section during the delivery execution.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '37.11.2',
+    'version'     => '37.11.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2060,6 +2060,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('37.10.2');
         }
 
-        $this->skip('37.10.2', '37.11.2');
+        $this->skip('37.10.2', '37.11.3');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.6.2.tgz",
-      "integrity": "sha512-FjLv2jxxtQfQ40PuW/KM8K76MM8CErvZjut8RKBZzadClCBQvolh7hwuFQHgrJlfObH/+nQLgUPmj4j9QAv13A=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.6.3.tgz",
+      "integrity": "sha512-R+9b8aGi4lkqlPqlYNtAZFz4reHSG5dwKi6PDYFkW6fuABU6iaGISCX1RccZjNZTQbKqFBtRWBN4y6e4rhDGjw=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TAO-10298-issue-with-keynavigation-and-interactions-without-inputs"
+    "@oat-sa/tao-test-runner-qti": "2.6.3"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.6.2"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TAO-10298-issue-with-keynavigation-and-interactions-without-inputs"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-10298
 
Update package.json
  
#### How to test
 
- prepare an instance of TAO
- import delivery assigned to ticket
- start the delivery as a test taker
- make sure that timer countdown
  
#### Dependencies
   
Companion PR :
 - [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/225