### PR TITLE
Fix/tca 551/test status and structure jump link is present when review panel is not enabled

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.7.0',
+    'version'     => '38.7.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2115,5 +2115,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.7.0');
         }
 
+        $this->skip('38.7.0', '38.7.1');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -7,12 +7,12 @@
     "@oat-sa/tao-test-runner": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.5.0.tgz",
-      "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
+      "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.10.7.tgz",
-      "integrity": "sha512-L5Eo5O9DbgAswSdT6KPC6nAWoLMe3NpkAL2c+KqHYs63YqaQ+jLFjsWTrOvQ+ug36Ry7I1RZqOAhs2MQJaXZxQ=="
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.10.8.tgz",
+      "integrity": "sha512-V7ByUFtEyGRX+pd2AeZ/9gO4nQp0KJ5yLNvKaKl9yOw6MZbRtDzga8ah8m1sGp9hZcrSQO+IrvmueaRc2luuvw=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.10.7"
+    "@oat-sa/tao-test-runner-qti": "2.10.8"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.10.4"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#fix/TCA-551/Test-status-and-structure-jump-link-is-present-when-Review-panel-is-not-enabled"
   }
 }


### PR DESCRIPTION
**Related**
https://oat-sa.atlassian.net/browse/TCA-551

**Description**
Updated package.json

**Requires**

- [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/254