### PR TITLE
package-lock.json update

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.11.2.tgz",
-      "integrity": "sha512-B+67ucuHfY9pAjIFhJFk2CYIp3PqAzyMjk1P3SotmRYxk6d9rWx0RGDrcGjvJhA9JhiCdKhTAXcc+SAN2VmmrQ=="
+      "version": "github:oat-sa/tao-test-runner-qti-fe#cb641023794466185d2e2394663973b929a87f6a",
+      "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-663/incorrect-timer-announcement"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.11.2"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-663/incorrect-timer-announcement"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-663
 
Heading level 1 with part-section-item name and timer announced without pauses.
  
#### How to test
 
- prepare a delivery with timer(s)
- execute delivery as a test taker
- enable screen reader and navigate with cursor keys to announce invisible mentioned header 1lvl
- check if item and timer announces separated

#### Related to:
https://github.com/oat-sa/tao-test-runner-qti-fe/pull/267