### PR TITLE
Feature/tao 10137/export qti test package to file in shared filesystem

### DIFF
--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -66,7 +66,7 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
             return $this->returnFailure(new common_exception_ResourceNotFound('Resource not found'));
         }
 
-        $qtiPackage = $this->getQtiPackageExporter()->exportDeliveryQtiPackage($test);
+        $qtiPackage = $this->getQtiPackageExporter()->exportDeliveryQtiPackage($test->getUri());
 
         $data[self::PARAM_PACKAGE_NAME] = base64_encode(file_get_contents($qtiPackage['path']));
 

--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -66,9 +66,9 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
             return $this->returnFailure(new common_exception_ResourceNotFound('Resource not found'));
         }
 
-        $qtiPackage = $this->getQtiPackageExporter()->exportDeliveryQtiPackage($test->getUri());
+        $exportReport = $this->getQtiPackageExporter()->exportDeliveryQtiPackage($test->getUri());
 
-        $data[self::PARAM_PACKAGE_NAME] = base64_encode(file_get_contents($qtiPackage['path']));
+        $data[self::PARAM_PACKAGE_NAME] = base64_encode(file_get_contents($exportReport->getData()['path']));
 
         return $this->returnSuccess($data);
     }

--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -250,7 +250,7 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
     /**
      * @return QtiPackageExporter
      */
-    private function getQtiPackageExporter()
+    private function getQtiPackageExporter(): QtiPackageExporter
     {
         return $this->getServiceLocator()->get(QtiPackageExporter::SERVICE_ID);
     }

--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -252,6 +252,6 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
      */
     private function getQtiPackageExporter()
     {
-        return $this->getServiceLocator()->get(QtiPackageExporter::class);
+        return $this->getServiceLocator()->get(QtiPackageExporter::SERVICE_ID);
     }
 }

--- a/helpers/QtiPackageExporter.php
+++ b/helpers/QtiPackageExporter.php
@@ -27,7 +27,6 @@ use oat\oatbox\filesystem\FileSystemService;
 use oat\tao\helpers\FileHelperService;
 use oat\tao\model\service\InjectionAwareService;
 use taoQtiTest_models_classes_export_TestExport22 as TestExporter;
-use core_kernel_classes_Resource as RdfResource;
 
 class QtiPackageExporter extends InjectionAwareService
 {
@@ -54,36 +53,40 @@ class QtiPackageExporter extends InjectionAwareService
     }
 
     /**
-     * @param RdfResource $test
+     * @param string $testUri
      *
      * @return array
      * @throws common_Exception
      * @throws common_exception_Error
      */
-    public function exportDeliveryQtiPackage(RdfResource $test)
+    public function exportDeliveryQtiPackage(string $testUri)
     {
         $exportReport = $this->testExporter->export(
             [
             'filename' => self::QTI_PACKAGE_FILENAME,
-            'instances' => $test->getUri(),
-            'uri' => $test->getUri()
+            'instances' => $testUri,
+            'uri' => $testUri
             ],
             $this->fileHelperService->createTempDir()
         );
+
+        if ($exportReport->containsError()) {
+            throw new common_Exception('QTI Test package export failed.');
+        }
 
         return $exportReport->getData();
     }
 
     /**
-     * @param RdfResource $test
+     * @param string $testUri
      * @param string $fileSystemId
      * @param string $filePath
      * @return File
      * @throws common_Exception
      */
-    public function exportQtiTestPackageToFile(RdfResource $test, string $fileSystemId, string $filePath): File
+    public function exportQtiTestPackageToFile(string $testUri, string $fileSystemId, string $filePath): File
     {
-        $result = $this->exportDeliveryQtiPackage($test);
+        $result = $this->exportDeliveryQtiPackage($testUri);
 
         return $this->moveFileToSharedFileSystem($result['path'], $fileSystemId, $filePath);
     }

