### PR TITLE
Update test-runner

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.4.2',
+    'version'     => '38.5.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2087,6 +2087,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.2.0');
         }
 
-        $this->skip('38.2.0', '38.4.2');
+        $this->skip('38.2.0', '38.5.0');
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.10.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#feature/TCA-597/screen-readers-adjustments"
   }
 }


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-622

**Description**
Redundant aria-label on contrast button.

**How to test**
1. Start test as a test taker
2. Navigate to the Color Contrast button
3. SR should announce "Change the current color preset" only once

#### Dependencies 

Requires :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/242