### PR TITLE
Feature TAO-10467 - Better highlight of a current delivery item label in review mode

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.5.1',
+    'version'     => '39.6.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.15.0.tgz",
-      "integrity": "sha512-GLPOKeDF7ZtX0QhV4RLinMGfPrEIBnTEfG7UW6euNDuVtrlFP5oV6HSdxoUq28Bo9Qr7mFQAmrNgFXlSebybTw=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.16.0.tgz",
+      "integrity": "sha512-gy9xkFOiV8TXsZzxoYnKspS+tBvrHwTQi4WOcstGzZ2zPopRhUbvghb8RPAvFdoRASg9WO23zN2TILG0H+Jk/Q=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.15.0"
+    "@oat-sa/tao-test-runner-qti": "2.16.0"
   }
 }


### PR DESCRIPTION
**Related to this issue**

It's related to this issue but for product we will implement variable `$info` that is some blue color

https://oat-sa.atlassian.net/browse/TAO-10467

**Description**

**As** test taker
**I would like** when browsing the review screen/navigator to have a more distinct color on the current Item
**so that** that I can identify instantly in which item I am on in respect to the whole section/test part.

**Context**

Ability to mark the color of the page on which you are in the preview on the left side of the page a little more so that it is quicker for candidates to identify it? For example, by displaying it in blue? In this way, the candidate can identify at a glance which page he or she is on in the preview. (Because at the moment there is only a very slight difference in color between the pages viewed and the page on which the candidate is on).

**Acceptance criteria**

- AC1

**GIVEN** test taker is during delivery execution which has enabled the review screen/navigator
**WHEN** test taker browses on review screen/navigator
**THEN** the current item on the review panel menu **MUST** be colorized