### PR TITLE
Fix BSA-180 stop checking csrf token on get items

### DIFF
--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -94,8 +94,6 @@ class taoQtiTest_actions_Items extends tao_actions_CommonModule
     public function getItems()
     {
         try {
-            $this->validateCsrf();
-
             if (!$this->hasRequestParameter('classUri')) {
                 throw new \InvalidArgumentException('Missing parameter classUri');
             }

--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.17.1',
+    'version'     => '38.17.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/js/provider/testItems.js
+++ b/views/js/provider/testItems.js
@@ -73,8 +73,7 @@ define([
              * @returns {Promise} that resolves with the classes
              */
             getItems : function getItems(params){
-                // force tokenised request
-                return request(config.getItems.url, params, 'GET', {}, true, false);
+                return request(config.getItems.url, params);
             },
 
             /**

--- a/views/js/test/provider/testItems/test.js
+++ b/views/js/test/provider/testItems/test.js
@@ -99,15 +99,14 @@ define([
         ];
         var returnVal;
 
-        assert.expect(6);
+        assert.expect(5);
 
         $.mockjax({
             url: mockConfig.getItems.url,
             response: function(settings) {
                 assert.equal(settings.url, mockConfig.getItems.url, 'The provider has called the right service');
                 assert.equal(settings.data, params, 'The correct params are in the request data');
-                assert.ok(settings.headers.hasOwnProperty('X-CSRF-Token'), 'A CSRF token is set in the request header');
-                assert.equal(typeof settings.headers['X-CSRF-Token'], 'string', 'The CSRF token is a string');
+                assert.notOk(settings.headers.hasOwnProperty('X-CSRF-Token'), 'No CSRF token is set in the request header');
                 this.responseText = JSON.stringify({ success: true, data: itemList });
             }
         });


### PR DESCRIPTION
- [BSA-180](https://oat-sa.atlassian.net/browse/BSA-180) fix: stop checking a request CSRF token on `getItems` request handling
- [BSA-180](https://oat-sa.atlassian.net/browse/BSA-180) fix: stop sending a CSRF token on `getItems` request
- [BSA-180](https://oat-sa.atlassian.net/browse/BSA-180) chore(version): bump a fix one

ℹ️ Related to #1491.