### PR TITLE
Fix BSA-231 resume assessment in case navigation fails due to time limit

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return [
     'label'       => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license'     => 'GPL-2.0',
-    'version'     => '39.7.4',
+    'version'     => '39.7.5',
     'author'      => 'Open Assessment Technologies',
     'requires'    => [
         'taoQtiItem' => '>=24.0.0',


### PR DESCRIPTION
- [BSA-231](https://oat-sa.atlassian.net/browse/BSA-231) fix: continue current interaction in case of an assessment navigation failure due to a time limit of a target
- [BSA-231](https://oat-sa.atlassian.net/browse/BSA-231) chore: split workflows of most of the `QtiRunnerMethods` by introducing early return points
- [BSA-231](https://oat-sa.atlassian.net/browse/BSA-231) chore(version): bump a fix one