### PR TITLE
Fix/tca 607/fix issue when proctor screen with terminated sessions is broken

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.4.1',
+    'version'     => '38.4.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -30,6 +30,8 @@ use oat\taoQtiTest\models\cat\CatService;
 use oat\taoTests\models\runner\time\TimePoint;
 use qtism\common\datatypes\Duration;
 use qtism\common\datatypes\QtiDuration;
+use qtism\data\AssessmentSection;
+use qtism\data\TestPart;
 use qtism\runtime\tests\AssessmentItemSession;
 use qtism\runtime\tests\AssessmentTestPlace;
 use qtism\runtime\tests\AssessmentTestSessionException;
@@ -402,19 +404,21 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
         $routeItem = $this->getCurrentRouteItem();
         $considerMinTime = $this->mustConsiderMinTime();
 
-        if ($places & AssessmentTestPlace::ASSESSMENT_TEST) {
+        if (($places & AssessmentTestPlace::ASSESSMENT_TEST) && ($routeItem instanceof RouteItem)) {
             $constraints[] = $this->getTimeConstraint($routeItem->getAssessmentTest(), $navigationMode, $considerMinTime, $applyExtraTime);
         }
 
-        if ($places & AssessmentTestPlace::TEST_PART) {
-            $constraints[] = $this->getTimeConstraint($this->getCurrentTestPart(), $navigationMode, $considerMinTime, $applyExtraTime);
+        $currentTestPart = $this->getCurrentTestPart();
+        if (($places & AssessmentTestPlace::TEST_PART) && ($currentTestPart instanceof TestPart)) {
+            $constraints[] = $this->getTimeConstraint($currentTestPart, $navigationMode, $considerMinTime, $applyExtraTime);
         }
 
-        if ($places & AssessmentTestPlace::ASSESSMENT_SECTION) {
-            $constraints[] = $this->getTimeConstraint($this->getCurrentAssessmentSection(), $navigationMode, $considerMinTime, $applyExtraTime);
+        $currentAssessmentSection = $this->getCurrentAssessmentSection();
+        if (($places & AssessmentTestPlace::ASSESSMENT_SECTION) && ($currentAssessmentSection instanceof AssessmentSection)) {
+            $constraints[] = $this->getTimeConstraint($currentAssessmentSection, $navigationMode, $considerMinTime, $applyExtraTime);
         }
 
-        if ($places & AssessmentTestPlace::ASSESSMENT_ITEM) {
+        if (($places & AssessmentTestPlace::ASSESSMENT_ITEM) && ($routeItem instanceof RouteItem)) {
             $constraints[] = $this->getTimeConstraint($routeItem->getAssessmentItemRef(), $navigationMode, $considerMinTime, $applyExtraTime);
         }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2087,6 +2087,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.2.0');
         }
 
-        $this->skip('38.2.0', '38.4.1');
+        $this->skip('38.2.0', '38.4.2');
     }
 }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TCA-607

To implement this ticket we had to get current time constraint from each test session and read remaining time and timer modifications from it. 
It introduced the error when there are terminated test tessions in the list. For terminated sessions there qti sdk doesn't return route item, assessment test and current assessment session/part.

Fix: Check if value returned by QTI SDK returns entity of required interface before using it.
