### PR TITLE
Feature/NEX-1529/remove test preview dependency

### DIFF
--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -254,7 +254,7 @@ define([
                                     fullPage: true
                                 });
                             } else {
-                                feedback().error('Test Preview is not installed, please contact to your administrator.');
+                                feedback().error('Test Preview is not installed, please contact your administrator.');
                             }
                         }
                     });

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -73,11 +73,11 @@ define([
 
     providerLoaderFactory()
         .addList({
-            previwers: {
+            previewers: {
                 id: 'qtiTests',
                 module: 'taoQtiTestPreviewer/previewer/adapter/test/qtiTest',
                 bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
-                category: 'previwers'
+                category: 'previewers'
             }
         })
         .load(context.bundle)

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -230,7 +230,7 @@ define([
                             const saveUrl = options.routes.save;
                             const testUri = saveUrl.slice(saveUrl.indexOf('uri=') + 4);
                             return previewerFactory(
-                                'qtiTest',
+                                'qtiTest', // TODO - move to BE configuration
                                 decodeURIComponent(testUri),
                                 {
                                     readOnly: false,
@@ -239,7 +239,7 @@ define([
                             )
                             .catch(err => {
                                 logger.error(err);
-                                feedback().error('Test Preview is not installed, please contact to your administrator.');
+                                feedback().error(__('Test Preview is not installed, please contact to your administrator.'));
                             });
                         }
                     });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-1529
Related to:
https://github.com/oat-sa/extension-tao-test/pull/348
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/88

**Issue:**
In working branches 
"oat-sa/extension-tao-test": "dev-feature/NEX-1043/test-preview-base-branch",  
"oat-sa/extension-tao-testqti": "dev-feature/NEX-1043/test-preview-base-branch", 
an issue with building bundles because of new dependency taoQtiTestPreview

**Solution:**
Dynamically load taoQtiTestPreviewer adapter

**How to test:**

1. checkout brances "oat-sa/extension-tao-test": "dev-feature/NEX-1043/test-preview-base-branch",  "oat-sa/extension-tao-testqti": "dev-feature/NEX-1043/test-preview-base-branch", 
2. in taoQtiTestPreviwer checkout to develop
3. open Tests page
4. press Preview button
5. in taoQtiTestPreviwer checkout to feature/NEX-1043/test-preview-base-branch
6. reload Tests page
7. press Preview button