### PR TITLE
Fix/tca 647/remaining time mismatch

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.6.0',
+    'version'     => '38.6.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2099,5 +2099,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.6.0');
 
         }
+
+        $this->skip('38.6.0', '38.6.1');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.10.1.tgz",
-      "integrity": "sha512-+GMn7y1aaPYr6G33a5U/ufHPyfq8+f7d4VfuhaxlUn/oqahHtMvcbh26swmBCK3AFYVoxl4nADtyaMDOuVYijg=="
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.10.4.tgz",
+      "integrity": "sha512-/uX0Dz+P/e7Bqs4TqZarsCrJeWi8Yzs+yr+uDwrTcsshFQT5mfJKQZkYLVPbNsavyxwhmi5Vi5vM4+rErlp5WQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.10.1"
+    "@oat-sa/tao-test-runner-qti": "2.10.4"
   }
 }


### PR DESCRIPTION
#### Related
https://oat-sa.atlassian.net/browse/TCA-647

#### Description
update package.json

#### How to test

- Set up a customer environment with proctoring enabled and test with a time limit
- Pause the test session from proctor interface
- During next heartbeat the pause will be detected and additional pause request will be sent to BE. Verify that the `pause` request has `itemDuration` parameter.

#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/246
