### PR TITLE
[TCA-674] Move the <h2> to the top of the item canvas section

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.10.3',
+    'version'     => '38.10.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -2115,6 +2115,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('38.7.0');
         }
 
-        $this->skip('38.7.0', '38.10.3');
+        $this->skip('38.7.0', '38.10.4');
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.10.8"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe.git#fix/TCA-674-move-h2-to-item-convas"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-674
 
Move the h2 to the top of the item canvas section
  
#### How to test
- prepare an instance of TAO with taoAct extension
- prepare a delivery with accessibility mode enabled
- execute delivery as a test taker
- make sure that h2 placed on the top of item content markup 
 
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/262