### PR TITLE
Fix/cs 7/fix authoring sorting

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '38.19.0',
+    'version'     => '38.19.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/js/controller/creator/views/actions.js
+++ b/views/js/controller/creator/views/actions.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 /**
@@ -97,12 +97,10 @@ function($, propertyView){
             $elements = $('.' + elementClass, $container);
             index = $elements.index($element);
             if (index > 0) {
-                $element.fadeOut(200, function(){
+                $element.fadeOut(200, () => {
                     $element
-                        .insertBefore($('.' + elementClass + ' :eq(' + (index - 1) + ')', $container))
-                        .fadeIn(400, function(){
-                            $container.trigger('change');
-                        });
+                        .insertBefore($(`.${elementClass}:eq(${index - 1})`, $container))
+                        .fadeIn(400, () => $container.trigger('change') );
                 });
             }
         });
@@ -121,12 +119,10 @@ function($, propertyView){
             $elements = $('.' + elementClass, $container);
             index = $elements.index($element);
             if (index < ($elements.length - 1) && $elements.length > 1) {
-                $element.fadeOut(200, function(){
+                $element.fadeOut(200, () => {
                     $element
-                        .insertAfter($('.' + elementClass + ' :eq(' + (index + 1) + ')', $container))
-                        .fadeIn(400, function(){
-                            $container.trigger('change');
-                        });
+                        .insertAfter($(`.${elementClass}:eq(${index + 1})`, $container))
+                        .fadeIn(400, () =>  $container.trigger('change') );
                 });
             }
         });


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/CS-7

In the test creator the selector used to move an item up or down was wrong, but somehow works with old versions of jquery. 
(the space before `:eq()` ) 
In order to anticipate the update to a newer version of jquery, we need to fix this issue.

**How to test :** 
 - In the authoring
 - Try to move items up and down in a section,
 - you can repeat the same by merging this branch in the branch `breaking/TDR-10/upgrade-jquery-handlebars` (you also need to have this branch on tao-core, taoTests and taoQtiTest)