### PR TITLE
[TCA-710] Inconsistent Timer announcement in the top bar

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.18.1',
+    'version'     => '38.18.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.19.1',
+    'version'     => '38.19.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "github:oat-sa/tao-test-runner-qti-fe#b92217f5c380e88c5ebe5ea3690f5651fe4ac8c1",
-      "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-710-timer-announcement"
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.12.6.tgz",
+      "integrity": "sha512-Q9Yz4AfCtiTDs0z37CHstKQaoV4NhG/J16awuxDzLH6rTqu4aeaRadMximtUjIiogb9NHt05oIBw3kg38SLoEw=="
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "github:oat-sa/tao-test-runner-qti-fe#1630d9ed901d16ff57b932c9670b0b3a8fc3e93f",
+      "version": "github:oat-sa/tao-test-runner-qti-fe#b92217f5c380e88c5ebe5ea3690f5651fe4ac8c1",
       "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-710-timer-announcement"
     }
   }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -7,12 +7,12 @@
     "@oat-sa/tao-test-runner": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.5.0.tgz",
-      "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
+      "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.12.6.tgz",
-      "integrity": "sha512-Q9Yz4AfCtiTDs0z37CHstKQaoV4NhG/J16awuxDzLH6rTqu4aeaRadMximtUjIiogb9NHt05oIBw3kg38SLoEw=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.13.1.tgz",
+      "integrity": "sha512-4AvagSecdLv1+OAo6oGdpByZuChEqJzIbushN2QUrSULqhZ6nFN+dFwNF6pKcNXDJTLWmKDUkkKXjqHsJHKnXg=="
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.12.6.tgz",
-      "integrity": "sha512-Q9Yz4AfCtiTDs0z37CHstKQaoV4NhG/J16awuxDzLH6rTqu4aeaRadMximtUjIiogb9NHt05oIBw3kg38SLoEw=="
+      "version": "github:oat-sa/tao-test-runner-qti-fe#1630d9ed901d16ff57b932c9670b0b3a8fc3e93f",
+      "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-710-timer-announcement"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-710-timer-announcement"
+    "@oat-sa/tao-test-runner-qti": "2.13.1"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.12.6"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TCA-710-timer-announcement"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-710
 
Update package.json  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery with timers but without review panel
- execute the delivery as a test taker
- enable screenreader and navigate to timers using arrow keys
- listen to timers announcement
- make sure that it is consistent with timers in h1 heading
- make sure to check with NVDA and JAWS 
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/279