### PR TITLE
Feature [BSA 199] - Split onPartChange and onTestEnd in individual functions for show differents messages

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.3.1',
+    'version'     => '39.4.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.3.0',
+    'version'     => '39.3.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -7,12 +7,12 @@
     "@oat-sa/tao-test-runner": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.5.0.tgz",
-      "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
+      "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.13.6",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.13.6.tgz",
-      "integrity": "sha512-/QaMdLT+IrBDAWWhP2YPEUQtpVwPF6AuTAXhV8K+e4PWIWvRJ1OCMrKm52ic4JG2QfGF1DQERthgu8B+yShlTg=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.14.0.tgz",
+      "integrity": "sha512-LBC19FGya9rVdS9il8d5v7QFz9ybIDaWQBDOEl/g9E+QK8bl7phjiFXonS+NQhW9ti1KyHoP9bUQGIlZ+UJK4Q=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.13.7"
+    "@oat-sa/tao-test-runner-qti": "2.14.0"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.13.6"
+    "@oat-sa/tao-test-runner-qti": "2.13.7"
   }
 }


### PR DESCRIPTION
**Related to this PR**

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/285

**Related to**

https://oat-sa.atlassian.net/browse/BSA-199

**Context**

`BOSA` has applied certain Navigation warnings in the test settings. The existing pop up messages are not meeting their needs as they confuse the candidate. As such, they have requested to apply their specific pop up messages in Dutch and French language respectively.

**User story description**

As a test author, I want the candidate to view comprehensive pop up warnings when navigating from one Test part to another or from one test section to another. By doing so, the candidate will understand clearly was expected of them in the test.