### PR TITLE
Feature/tca 733/announce current item

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.0.2',
+    'version'     => '39.1.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.13.3.tgz",
-      "integrity": "sha512-hdwS+AX2T097hOvnOpt6yPsxCLFYzeEa0dqVXRlUdeQi20gTUSAnLiRs6ICzmUdAOr/nY7ToWA8LT1pYPvo/lg=="
+      "version": "github:oat-sa/tao-test-runner-qti-fe#a42b2957b3bfa6042375ee50bf9f62f68665e1a5",
+      "from": "github:oat-sa/tao-test-runner-qti-fe#feature/TCA-733/announce-current-item"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.13.3"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/TCA-733/announce-current-item"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-733
 
Add announcement for current item after navigate via `next` button
  
#### How to test
 
- prepare an instance of TAO 
- run the assesment with enabled screen reader
- listen the item annoncement after load new item

#### related PR

- https://github.com/oat-sa/tao-test-runner-qti-fe/pull/288