--- a/helpers/QtiPackageExporter.php
+++ b/helpers/QtiPackageExporter.php
@@ -63,9 +63,9 @@ class QtiPackageExporter extends InjectionAwareService
     {
         $exportReport = $this->testExporter->export(
             [
-            'filename' => self::QTI_PACKAGE_FILENAME,
-            'instances' => $testUri,
-            'uri' => $testUri
+                'filename' => self::QTI_PACKAGE_FILENAME,
+                'instances' => $testUri,
+                'uri' => $testUri
             ],
             $this->fileHelperService->createTempDir()
         );
@@ -87,6 +87,9 @@ class QtiPackageExporter extends InjectionAwareService
     public function exportQtiTestPackageToFile(string $testUri, string $fileSystemId, string $filePath): File
     {
         $result = $this->exportDeliveryQtiPackage($testUri);
+        if (!isset($result['path']) || !is_string($result['path'])) {
+            throw new common_Exception('Export report does not contain path to exported QTI package: ' . json_encode($result));
+        }
 
         return $this->moveFileToSharedFileSystem($result['path'], $fileSystemId, $filePath);
     }

--- a/helpers/QtiPackageExporter.php
+++ b/helpers/QtiPackageExporter.php
@@ -22,6 +22,7 @@ namespace oat\taoQtiTest\helpers;
 
 use common_Exception;
 use common_exception_Error;
+use common_report_Report;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\tao\helpers\FileHelperService;
@@ -70,7 +71,7 @@ class QtiPackageExporter extends InjectionAwareService
             $this->fileHelperService->createTempDir()
         );
 
-        if ($exportReport->containsError()) {
+        if ($exportReport->getType() === common_report_Report::TYPE_ERROR) {
             throw new common_Exception('QTI Test package export failed.');
         }
 

--- a/helpers/QtiPackageExporter.php
+++ b/helpers/QtiPackageExporter.php
@@ -75,6 +75,11 @@ class QtiPackageExporter extends InjectionAwareService
             throw new common_Exception('QTI Test package export failed.');
         }
 
+        $reportData = $exportReport->getData();
+        if (!isset($reportData['path']) || !is_string($reportData['path'])) {
+            throw new common_Exception('Export report does not contain path to exported QTI package: ' . json_encode($reportData));
+        }
+
         return $exportReport;
     }
 
@@ -88,9 +93,6 @@ class QtiPackageExporter extends InjectionAwareService
     public function exportQtiTestPackageToFile(string $testUri, string $fileSystemId, string $filePath): File
     {
         $result = $this->exportDeliveryQtiPackage($testUri)->getData();
-        if (!isset($result['path']) || !is_string($result['path'])) {
-            throw new common_Exception('Export report does not contain path to exported QTI package: ' . json_encode($result));
-        }
 
         return $this->moveFileToSharedFileSystem($result['path'], $fileSystemId, $filePath);
     }
