### PR TITLE
version bump

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.5.0',
+    'version'     => '38.5.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2087,6 +2087,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.2.0');
         }
 
-        $this->skip('38.2.0', '38.5.0');
+        $this->skip('38.2.0', '38.5.1');
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.10.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#feature/TCA-664/close-shortcuts-popup-by-esc"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-664
 
shortcuts popup is closable by ESC key
  
#### How to test
 
- prepare an instance of TAO
- prepare a delivery with enabled accesibility mode
- execute the delivery as a test taker
- try to navigate to shortcuts popup via jumplinks
- make sure shortcuts popup is closable by ESC key
  
#### Dependencies

Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/249