### PR TITLE
Fix/nsup 30 import test package on windows platform

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.0.1',
+    'version'     => '39.0.2',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/QtiTestUtils.php
+++ b/models/classes/QtiTestUtils.php
@@ -184,6 +184,7 @@ class QtiTestUtils extends ConfigurableService
                     
                     // And moreover, it sometimes refer the temp directory as Windows\TEMP instead of Windows\Temp.
                     $itemRefCanonicalHref = str_replace('\\TEMP\\', '\\Temp\\', $itemRefCanonicalHref);
+                    $itemResourceCanonicalHref = str_replace('\\TEMP\\', '\\Temp\\', $itemResourceCanonicalHref);
                 }
                 
                 // With some MacOS flavours, the $itemRefCanonicalHref comes out with


### PR DESCRIPTION
On windows platform temp directory may be in upper case:
```
itemResourceCanonicalHref: C:\Windows\TEMP\tmp578902822\items\i1595365685730942554\qti.xml 
itemRefCanonicalHref: C:\Windows\Temp\tmp578902822\items\i1595365685730942554\qti.xml
```