### PR TITLE
Fix xmleditor import dont work

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.2.0',
+    'version'     => '39.2.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/js/controller/content/edit.js
+++ b/views/js/controller/content/edit.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
-define(['taoQtiTest/lib/codemirror/xmlEditor', 'taoQtiTest/lib/codemirror/schemas/ims_qti_v2p1', 'css!taoQtiTestCss/xml-editor'], function (
+define(['taoQtiTest/lib/codemirror/xmleditor', 'taoQtiTest/lib/codemirror/schemas/ims_qti_v2p1', 'css!taoQtiTestCss/xml-editor'], function (
     xmlEditor,
     schemaInfo
 ) {


### PR DESCRIPTION
**Description**

When we run `npx grunt taoqtitestbundle` inside `tao/views/build`, throws a error. Bundling is broken

**AC**

- Run `npx grunt taoqtitestbundle` inside `tao/views/build` and no errors