### PR TITLE
[TCA-551] "Test status and structure" jump link is present when Review panel is not enabled in the test

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.16.2',
+    'version'     => '38.16.3',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.16.0',
+    'version'     => '38.16.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.16.1',
+    'version'     => '38.16.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -7,12 +7,12 @@
     "@oat-sa/tao-test-runner": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.5.0.tgz",
-      "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
+      "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.12.0.tgz",
-      "integrity": "sha512-Pm/qmnegED/OEGDEaUXq5lMCsnO4sL7F6M+lbhKYK6IR3R2U65pg6vhhzyGUyTsf3LzDBbxRAV2iQAOgSThdGA=="
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.12.4.tgz",
+      "integrity": "sha512-hfRtRY/ztw0C30HkkjiMBN+uo5Q8oAiwDxk9kedm9OdRrazXSVRoaDvm16ifsDLLYpclnrPc0venak0pgm76VQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.12.0"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-551-test-status-jumplink-not-present"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-551
 
Update package.json
  
#### How to test

- prepare an instance of TAO with taoAct extension
- prepare a delivery with two section. the fist one should be without review panel and the second with
- execute delivery as a test taker
- navigate from the section without review panel to the section with
- make sure that "Test status and structure" jumplink is available
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/270