### PR TITLE
TAO-10312 Fix: allow creating a new test under a non ascii labeled class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,9 +58,10 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
+    "ext-dom": "*",
+    "oat-sa/composer-npm-bridge": "^0.3.0",
     "oat-sa/lib-test-cat": "2.3.7",
-    "oat-sa/composer-npm-bridge": "^0.3.0"
+    "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
   },
   "autoload": {
     "psr-4": {
@@ -71,4 +72,3 @@
     }
   }
 }
-

--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.8.1',
+    'version'     => '38.8.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -415,12 +415,14 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
             foreach ($report as $r) {
                 $data = $r->getData();
-                $overwrittenItemsIds = array_keys($data->overwrittenItems);
 
                 // -- Rollback all items.
                 // 1. Simply delete items that were not involved in overwriting.
                 foreach ($data->newItems as $item) {
-                    if (!$item instanceof MetadataGuardianResource && !in_array($item->getUri(), $overwrittenItemsIds)) {
+                    if (
+                        !$item instanceof MetadataGuardianResource
+                        && !array_key_exists($item->getUri(), $data->overwrittenItems)
+                    ) {
                         common_Logger::d("Rollbacking new item '" . $item->getUri() . "'...");
                         @$itemService->deleteResource($item);
                     }
@@ -883,33 +885,6 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
     }
 
     /**
-     * Convenience method that extracts entries of a $path array that correspond
-     * to a given $fileName.
-     *
-     * @param array $paths An array of strings representing absolute paths within a given directory.
-     * @return array $extractedPath The paths that meet the $fileName criterion.
-     */
-    private function filterTestContentDirectory(array $paths, $fileName)
-    {
-        $returnValue = [];
-
-        foreach ($paths as $path) {
-            $pathinfo = pathinfo($path);
-            $pattern = $pathinfo['filename'];
-
-            if (!empty($pathinfo['extension'])) {
-                $pattern .= $pathinfo['extension'];
-            }
-
-            if ($fileName === $pattern) {
-                $returnValue[] = $path;
-            }
-        }
-
-        return $returnValue;
-    }
-
-    /**
      * Get the items from a QTI test document.
      *
      * @param \qtism\data\storage\xml\XmlDocument $doc The QTI XML document to be inspected to retrieve the items.
@@ -975,35 +950,44 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      * Get root qti test directory or crate if not exists
      *
      * @param core_kernel_classes_Resource $test
-     * @param boolean $createTestFile Whether or not create an empty QTI XML test file. Default is (boolean) true.
+     * @param boolean                      $createTestFile Whether or not create an empty QTI XML test file. Default is
+     *                                                     (boolean) true.
+     *
      * @return Directory
+     *
+     * @throws taoQtiTest_models_classes_QtiTestServiceException
+     * @throws common_exception_InconsistentData
+     * @throws core_kernel_persistence_Exception
      */
     public function getQtiTestDir(core_kernel_classes_Resource $test, $createTestFile = true)
     {
         $testModel = $this->getServiceLocator()->get(TestService::class)->getTestModel($test);
-        if ($testModel->getUri() != self::INSTANCE_TEST_MODEL_QTI) {
+
+        if ($testModel->getUri() !== self::INSTANCE_TEST_MODEL_QTI) {
             throw new taoQtiTest_models_classes_QtiTestServiceException(
                 'The selected test is not a QTI test',
                 taoQtiTest_models_classes_QtiTestServiceException::TEST_READ_ERROR
             );
         }
+
         $dir = $test->getOnePropertyValue($this->getProperty(TestService::PROPERTY_TEST_CONTENT));
 
-        if (!is_null($dir)) {
+        if (null !== $dir) {
+            /** @noinspection PhpIncompatibleReturnTypeInspection */
             return $this->getFileReferenceSerializer()->unserialize($dir);
-        } else {
-            return $this->createContent($test, $createTestFile);
         }
+
+        return $this->createContent($test, $createTestFile);
     }
 
     protected function searchInTestDirectory(Directory $dir)
     {
+        $iterator = $dir->getFlyIterator(Directory::ITERATOR_RECURSIVE | Directory::ITERATOR_FILE);
+        $files = [];
 
-            $iterator = $dir->getFlyIterator(Directory::ITERATOR_RECURSIVE | Directory::ITERATOR_FILE);
-            $files = [];
-            /**
-             * @var File $file
-             */
+        /**
+         * @var File $file
+         */
         foreach ($iterator as $file) {
             if ($file->getBasename() === self::TAOQTITEST_FILENAME) {
                 $files[] = $file;
@@ -1014,10 +998,12 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         if (empty($files)) {
             throw new Exception('No QTI-XML test file found.');
         }
-            $file = current($files);
-            $fileName = str_replace($dir->getPrefix() . '/', '', $file->getPrefix());
-            $this->setQtiIndexFile($dir, $fileName);
-            return $file;
+
+        $file = current($files);
+        $fileName = str_replace($dir->getPrefix() . '/', '', $file->getPrefix());
+        $this->setQtiIndexFile($dir, $fileName);
+
+        return $file;
     }
 
     /**
@@ -1191,7 +1177,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      */
     public function getQtiTestAcceptableLatency()
     {
-        $ext = $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)
+        $ext = $this->getServiceLocator()->get(common_ext_ExtensionsManager::SERVICE_ID)
             ->getExtensionById('taoQtiTest');
         $latency = $ext->getConfig(self::CONFIG_QTITEST_ACCEPTABLE_LATENCY);
         if (empty($latency)) {
@@ -1231,8 +1217,6 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
     }
 
     /**
-     * @noinspection PhpDocMissingThrowsInspection
-     *
      * @param string $json
      *
      * @throws ResourceAccessDeniedException
@@ -1253,7 +1237,6 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
             }
         }
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         $this->getSecureResourceService()->validatePermissions($ids, ['READ']);
     }
 }

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -26,6 +26,7 @@ use oat\taoQtiItem\model\qti\Resource;
 use oat\taoQtiItem\model\qti\ImportService;
 use oat\taoQtiTest\models\metadata\MetadataTestContextAware;
 use oat\taoTests\models\event\TestUpdatedEvent;
+use qtism\common\utils\Format;
 use qtism\data\storage\StorageException;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\data\storage\xml\marshalling\UnmarshallingException;
@@ -1082,7 +1083,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
             $doc->documentElement->setAttribute('title', $test->getLabel());
 
             //generate a valid qti identifier
-            $identifier = tao_helpers_Display::textCleaner($test->getLabel(), '*', 32);
+            $identifier = Format::sanitizeIdentifier($test->getLabel());
             $identifier = str_replace('_', '-', $identifier);
             if (preg_match('/^[0-9]/', $identifier)) {
                 $identifier = '_' . $identifier;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2115,6 +2115,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.7.0');
         }
 
-        $this->skip('38.7.0', '38.8.1');
+        $this->skip('38.7.0', '38.8.2');
     }
 }

--- a/test/unit/models/classes/QtiTestServiceTest.php
+++ b/test/unit/models/classes/QtiTestServiceTest.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace oat\taoQtiTest\test\unit\models\classes;
+
+use common_exception_InconsistentData;
+use core_kernel_classes_Property as KernelProperty;
+use core_kernel_classes_Resource as KernelResource;
+use DOMDocument;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\fileReference\FileReferenceSerializer;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\filesystem\Directory;
+use oat\oatbox\filesystem\File;
+use oat\tao\model\service\ApplicationService;
+use qtism\common\utils\Format;
+use taoQtiTest_models_classes_QtiTestService as QtiTestService;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class QtiTestServiceTest extends TestCase
+{
+    private const TEST_TEMPLATE = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+    identifier="{testId}" title="{testTitle}" toolName="tao" toolVersion="{taoVersion}">
+    <testPart navigationMode="linear" submissionMode="individual" identifier="testPart-1">
+        <itemSessionControl maxAttempts="0"/>
+        <assessmentSection identifier="assessmentSection-1" title="Section 1" visible="true" required="true">
+        </assessmentSection>
+    </testPart>
+</assessmentTest>
+XML;
+
+    private const PLATFORM_VERSION = 'v1-test';
+
+    /** @var Directory|MockObject */
+    private $defaultDirectoryMock;
+
+    /** @var FileReferenceSerializer|MockObject */
+    private $fileReferenceSerializerMock;
+
+    /** @var KernelProperty|MockObject */
+    private $testContentPropertyMock;
+
+    /** @var QtiTestService */
+    private $sut;
+
+    /**
+     * @before
+     */
+    public function init(): void
+    {
+        $this->defaultDirectoryMock        = $this->createMock(Directory::class);
+        $this->fileReferenceSerializerMock = $this->createMock(FileReferenceSerializer::class);
+        $this->testContentPropertyMock     = $this->createMock(KernelProperty::class);
+
+        $serviceLocator = $this->creteServiceLocatorMock();
+
+        $this->sut = $this->createPartialMock(
+            QtiTestService::class,
+            ['getDefaultDir', 'getQtiTestTemplateFileAsString', 'getServiceManager']
+        );
+
+        $this->sut
+            ->method('getDefaultDir')
+            ->willReturn($this->defaultDirectoryMock);
+
+        $this->sut
+            ->method('getQtiTestTemplateFileAsString')
+            ->willReturn(self::TEST_TEMPLATE);
+
+        $this->sut
+            ->method('getServiceManager')
+            ->willReturn($serviceLocator);
+
+        $this->sut->setServiceLocator($serviceLocator);
+        $this->sut->setModel(
+            $this->createModelMock()
+        );
+    }
+
+    public function testCreateContent(): void
+    {
+        $test = $this->createTestMock('https://example.com', '0_label-with_sømę-exötïč_charæctêrß');
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $this->assertSame(
+            $this->createDirectoryMock(
+                $test,
+                $this->createNewFileMock($test)
+            ),
+            $this->sut->createContent($test)
+        );
+    }
+
+    public function testOverwriteContent(): void
+    {
+        $test = $this->createTestMock('https://example.com', 'label');
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $this->assertSame(
+            $this->createDirectoryMock(
+                $test,
+                $this->createNewFileMock($test),
+                true,
+                false
+            ),
+            $this->sut->createContent($test, true, false)
+        );
+    }
+
+    public function testExceptionOnExistingContent(): void
+    {
+        $test = $this->createTestMock('https://example.com', 'label');
+
+        $this->expectExceptionObject(
+            new common_exception_InconsistentData("Data directory for test {$test->getUri()} already exists.")
+        );
+
+        $this->createDirectoryMock(
+            $test,
+            null,
+            true
+        );
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $this->sut->createContent($test);
+    }
+
+    public function testExistingContentFile(): void
+    {
+        $test = $this->createTestMock('https://example.com', 'label');
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $this->assertSame(
+            $this->createDirectoryMock(
+                $test,
+                $this->createExistingFileMock($test),
+                true,
+                false
+            ),
+            $this->sut->createContent($test, false, false)
+        );
+    }
+
+    private function createTemplateDocument(): DOMDocument
+    {
+        $document = new DOMDocument('1.0', 'UTF-8');
+
+        $document->loadXML(self::TEST_TEMPLATE);
+
+        return $document;
+    }
+
+    private function createTestDom(KernelResource $test): DOMDocument
+    {
+        $document = $this->createTemplateDocument();
+
+        $this
+            ->updateDocumentTitle($document, $test)
+            ->documentElement->setAttribute(
+                'identifier',
+                str_replace('_', '-', Format::sanitizeIdentifier($test->getLabel()))
+            );
+        $document->documentElement->setAttribute('toolVersion', self::PLATFORM_VERSION);
+
+        return $document;
+    }
+
+    private function updateDocumentTitle(DOMDocument $document, KernelResource $test): DOMDocument
+    {
+        $document->documentElement->setAttribute('title', $test->getLabel());
+
+        return $document;
+    }
+
+    private function createNewFileMock(KernelResource $test): File
+    {
+        $fileMock = $this->createMock(File::class);
+
+        $fileMock
+            ->expects(static::once())
+            ->method('write')
+            ->with(
+                $this->createTestDom($test)->saveXML()
+            )
+            ->willReturn(true);
+
+        return $fileMock;
+    }
+
+    private function createExistingFileMock(KernelResource $test): File
+    {
+        $documentTemplate = $this->createTemplateDocument();
+
+        $fileMock = $this->createMock(File::class);
+
+        $fileMock
+            ->expects(static::once())
+            ->method('exists')
+            ->willReturn(true);
+
+        $fileMock
+            ->expects(static::once())
+            ->method('read')
+            ->willReturn($documentTemplate->saveXML());
+
+        $fileMock
+            ->expects(static::once())
+            ->method('update')
+            ->with(
+                $this->updateDocumentTitle($documentTemplate, $test)->saveXML()
+            )
+            ->willReturn(true);
+
+        return $fileMock;
+    }
+
+    private function createTestMock(string $uri, string $label): KernelResource
+    {
+        $testMock = $this->createMock(KernelResource::class);
+
+        $testMock
+            ->method('getUri')
+            ->willReturn($uri);
+
+        $testMock
+            ->method('getLabel')
+            ->willReturn($label);
+
+        return $testMock;
+    }
+
+    /**
+     * @param KernelResource|MockObject $test
+     * @param File|MockObject|null      $file
+     * @param bool                      $exists
+     * @param bool                      $preventOverride
+     *
+     * @return Directory
+     */
+    private function createDirectoryMock(
+        KernelResource $test,
+        File $file = null,
+        bool $exists = false,
+        $preventOverride = true
+    ): Directory {
+        $mainInvocationRule = !$exists || !$preventOverride ? static::once() : static::never();
+
+        $directoryMock = $this->createMock(Directory::class);
+
+        $directoryMock
+            ->expects(static::once())
+            ->method('exists')
+            ->willReturn($exists);
+
+        $directoryMock
+            ->expects(clone $mainInvocationRule)
+            ->method('getFile')
+            ->with('tao-qtitest-testdefinition.xml')
+            ->willReturn($file);
+
+        $this->defaultDirectoryMock
+            ->expects(static::once())
+            ->method('getDirectory')
+            ->with(md5($test->getUri()))
+            ->willReturn($directoryMock);
+
+        $serializedDirectoryData = 'serialized_directory_data';
+
+        $this->fileReferenceSerializerMock
+            ->expects(clone $mainInvocationRule)
+            ->method('serialize')
+            ->with($directoryMock)
+            ->willReturn($serializedDirectoryData);
+
+        $test
+            ->expects(clone $mainInvocationRule)
+            ->method('editPropertyValues')
+            ->with($this->testContentPropertyMock, $serializedDirectoryData);
+
+        return $directoryMock;
+    }
+
+    private function creteServiceLocatorMock(): ServiceLocatorInterface
+    {
+        $serviceLocatorMock = $this->createMock(ServiceLocatorInterface::class);
+        $serviceLocatorMock
+            ->method('get')
+            ->willReturnMap(
+                [
+                    [ApplicationService::SERVICE_ID, $this->createApplicationServiceMock()],
+                    [FileReferenceSerializer::SERVICE_ID, $this->fileReferenceSerializerMock],
+                ]
+            );
+
+        return $serviceLocatorMock;
+    }
+
+    private function createModelMock(): Ontology
+    {
+        $modelMock = $this->createMock(Ontology::class);
+
+        $modelMock
+            ->method('getProperty')
+            ->willReturnMap(
+                [
+                    ['http://www.tao.lu/Ontologies/TAOTest.rdf#TestContent', $this->testContentPropertyMock],
+                ]
+            );
+
+        return $modelMock;
+    }
+
+    private function createApplicationServiceMock(): ApplicationService
+    {
+        $applicationServiceMock = $this->createMock(ApplicationService::class);
+
+        $applicationServiceMock
+            ->method('getPlatformVersion')
+            ->willReturn(self::PLATFORM_VERSION);
+
+        return $applicationServiceMock;
+    }
+}


### PR DESCRIPTION
- [TAO-10312](https://oat-sa.atlassian.net/browse/TAO-10312) chore: clean up `taoQtiTest_models_classes_QtiTestService`'s static analyzer warning causes
- [TAO-10312](https://oat-sa.atlassian.net/browse/TAO-10312) fix: sanitize a test's identifier during its creation by means of QTI SDK's `Format::sanitizeIdentifier()`
- [TAO-10312](https://oat-sa.atlassian.net/browse/TAO-10312) chore(version): bump a fix one

The actual fix is [here](https://github.com/oat-sa/extension-tao-testqti/pull/1816/commits/66df3109af42be36faa17a63b7b7ac40dfaac75d), the rest was mostly about static analyzer warning fixes.

### How to test
- Create a test class (directory) with non-ascii letters in its label
- Try to create a test instance under it