### PR TITLE
[TCA-665] Incorrect KB navigation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.6.0',
+    'version'     => '38.6.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.8.0',
+    'version'     => '38.8.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2099,5 +2099,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.6.0');
 
         }
+
+        $this->skip('38.6.0', '38.6.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2100,7 +2100,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.6.0');
 
         }
-      
+
         $this->skip('38.6.0', '38.6.1');
 
         if ($this->isversion('38.6.1')) {
@@ -2115,6 +2115,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.7.0');
         }
 
-        $this->skip('38.7.0', '38.8.0');
+        $this->skip('38.7.0', '38.8.1');
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#fix/TCA-665-incorrect-keyboard-navigation"
+    "@oat-sa/tao-test-runner-qti": "2.10.5"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.10.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#fix/TCA-665-incorrect-keyboard-navigation"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-665
 
Make sure that keyNavigation is destroyed before initialization for the next item
 
#### How to test

- prepare an instance of TAO with taoAct extension
- find the delivery mentioned in the ticket
- activate accessibility mode for it
- execute delivery as a test taker
- try to navigate between items using next item shortcut `ALT+SHIFT+N`
- make sure that keyNavigation remains working properly after navigation
  
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/252