### PR TITLE
Feature BSA-147 selector load classes and items at the same time

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.10.3',
+    'version'     => '38.11.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.5.0',
+    'version'     => '38.6.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2115,6 +2115,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.7.0');
         }
 
-        $this->skip('38.7.0', '38.10.3');
+        $this->skip('38.7.0', '38.11.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2087,6 +2087,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.2.0');
         }
 
-        $this->skip('38.2.0', '38.5.0');
+        $this->skip('38.2.0', '38.6.0');
     }
 }

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -48,6 +48,8 @@ define([
         feedback.error(err.message || __('An error occured while retrieving items'));
     };
 
+    const ITEM_URI = 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item';
+
     /**
      * The ItemView setup items related components
      * @exports taoQtiTest/controller/creator/views/item
@@ -58,11 +60,11 @@ define([
             type: __('items'),
             selectionMode: resourceSelectorFactory.selectionModes.multiple,
             selectAllPolicy: resourceSelectorFactory.selectAllPolicies.visible,
-            classUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
+            classUri: ITEM_URI,
             classes: [
                 {
                     label: 'Item',
-                    uri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
+                    uri: ITEM_URI,
                     type: 'class'
                 }
             ]

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -32,18 +32,18 @@ define([
     /**
      * Create a dedicated logger
      */
-    var logger = loggerFactory('taoQtiTest/creator/views/item');
+    const logger = loggerFactory('taoQtiTest/creator/views/item');
 
     /**
      * Let's you access the data
      */
-    var testItemProvider = testItemProviderFactory();
+    const testItemProvider = testItemProviderFactory();
 
     /**
      * Handles errors
      * @param {Error} err
      */
-    var onError = function onError(err) {
+    const onError = function onError(err) {
         logger.error(err);
         feedback.error(err.message || __('An error occured while retrieving items'));
     };
@@ -54,7 +54,7 @@ define([
      * @param {jQueryElement} $container - where to append the view
      */
     return function itemView($container) {
-        var selectorConfig = {
+        const selectorConfig = {
             type: __('items'),
             selectionMode: resourceSelectorFactory.selectionModes.multiple,
             selectAllPolicy: resourceSelectorFactory.selectAllPolicies.visible,
@@ -71,32 +71,27 @@ define([
         //set up the resource selector with one root class Item in classSelector
         const resourceSelector = resourceSelectorFactory($container, selectorConfig)
             .on('render', function () {
-                var self = this;
-                $container.on('itemselected.creator', function () {
-                    self.clearSelection();
+                $container.on('itemselected.creator', () => {
+                    this.clearSelection();
                 });
             })
             .on('query', function (params) {
-                var self = this;
-
                 //ask the server the item from the component query
                 testItemProvider
                     .getItems(params)
-                    .then(function (items) {
+                    .then(items => {
                         //and update the item list
-                        self.update(items, params);
+                        this.update(items, params);
                     })
                     .catch(onError);
             })
             .on('classchange', function (classUri) {
-                var self = this;
-
                 //by changing the class we need to change the
                 //properties filters
                 testItemProvider
                     .getItemClassProperties(classUri)
-                    .then(function (filters) {
-                        self.updateFilters(filters);
+                    .then(filters => {
+                        this.updateFilters(filters);
                     })
                     .catch(onError);
             })
@@ -130,7 +125,7 @@ define([
             .then(function () {
                 // add classes in classSelector
                 selectorConfig.classes[0].children.forEach(node => {
-                    resourceSelector.addClass(node, 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item');
+                    resourceSelector.addClass(node, selectorConfig.classUri);
                 });
                 resourceSelector.updateFilters(selectorConfig.filters);
             })

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -20,14 +20,13 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'lodash',
     'jquery',
     'i18n',
     'core/logger',
     'taoQtiTest/provider/testItems',
     'ui/resource/selector',
     'ui/feedback'
-], function (_, $, __, loggerFactory, testItemProviderFactory, resourceSelectorFactory, feedback) {
+], function ($, __, loggerFactory, testItemProviderFactory, resourceSelectorFactory, feedback) {
     'use strict';
 
     /**

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -125,7 +125,7 @@ define([
             .then(function () {
                 // add classes in classSelector
                 selectorConfig.classes[0].children.forEach(node => {
-                    resourceSelector.addClass(node, selectorConfig.classUri);
+                    resourceSelector.addClassNode(node, selectorConfig.classUri);
                 });
                 resourceSelector.updateFilters(selectorConfig.filters);
             })


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/BSA-147
**Should be merged after https://github.com/oat-sa/tao-core-ui-fe/pull/138**
**Need update views/package.json**

Was added a new function `addClass` in `resource/selector`.

There are two slow ajax requests on the test authoring page.
`/taoQtiTest/Items/getItemClasses` and `/taoQtiTest/Items/getItems`
Goal:
`getItems` goes at the same time or before `getItemClasses`

In the current implementation, we can't add Node to classSelector if it not presented in selectionComponent. Need an additional function to add classes to classSelector after selectionComponent is rendered.

How to test:

1. go to Items
2. create subclasses 3 and more levels
3. go to Tests
4. open devTools, tab Network
5. open test Authoring
6. see request `getItems`  goes at the same time as `getItemClasses`
7. check classSelector, tree of classes should be loaded
![image](https://user-images.githubusercontent.com/25976342/84515660-70480100-acd5-11ea-80d3-27bb0695d82c.png)