@@ -106,7 +108,8 @@ class QtiPackageExporter extends InjectionAwareService
     {
         $source = $this->fileHelperService->readFile($sourceFilePath);
 
-        $file = $this->fileSystemService->getDirectory($fileSystemId)
+        $file = $this->fileSystemService
+            ->getDirectory($fileSystemId)
             ->getFile($destinationFilePath);
         $file->put($source);
 

--- a/helpers/QtiPackageExporter.php
+++ b/helpers/QtiPackageExporter.php
@@ -56,7 +56,7 @@ class QtiPackageExporter extends InjectionAwareService
     /**
      * @param string $testUri
      *
-     * @return array
+     * @return common_report_Report
      * @throws common_Exception
      * @throws common_exception_Error
      */

--- a/helpers/QtiPackageExporter.php
+++ b/helpers/QtiPackageExporter.php
@@ -60,7 +60,7 @@ class QtiPackageExporter extends InjectionAwareService
      * @throws common_Exception
      * @throws common_exception_Error
      */
-    public function exportDeliveryQtiPackage(string $testUri)
+    public function exportDeliveryQtiPackage(string $testUri): common_report_Report
     {
         $exportReport = $this->testExporter->export(
             [
@@ -75,7 +75,7 @@ class QtiPackageExporter extends InjectionAwareService
             throw new common_Exception('QTI Test package export failed.');
         }
 
-        return $exportReport->getData();
+        return $exportReport;
     }
 
     /**
@@ -87,7 +87,7 @@ class QtiPackageExporter extends InjectionAwareService
      */
     public function exportQtiTestPackageToFile(string $testUri, string $fileSystemId, string $filePath): File
     {
-        $result = $this->exportDeliveryQtiPackage($testUri);
+        $result = $this->exportDeliveryQtiPackage($testUri)->getData();
         if (!isset($result['path']) || !is_string($result['path'])) {
             throw new common_Exception('Export report does not contain path to exported QTI package: ' . json_encode($result));
         }

--- a/manifest.php
+++ b/manifest.php
@@ -25,6 +25,7 @@ use oat\taoQtiTest\scripts\install\RegisterCreatorServices;
 use oat\taoQtiTest\scripts\install\RegisterFrontendPaths;
 use oat\taoQtiTest\scripts\install\RegisterQtiCategoryPresetProviders;
 use oat\taoQtiTest\scripts\install\RegisterQtiFlysystemManager;
+use oat\taoQtiTest\scripts\install\RegisterQtiPackageExporter;
 use oat\taoQtiTest\scripts\install\RegisterSectionPauseService;
 use oat\taoQtiTest\scripts\install\RegisterTestCategoryPresetProviderService;
 use oat\taoQtiTest\scripts\install\RegisterTestContainer;
@@ -48,12 +49,12 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.5.0',
+    'version'     => '38.6.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',
         'taoTests'   => '>=14.0.0',
-        'tao'        => '>=42.12.0',
+        'tao'        => '>=42.13.0',
         'generis'    => '>=12.20.0',
         'taoDelivery' => '>=14.10.0',
         'taoItems'   => '>=6.0.0',
@@ -89,7 +90,8 @@ return [
             SetLinearNextItemWarningConfig::class,
             RegisterFrontendPaths::class,
             RegisterTimerStrategyService::class,
-            RegisterTimerAdjustmentService::class
+            RegisterTimerAdjustmentService::class,
+            RegisterQtiPackageExporter::class
         ]
     ],
     'update' => 'oat\\taoQtiTest\\scripts\\update\\Updater',

--- a/scripts/install/RegisterQtiPackageExporter.php
+++ b/scripts/install/RegisterQtiPackageExporter.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\scripts\install;
+
+use common_report_Report;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\tao\helpers\FileHelperService;
+use oat\taoQtiTest\helpers\QtiPackageExporter;
+use taoQtiTest_models_classes_export_TestExport22;
+use oat\oatbox\extension\InstallAction;
+
+class RegisterQtiPackageExporter extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $serviceManager = $this->getServiceManager();
+        $qtiPackageExporter = new QtiPackageExporter(
+            new taoQtiTest_models_classes_export_TestExport22(),
+            $serviceManager->get(FileSystemService::SERVICE_ID),
+            $serviceManager->get(FileHelperService::class)
+        );
+        $serviceManager->register(QtiPackageExporter::SERVICE_ID, $qtiPackageExporter);
+
+        return new common_report_Report(
+            common_report_Report::TYPE_SUCCESS,
+            'QtiPackageExporter successfully registered.'
+        );
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -80,6 +80,7 @@ use oat\taoQtiTest\models\TestModelService;
 use oat\taoQtiTest\models\TestRunnerClientConfigRegistry;
 use oat\taoQtiTest\models\TestSessionService;
 use oat\taoQtiTest\scripts\install\RegisterCreatorServices;
+use oat\taoQtiTest\scripts\install\RegisterQtiPackageExporter;
 use oat\taoQtiTest\scripts\install\RegisterTestRunnerPlugins;
 use oat\taoQtiTest\scripts\install\SetSynchronisationService;
 use oat\taoQtiTest\scripts\install\SetupEventListeners;
@@ -2088,5 +2089,10 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('38.2.0', '38.5.0');
+
+        if ($this->isVersion('38.5.0')) {
+            $this->runExtensionScript(RegisterQtiPackageExporter::class);
+            $this->setVersion('38.6.0');
+        }
     }
 }

