### PR TITLE
[TCA-682] "Flagged" status remains in Jump to question when item is unflagged

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.16.0',
+    'version'     => '38.16.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-682-fix-item-status-in-jumplink"
+    "@oat-sa/tao-test-runner-qti": "2.12.2"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.12.0"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-682-fix-item-status-in-jumplink"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-682
 
Get item flagged status from current item
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery with accessibility feature enabled, review panel and possibility to flag items
- execute delivery as a test taker
- navigate from the fist item
- try to flag and unflag item
- make sure that item status is correctly update in corresponding jumplink 

#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/269