### PR TITLE
Fix/tca 735/focus munu button kbd

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.5.1',
+    'version'     => '39.6.0',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha1-N/j4WxVgkYN9sjZDov4yOqpABhg="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.15.0.tgz",
-      "integrity": "sha512-GLPOKeDF7ZtX0QhV4RLinMGfPrEIBnTEfG7UW6euNDuVtrlFP5oV6HSdxoUq28Bo9Qr7mFQAmrNgFXlSebybTw=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.16.0.tgz",
+      "integrity": "sha512-gy9xkFOiV8TXsZzxoYnKspS+tBvrHwTQi4WOcstGzZ2zPopRhUbvghb8RPAvFdoRASg9WO23zN2TILG0H+Jk/Q=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.15.0"
+    "@oat-sa/tao-test-runner-qti": "2.16.0"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.16.0"
+    "@oat-sa/tao-test-runner-qti": "oat-sa/tao-test-runner-qti#fix/TCA-735/focus-munu-button-kbd"
   }
 }


### PR DESCRIPTION
Related to : 
- https://oat-sa.atlassian.net/browse/TCA-735
 
tools menus lose focus when submenu item activated via keyboard
  
#### How to test

- execute delivery as a test taker
- try to switch contrast heme using keyboard
- check focus is on menu item
 
#### Dependencies
 
