### PR TITLE
[TCA-700] "time_remaining" in json is incorrect for exit_code 703

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.1.0',
+    'version'     => '39.1.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.13.5",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.13.5.tgz",
-      "integrity": "sha512-SUUS7ssqK9ed1943xBz8s2S6XtT+sKbPAS8LiqDcxT41LgcRhGS4kAotZPxeagGlLrBY6TP+MRkpuAnbNRzUTg=="
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.13.6.tgz",
+      "integrity": "sha512-/QaMdLT+IrBDAWWhP2YPEUQtpVwPF6AuTAXhV8K+e4PWIWvRJ1OCMrKm52ic4JG2QfGF1DQERthgu8B+yShlTg=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.13.5"
+    "@oat-sa/tao-test-runner-qti": "2.13.6"
   }
 }


### PR DESCRIPTION
Fix incorrect itemDuration on timeout
 
Related to : https://oat-sa.atlassian.net/browse/TCA-700

Update package.json
 
#### Steps to reproduce (from ticket description)
 - Start a test as TT, Guest or via LTI
 - Pass all items in the first section (don’t move to the next section) pass all items and wait until time is over 
 - Log in as Admin open Results in main menu
 - Select passed Delivery
 - Click Transmission Monitoring button at top. Click View button for last test result
 - Click Export ODS button at left, download .json file.
 - Open the file in browser/other editor and check `time_remaining` value
  
#### How to test
 - Start a test as TT, Guest or via LTI, stay on the first item
 - Open brower developer tools, the network tab
 - Wait for the timeout event
 - Verify that `itemDuration` in the timeout request has same or greater amount of seconds as the section time limit
