### PR TITLE
Feature/inv 168/xml editor new tab

### DIFF
--- a/actions/class.XmlEditor.php
+++ b/actions/class.XmlEditor.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+class taoQtiTest_actions_XmlEditor extends tao_actions_ServiceModule
+{
+   public function edit()
+   {
+       $this->setView('XmlEditor/xml_editor.tpl');
+   }
+}

--- a/actions/class.XmlEditor.php
+++ b/actions/class.XmlEditor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,7 +22,7 @@
 
 class taoQtiTest_actions_XmlEditor extends tao_actions_ServiceModule
 {
-   public function edit()
+   public function edit() : void
    {
        $this->setView('XmlEditor/xml_editor.tpl');
    }

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -5,7 +5,7 @@
         <sections>
             <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
                 <actions allowClassActions="true">
-                    <action id="test-xml-editor" name="XML Editor"  url="/taoQtiTest/xmlEditor/edit" group="content" context="instance">
+                    <action id="test-xml-editor" name="XML Editor"  url="/taoQtiTest/XmlEditor/edit" group="content" context="instance">
                         <icon id="icon-edit"/>
                     </action>
                 </actions>

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE structures SYSTEM "../../tao/doc/structures.dtd">
+<structures>
+    <structure id="tests" name="Tests" level="1" group="main">
+        <sections>
+            <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
+                <actions allowClassActions="true">
+                    <action id="test-xml-editor" name="XML Editor"  url="/taoQtiTest/xmlEditor/edit" group="content" context="instance">
+                        <icon id="icon-edit"/>
+                    </action>
+                </actions>
+            </section>
+        </sections>
+    </structure>
+</structures>

--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.5.0',
+    'version'     => '38.6.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -39,6 +39,7 @@ use oat\taoQtiTest\scripts\install\SetSynchronisationService;
 use oat\taoQtiTest\scripts\install\SetupEventListeners;
 use oat\taoQtiTest\scripts\install\SetUpQueueTasks;
 use oat\taoQtiTest\scripts\install\SyncChannelInstaller;
+use oat\taoQtiTest\models\xmlEditor\XmlEditorInterface;
 
 $extpath = __DIR__ . DIRECTORY_SEPARATOR;
 $taopath = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'tao' . DIRECTORY_SEPARATOR;
@@ -109,6 +110,8 @@ return [
         ['grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole', ['ext' => 'taoQtiTest', 'mod' => 'Items']],
         ['grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole', ['ext' => 'taoQtiTest', 'mod' => 'RestQtiTests']],
         ['grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoQtiTest', 'mod' => 'RestQtiTests']],
+        ['deny', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole', ['ext' => 'taoQtiTest', 'mod' => 'XmlEditor']],
+        ['grant', XmlEditorInterface::XML_EDITOR_ROLE, ['ext' => 'taoQtiTest', 'mod' => 'XmlEditor']]
     ],
     'constants' => [
         # actions directory

--- a/models/classes/xmlEditor/XmlEditorInterface.php
+++ b/models/classes/xmlEditor/XmlEditorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+
+namespace oat\taoQtiTest\models\xmlEditor;
+
+interface XmlEditorInterface
+{
+    public const XML_EDITOR_ROLE = 'http://www.tao.lu/Ontologies/generis.rdf#TestXMLEditor';
+}

--- a/models/classes/xmlEditor/XmlEditorInterface.php
+++ b/models/classes/xmlEditor/XmlEditorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/models/ontology/qtitest.rdf
+++ b/models/ontology/qtitest.rdf
@@ -5,6 +5,8 @@
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:test="http://www.tao.lu/Ontologies/TAOTest.rdf#"
 	xmlns:wf="http://www.tao.lu/middleware/wfEngine.rdf#"
+    xmlns:generis="http://www.tao.lu/Ontologies/generis.rdf#"
+    xmlns:tao="http://www.tao.lu/Ontologies/TAO.rdf#">
 >
 
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOTest.rdf#QtiTestModel">
@@ -36,5 +38,13 @@
     <wf:PropertyServiceDefinitionsFormalParameterIn rdf:resource="http://www.tao.lu/Ontologies/TAOTest.rdf#FormalParamQtiTestDefinition"/>
     <wf:PropertyServiceDefinitionsFormalParameterIn rdf:resource="http://www.tao.lu/Ontologies/TAOTest.rdf#FormalParamQtiTestCompilation"/>
   </rdf:Description>
+
+  <!-- XML Editor Role -->
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#TestXMLEditor">
+      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#UserRole"/>
+      <rdfs:label xml:lang="en-US"><![CDATA[Test XML Editor]]></rdfs:label>
+      <rdfs:comment xml:lang="en-US"><![CDATA[The Test XML Editor Role]]></rdfs:comment>
+      <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#BackOfficeRole"/>
+    </rdf:Description>
   
 </rdf:RDF>

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -79,6 +79,7 @@ use oat\taoQtiTest\models\TestCategoryRulesService;
 use oat\taoQtiTest\models\TestModelService;
 use oat\taoQtiTest\models\TestRunnerClientConfigRegistry;
 use oat\taoQtiTest\models\TestSessionService;
+use oat\taoQtiTest\models\xmlEditor\XmlEditorInterface;
 use oat\taoQtiTest\scripts\install\RegisterCreatorServices;
 use oat\taoQtiTest\scripts\install\RegisterTestRunnerPlugins;
 use oat\taoQtiTest\scripts\install\SetSynchronisationService;
@@ -2087,6 +2088,16 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.2.0');
         }
 
-        $this->skip('38.2.0', '38.6.0');
+        $this->skip('38.2.0', '38.5.0');
+
+        if ($this->isVersion('38.5.0')) {
+            OntologyUpdater::syncModels();
+
+            AclProxy::applyRule(new AccessRule('deny', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole', ['ext' => 'taoQtiTest', 'mod' => 'XmlEditor']));
+            AclProxy::applyRule(new AccessRule('grant', XmlEditorInterface::XML_EDITOR_ROLE, ['ext' => 'taoQtiTest', 'mod' => 'XmlEditor']));
+
+            $this->setVersion('38.6.0');
+
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2087,6 +2087,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.2.0');
         }
 
-        $this->skip('38.2.0', '38.5.0');
+        $this->skip('38.2.0', '38.6.0');
     }
 }

--- a/views/templates/XmlEditor/xml_editor.tpl
+++ b/views/templates/XmlEditor/xml_editor.tpl
@@ -1,0 +1,3 @@
+<div id="xml-editor" data-content-target="wide">
+    <textarea rows="10" cols="45" name="text"></textarea>
+</div>


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INV-169
Steps:
1. Login by a user without `Xml Editor Role`. The tab will be disabled
2. Login by a user with `Xml Editor Role`. The tab will be enabled

https://oat-sa.atlassian.net/browse/INV-168 
Steps:
1. Open 'Tests' page
2. Open the new tab 'XML Editor'
