### PR TITLE
Fix/tca 741/alt shift t shortcut target

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.6.3',
+    'version'     => '39.6.4',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.16.2.tgz",
-      "integrity": "sha512-E6PpdqJM0gnLm5NLnP1MfW6tpIfG4YFbdbSqv6e/OY784X9tk5Jwb6bFU7LiPxkVnkEgtDlFtcY5KaMFyC5VWA=="
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.16.3.tgz",
+      "integrity": "sha512-wwOldvd9sZCi2H38LJTv/+Db8GH1yPizaQng7sLzxUFan8eaxx8+G+kFRd0UrPcfQdnz4abhKjFhexdTU5qekA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "oat-sa/tao-test-runner-qti#fix/TCA-741/alt-shift-t-shortcut-target"
+    "@oat-sa/tao-test-runner-qti": "2.16.3"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.16.2"
+    "@oat-sa/tao-test-runner-qti": "oat-sa/tao-test-runner-qti#fix/TCA-741/alt-shift-t-shortcut-target"
   }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-741
  
change behavior of Alt-Shift-T keyboard shortcut to `focus on first interactive element`
 
#### How to test:

- prepare a delivery accessibility mode enabled
- use Alt-Shift-T shortcut
- ensure focus changed to first interactive element (jumplink) and screen reader announces it
 
#### Dependencies

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/307