--- a/test/integration/QtiPackageExportTest.php
+++ b/test/integration/QtiPackageExportTest.php
@@ -23,6 +23,7 @@ namespace oat\taoQtiTest\test\integration;
 use Exception;
 use oat\generis\model\data\ModelManager;
 use oat\generis\model\data\Ontology;
+use oat\oatbox\service\ServiceManager;
 use oat\tao\test\integration\RestTestRunner;
 use oat\taoQtiTest\helpers\QtiPackageExporter;
 use Slim\Http\Headers;
@@ -46,8 +47,9 @@ class QtiPackageExportTest extends RestTestRunner
     public function setUp(): void
     {
         parent::setUp();
+
         $this->serviceLocatorMock = $this->getServiceLocatorMock([
-            QtiPackageExporter::class => new QtiPackageExporter(),
+            QtiPackageExporter::SERVICE_ID => ServiceManager::getServiceManager()->get(QtiPackageExporter::SERVICE_ID),
             Ontology::SERVICE_ID => ModelManager::getModel(),
         ]);
     }

--- a/test/unit/helpers/QtiPackageExporterTest.php
+++ b/test/unit/helpers/QtiPackageExporterTest.php
@@ -99,29 +99,32 @@ class QtiPackageExporterTest extends TestCase
         $fileSystemId = 'FILE_SYSTEM_ID';
         $filePath = 'FILE_PATH';
 
+        $expectedFileContent =  'EXPORTED_FILE_CONTENT';
         $expectedReport = common_report_Report::createSuccess('FAKE ERROR MESSAGE');
         $expectedReport->setData(['path' => 'FAKE_QTI_PACKAGE_PATH']);
         $this->exporterMock->method('export')
             ->willReturn($expectedReport);
 
         $this->fileHelperServiceMock->method('readFile')
-            ->willReturn('FILE_RESOURCE');
+            ->willReturn($expectedFileContent);
 
         $fileMock = $this->createMock(File::class);
+        $fileMock->expects(self::once())
+            ->method('put')
+            ->with($expectedFileContent);
         $directoryMock = $this->createMock(Directory::class);
-        $directoryMock->method('getFile')
+        $directoryMock->expects(self::once())
+            ->method('getFile')
+            ->with($filePath)
             ->willReturn($fileMock);
 
-        $this->fileSystemServiceMock->method('getDirectory')
+        $this->fileSystemServiceMock
+            ->expects(self::once())
+            ->method('getDirectory')
+            ->with($fileSystemId)
             ->willReturn($directoryMock);
 
