### PR TITLE
Fix/tao 10532/all added test parts have max attempts set to 1

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -52,7 +52,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '39.8.0',
+    'version' => '39.8.1',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -81,7 +81,7 @@
                     <label for="testpart-max-attempts">{{__ 'Max Attempts'}}</label>
                 </div>
                 <div class="col-6">
-                    <input name="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="1" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                    <input name="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
                 </div>
                 <div class="col-1 help">
                     <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/TAO-10532
**Description:** Test Authoring - All added test parts have Max Attempts set to 1
**How to test:** 
1. Login as admin
2. Go to Tests
3. Create a new test and go to Authoring
4. Add several test parts
**Expected Result:**
all test part Max Attempts value is 0 by default. 