### PR TITLE
Fix TAO-10417 update tao test runner qti

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.0.0',
+    'version'     => '39.0.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
       "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.13.2",
-      "resolved": "github:oat-sa/tao-test-runner-qti-fe#c9a7113dffdf3957a82acd71ff08487286494743"
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.13.3.tgz",
+      "integrity": "sha512-hdwS+AX2T097hOvnOpt6yPsxCLFYzeEa0dqVXRlUdeQi20gTUSAnLiRs6ICzmUdAOr/nY7ToWA8LT1pYPvo/lg=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.13.2"
+    "@oat-sa/tao-test-runner-qti": "2.13.3"
   }
 }


### PR DESCRIPTION
- [TAO-10417](https://oat-sa.atlassian.net/browse/TAO-10417) fix: build of `tao-test-runner-qti` by bumping a required version to `2.13.3`
- [TAO-10417](https://oat-sa.atlassian.net/browse/TAO-10417) chore(version): bump a fix one