-        $result = $this->subject->exportQtiTestPackageToFile($testUri, $fileSystemId, $filePath);
-
-        self::assertInstanceOf(
-            File::class,
-            $result,
-            'Method must return instance of File in case of successful export.'
-        );
+        $this->subject->exportQtiTestPackageToFile($testUri, $fileSystemId, $filePath);
     }
 
     /**

--- a/test/unit/helpers/QtiPackageExporterTest.php
+++ b/test/unit/helpers/QtiPackageExporterTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\helpers;
+
+use common_Exception;
+use common_report_Report;
+use oat\oatbox\filesystem\Directory;
+use oat\oatbox\filesystem\File;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\tao\helpers\FileHelperService;
+use taoQtiTest_models_classes_export_TestExport22;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\taoQtiTest\helpers\QtiPackageExporter;
+
+class QtiPackageExporterTest extends TestCase
+{
+    /** @var QtiPackageExporter */
+    private $subject;
+
+    /** @var taoQtiTest_models_classes_export_TestExport22|MockObject */
+    private $exporterMock;
+
+    /** @var FileSystemService|MockObject */
+    private $fileSystemServiceMock;
+
+    /** @var FileHelperService|MockObject */
+    private $fileHelperServiceMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->exporterMock = $this->createMock(taoQtiTest_models_classes_export_TestExport22::class);
+        $this->fileSystemServiceMock = $this->createMock(FileSystemService::class);
+        $this->fileHelperServiceMock = $this->createMock(FileHelperService::class);
+        $this->fileHelperServiceMock->method('createTempDir')->willReturn('FAKE_TMP_DIR');
+
+        $this->subject = new QtiPackageExporter(
+            $this->exporterMock,
+            $this->fileSystemServiceMock,
+            $this->fileHelperServiceMock
+        );
+    }
+
+    public function testExportDeliveryQtiPackage_ThrowsExceptionWhenExportFails(): void
+    {
+        $testUri = 'FAKE_TEST_URI';
+
+        $expectedReport = common_report_Report::createFailure('FAKE ERROR MESSAGE');
+        $this->exporterMock->method('export')
+            ->willReturn($expectedReport);
+
+        $this->expectException(common_Exception::class);
+        $this->subject->exportDeliveryQtiPackage($testUri);
+    }
+
+    /**
+     * @param array $reportData
+     *
+     * @dataProvider dataProviderReportDataWithoutValidPath
+     */
+    public function testExportQtiTestPackageToFile_ThrowsExceptionWhenReportDoesNotHaveValidPath(array $reportData): void
+    {
+        $testUri = 'FAKE_TEST_URI';
+        $fileSystemId = 'FILE_SYSTEM_ID';
+        $filePath = 'FILE_PATH';
+
+        $expectedReport = common_report_Report::createSuccess('FAKE ERROR MESSAGE');
+        $expectedReport->setData($reportData);
+
+        $this->exporterMock->method('export')
+            ->willReturn($expectedReport);
+
+        $this->expectException(common_Exception::class);
+        $this->subject->exportQtiTestPackageToFile($testUri, $fileSystemId, $filePath);
+    }
+
+    public function testExportQtiTestPackageToFile_ReturnsValidFileAfterSuccessfulExport(): void
+    {
+        $testUri = 'FAKE_TEST_URI';
+        $fileSystemId = 'FILE_SYSTEM_ID';
+        $filePath = 'FILE_PATH';
+
+        $expectedReport = common_report_Report::createSuccess('FAKE ERROR MESSAGE');
+        $expectedReport->setData(['path' => 'FAKE_QTI_PACKAGE_PATH']);
+        $this->exporterMock->method('export')
+            ->willReturn($expectedReport);
+
+        $this->fileHelperServiceMock->method('readFile')
+            ->willReturn('FILE_RESOURCE');
+
+        $fileMock = $this->createMock(File::class);
+        $directoryMock = $this->createMock(Directory::class);
+        $directoryMock->method('getFile')
+            ->willReturn($fileMock);
+
+        $this->fileSystemServiceMock->method('getDirectory')
+            ->willReturn($directoryMock);
+
+        $result = $this->subject->exportQtiTestPackageToFile($testUri, $fileSystemId, $filePath);
+
+        self::assertInstanceOf(
+            File::class,
+            $result,
+            'Method must return instance of File in case of successful export.'
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderReportDataWithoutValidPath(): array
+    {
+        return [
+            'No path key' => [
+                'reportData' => [],
+            ],
+            'Path is not a string' => [
+                'reportData' => [
+                    'path' => ['some array value'],
+                ],
+            ],
+        ];
+    }
+}
+


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TAO-10137

According to prepared implementation plan we have to be able to publish delivery to remote environment(s) as a separate action on Deliveries page after delivery is created. We publish QTI test package between two environments and recreate delivery on the target environment. To make sure that we publish exactly the same delivery we have to publish exactly the same test. Because of that when delivery is created we have to  export snapshot of origin test from which delivery was created and store it in shared file system to be able to use later for remote publishing.
Added method to export QTI test to specified file path on shared file system. Refactored exporter class to be able to provide all dependencies via constructor.

How to test:
Not possible to test via UI yet.
Call to `exportQtiTestPackageToFile` with existing test uri, file system ID and new file path -> test must be exported to this file.

Requires:
- [ ] https://github.com/oat-sa/tao-core/pull/2543