### PR TITLE
Fix/inv 252/qti blocker

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.6.0',
+    'version'     => '39.6.1',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -41,6 +41,12 @@ use qtism\data\View;
  */
 class taoQtiTest_models_classes_QtiTestConverter
 {
+
+    /**
+     * operators for which qtsm classes are postfix
+     *
+     * @var array $operatorClassesOperatorPostfix
+     */
     static $operatorClassesPostfix = [
         'and',
         'custom',

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -41,6 +41,13 @@ use qtism\data\View;
  */
 class taoQtiTest_models_classes_QtiTestConverter
 {
+    static $operatorClassesPostfix = [
+        'and',
+        'custom',
+        'math',
+        'or',
+        'stats'
+    ];
 
     /**
      * The instance of the XmlDocument that represents the QTI Test.
@@ -461,15 +468,7 @@ class taoQtiTest_models_classes_QtiTestConverter
             'qtism\\data\\state\\'
         ];
 
-        $operatorClassesPostfix = [
-            'and',
-            'custom',
-            'math',
-            'or',
-            'stats'
-        ];
-
-        if (in_array(mb_strtolower($name), $operatorClassesPostfix)) {
+        if (in_array(mb_strtolower($name), self::$operatorClassesPostfix)) {
             $name .= 'Operator';
         }
 

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -460,6 +460,20 @@ class taoQtiTest_models_classes_QtiTestConverter
             'qtism\\data\\rules\\',
             'qtism\\data\\state\\'
         ];
+
+        $operatorClassesPostfix = [
+            'and',
+            'or',
+            'custom',
+            'math',
+            'or',
+            'stats'
+        ];
+
+        if (in_array(mb_strtolower($name), $operatorClassesPostfix)) {
+            $name .= 'Operator';
+        }
+
         foreach ($namespaces as $namespace) { // this could be cached
             $className = $namespace . ucfirst($name);
             if (class_exists($className, true)) {

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -463,7 +463,6 @@ class taoQtiTest_models_classes_QtiTestConverter
 
         $operatorClassesPostfix = [
             'and',
-            'or',
             'custom',
             'math',
             'or',

--- a/test/integration/QtiTestConverterTest.php
+++ b/test/integration/QtiTestConverterTest.php
@@ -120,16 +120,16 @@ class QtiTestConverterTest extends GenerisPhpUnitTestRunner
     public function testLookupClass()
     {
         $class = new ReflectionClass(taoQtiTest_models_classes_QtiTestConverter::class);
-        $method = $class->getMethod('lookupClass');
-        $method->setAccessible(true);
+        $lookupClassMethod = $class->getMethod('lookupClass');
+        $lookupClassMethod->setAccessible(true);
 
         $doc = new XmlDocument('2.1');
         $converter = new taoQtiTest_models_classes_QtiTestConverter($doc);
 
-        $result = $method->invoke($converter, 'or');
+        $result = $lookupClassMethod->invoke($converter, 'or');
         $this->assertEquals($result, 'qtism\data\expressions\operators\OrOperator');
 
-        $result = $method->invoke($converter, 'lt');
+        $result = $lookupClassMethod->invoke($converter, 'lt');
         $this->assertEquals($result, 'qtism\data\expressions\operators\Lt');
     }
 }

--- a/test/integration/QtiTestConverterTest.php
+++ b/test/integration/QtiTestConverterTest.php
@@ -24,6 +24,7 @@ namespace oat\taoQtiTest\test\integration;
 use oat\generis\test\GenerisPhpUnitTestRunner;
 use qtism\data\storage\StorageException;
 use qtism\data\storage\xml\XmlDocument;
+use ReflectionClass;
 use \taoQtiTest_models_classes_QtiTestConverter;
 
 /**
@@ -114,5 +115,21 @@ class QtiTestConverterTest extends GenerisPhpUnitTestRunner
         ;
         
         $this->assertEquals($result, $expected);
+    }
+
+    public function testLookupClass()
+    {
+        $class = new ReflectionClass(taoQtiTest_models_classes_QtiTestConverter::class);
+        $method = $class->getMethod('lookupClass');
+        $method->setAccessible(true);
+
+        $doc = new XmlDocument('2.1');
+        $converter = new taoQtiTest_models_classes_QtiTestConverter($doc);
+
+        $result = $method->invoke($converter, 'or');
+        $this->assertEquals($result, 'qtism\data\expressions\operators\OrOperator');
+
+        $result = $method->invoke($converter, 'lt');
+        $this->assertEquals($result, 'qtism\data\expressions\operators\Lt');
     }
 }


### PR DESCRIPTION
__Related to task:__ https://oat-sa.atlassian.net/browse/INV-252
__Description:__ XML editor not working on save
__What is fixed:__ the lookupClass method has been fixed
classes with the 'Operator' postfix were searched incorrectly

__How to test:__ 
1) need test which in its xml contains a tag 'preCondition' which has conditions 'or' or 'and'
2) go to the Test section, select this test and open the 'XML Editor'
3) click Save
tests xml should be saved successfully
