### PR TITLE
Feature BSA-167 customizable default settings of newly added test elements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
     "ext-dom": "*",
     "oat-sa/composer-npm-bridge": "^0.3.0",
     "oat-sa/lib-test-cat": "2.3.7",
-    "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
+    "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
+    "qtism/qtism": "~0"
   },
   "autoload": {
     "psr-4": {

--- a/config/default/AssessmentTestXmlFactory.conf.php
+++ b/config/default/AssessmentTestXmlFactory.conf.php
@@ -18,5 +18,12 @@
  */
 
 use oat\taoQtiTest\models\test\AssessmentTestXmlFactory;
+use oat\taoQtiTest\models\test\Template\DefaultConfigurationRegistry;
 
-return new AssessmentTestXmlFactory();
+return new AssessmentTestXmlFactory(
+    [
+        'configurationRegistry' => [
+            'class' => DefaultConfigurationRegistry::class,
+        ],
+    ]
+);

--- a/manifest.php
+++ b/manifest.php
@@ -40,6 +40,7 @@ use oat\taoQtiTest\scripts\install\RegisterTimerAdjustmentService;
 use oat\taoQtiTest\scripts\install\RegisterTimerStrategyService;
 use oat\taoQtiTest\scripts\install\SetLinearNextItemWarningConfig;
 use oat\taoQtiTest\scripts\install\SetSynchronisationService;
+use oat\taoQtiTest\scripts\install\SetupDefaultTemplateConfiguration;
 use oat\taoQtiTest\scripts\install\SetupEventListeners;
 use oat\taoQtiTest\scripts\install\SetUpQueueTasks;
 use oat\taoQtiTest\scripts\install\SyncChannelInstaller;
@@ -52,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '39.8.0',
+    'version' => '40.0.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',
@@ -96,6 +97,7 @@ return [
             RegisterTimerAdjustmentService::class,
             RegisterQtiPackageExporter::class,
             SetupProvider::class,
+            SetupDefaultTemplateConfiguration::class,
         ],
     ],
     'update' => Updater::class,

--- a/migrations/Version202009171520092260_taoQtiTest.php
+++ b/migrations/Version202009171520092260_taoQtiTest.php
@@ -119,11 +119,7 @@ final class Version202009171520092260_taoQtiTest extends AbstractMigration
             DefaultConfigurationRegistry::getRegistry()->get(DefaultConfigurationRegistry::ID)
             as $configurationKey => $value
         ) {
-            if (!isset($registryConfigurationToFactoryOptionsMap[$configurationKey])) {
-                continue;
-            }
-
-            $option = $registryConfigurationToFactoryOptionsMap[$configurationKey];
+            $option = $registryConfigurationToFactoryOptionsMap[$configurationKey] ?? null;
 
             if (isset(self::TRIMMABLE_OPTION_VALUE_POSTFIXES[$option])) {
                 $value .= self::TRIMMABLE_OPTION_VALUE_POSTFIXES[$option];
@@ -131,6 +127,8 @@ final class Version202009171520092260_taoQtiTest extends AbstractMigration
 
             $options[$option] = $value;
         }
+
+        unset($options[null]);
 
         $this->addReport(
             Report::createSuccess(

--- a/migrations/Version202009171520092260_taoQtiTest.php
+++ b/migrations/Version202009171520092260_taoQtiTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use common_report_Report as Report;
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiTest\models\test\AssessmentTestXmlFactory;
+use oat\taoQtiTest\models\test\Template\DefaultConfigurationRegistry;
+use oat\taoQtiTest\scripts\install\SetupDefaultTemplateConfiguration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202009171520092260_taoQtiTest extends AbstractMigration
+{
+    private const FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP = [
+        'test_part_id'             => SetupDefaultTemplateConfiguration::PART_ID_PREFIX,
+        'assessment_section_id'    => SetupDefaultTemplateConfiguration::SECTION_ID_PREFIX,
+        'assessment_section_title' => SetupDefaultTemplateConfiguration::SECTION_TITLE_PREFIX,
+        'navigation_mode'          => SetupDefaultTemplateConfiguration::NAVIGATION_MODE,
+        'submission_mode'          => SetupDefaultTemplateConfiguration::SUBMISSION_MODE,
+        'max_attempts'             => SetupDefaultTemplateConfiguration::MAX_ATTEMPTS,
+    ];
+
+    private const TRIMMABLE_OPTION_VALUE_POSTFIXES = [
+        'test_part_id'             => '-1',
+        'assessment_section_id'    => '-1',
+        'assessment_section_title' => ' 1',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Register ' . AssessmentTestXmlFactory::class;
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var AssessmentTestXmlFactory $testTemplateFactory */
+        $testTemplateFactory = $this->getServiceLocator()->get(AssessmentTestXmlFactory::class);
+
+        $testTemplateFactory->setOptions(
+            $this->upgradeTemplateFactoryOptions(
+                $testTemplateFactory->getOptions()
+            )
+        );
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $this->getServiceManager()->register(AssessmentTestXmlFactory::SERVICE_ID, $testTemplateFactory);
+
+        $this->addReport(
+            Report::createSuccess(
+                sprintf('Registered %s service.', AssessmentTestXmlFactory::SERVICE_ID)
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var AssessmentTestXmlFactory $testTemplateFactory */
+        $testTemplateFactory = $this->getServiceLocator()->get(AssessmentTestXmlFactory::class);
+
+        $testTemplateFactory->setOptions(
+            $this->downgradeTemplateFactoryOptions(
+                $testTemplateFactory->getOptions()
+            )
+        );
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $this->getServiceManager()->register(AssessmentTestXmlFactory::SERVICE_ID, $testTemplateFactory);
+
+        $this->addReport(
+            Report::createSuccess(
+                sprintf('Registered %s service.', AssessmentTestXmlFactory::SERVICE_ID)
+            )
+        );
+
+        DefaultConfigurationRegistry::getRegistry()->remove(DefaultConfigurationRegistry::ID);
+
+        $this->addReport(
+            Report::createSuccess(
+                sprintf('Unregistered %s registry.', DefaultConfigurationRegistry::ID)
+            )
+        );
+    }
+
+    private function upgradeTemplateFactoryOptions(array $options): array
+    {
+        $this->registerTemplateOptionsInRegistry($options);
+
+        $options = array_diff_key($options, self::FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP);
+
+        $options[AssessmentTestXmlFactory::OPTION_CONFIGURATION_REGISTRY] = [
+            'class' => DefaultConfigurationRegistry::class,
+        ];
+
+        $this->addReport(
+            Report::createSuccess(
+                sprintf(
+                    "Upgraded %s service options to the following ones:\n%s",
+                    AssessmentTestXmlFactory::SERVICE_ID,
+                    json_encode($options, JSON_PRETTY_PRINT)
+                )
+            )
+        );
+
+        return $options;
+    }
+
+    private function downgradeTemplateFactoryOptions(array $options): array
+    {
+        unset($options[AssessmentTestXmlFactory::OPTION_CONFIGURATION_REGISTRY]);
+
+        $registryConfigurationToFactoryOptionsMap = array_flip(self::FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP);
+
+        foreach (
+            DefaultConfigurationRegistry::getRegistry()->get(DefaultConfigurationRegistry::ID)
+            as $configurationKey => $value
+        ) {
+            if (!isset($registryConfigurationToFactoryOptionsMap[$configurationKey])) {
+                continue;
+            }
+
+            $option = $registryConfigurationToFactoryOptionsMap[$configurationKey];
+
+            if (isset(self::TRIMMABLE_OPTION_VALUE_POSTFIXES[$option])) {
+                $value .= self::TRIMMABLE_OPTION_VALUE_POSTFIXES[$option];
+            }
+
+            $options[$option] = $value;
+        }
+
+        $this->addReport(
+            Report::createSuccess(
+                sprintf(
+                    "Downgraded %s service options to the following ones:\n%s",
+                    AssessmentTestXmlFactory::SERVICE_ID,
+                    json_encode($options, JSON_PRETTY_PRINT)
+                )
+            )
+        );
+
+        return $options;
+    }
+
+    private function registerTemplateOptionsInRegistry(array $options): void
+    {
+        $parameters = [];
+
+        foreach ($options as $option => $value) {
+            if (!isset(self::FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP[$option])) {
+                continue;
+            }
+
+            $parameter = self::FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP[$option];
+
+            if (isset(self::TRIMMABLE_OPTION_VALUE_POSTFIXES[$option])) {
+                $value = substr($value, 0, -2);
+            }
+
+            $parameters[] = "--$parameter";
+            $parameters[] = (string)$value;
+        }
+
+        $this->addReport(
+            $this->propagate(new SetupDefaultTemplateConfiguration())($parameters)
+        );
+    }
+}

--- a/migrations/Version202009171520092260_taoQtiTest.php
+++ b/migrations/Version202009171520092260_taoQtiTest.php
@@ -148,22 +148,32 @@ final class Version202009171520092260_taoQtiTest extends AbstractMigration
         $parameters = [];
 
         foreach ($options as $option => $value) {
-            if (!isset(self::FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP[$option])) {
-                continue;
-            }
-
-            $parameter = self::FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP[$option];
+            $parameter = self::FACTORY_OPTIONS_TO_REGISTRY_CONFIGURATION_MAP[$option] ?? null;
 
             if (isset(self::TRIMMABLE_OPTION_VALUE_POSTFIXES[$option])) {
                 $value = substr($value, 0, -2);
             }
 
-            $parameters[] = "--$parameter";
-            $parameters[] = (string)$value;
+            $parameters[$parameter] = $value;
         }
 
         $this->addReport(
-            $this->propagate(new SetupDefaultTemplateConfiguration())($parameters)
+            $this->propagate(new SetupDefaultTemplateConfiguration())(
+                $this->transformScriptActionParameters($parameters))
         );
+    }
+
+    private function transformScriptActionParameters(array $parameters): array
+    {
+        unset($parameters[null]);
+
+        $result = [];
+
+        foreach ($parameters as $parameter => $value) {
+            $result[] = "--$parameter";
+            $result[] = (string)$value;
+        }
+
+        return $result;
     }
 }

--- a/models/classes/test/Template/DefaultConfigurationRegistry.php
+++ b/models/classes/test/Template/DefaultConfigurationRegistry.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace oat\taoQtiTest\models\test\Template;
 
+use DomainException;
 use InvalidArgumentException;
 use oat\tao\model\ClientLibConfigRegistry;
 use qtism\data\NavigationMode;
@@ -35,33 +36,53 @@ class DefaultConfigurationRegistry extends ClientLibConfigRegistry
 
     public function setPartIdPrefix(string $partIdPrefix): self
     {
-        $this->register(self::ID, compact('partIdPrefix'));
+        $this->register(static::ID, compact('partIdPrefix'));
 
         return $this;
+    }
+
+    public function getPartIdPrefix(): string
+    {
+        return $this->getConfigurationValue(__FUNCTION__);
     }
 
     public function setSectionIdPrefix(string $sectionIdPrefix): self
     {
-        $this->register(self::ID, compact('sectionIdPrefix'));
+        $this->register(static::ID, compact('sectionIdPrefix'));
 
         return $this;
+    }
+
+    public function getSectionIdPrefix(): string
+    {
+        return $this->getConfigurationValue(__FUNCTION__);
     }
 
     public function setSectionTitlePrefix(string $sectionTitlePrefix): self
     {
-        $this->register(self::ID, compact('sectionTitlePrefix'));
+        $this->register(static::ID, compact('sectionTitlePrefix'));
 
         return $this;
     }
 
+    public function getSectionTitlePrefix(): string
+    {
+        return $this->getConfigurationValue(__FUNCTION__);
+    }
+
     public function setCategories(array $categories): self
     {
-        $configuration = $this->get(self::ID);
+        $configuration = $this->get(static::ID);
         $configuration['categories'] = $categories;
 
-        $this->set(self::ID, $configuration);
+        $this->set(static::ID, $configuration);
 
         return $this;
+    }
+
+    public function getCategories(): array
+    {
+        return $this->getConfigurationValue(__FUNCTION__);
     }
 
     public function setNavigationMode(int $navigationMode): self
@@ -76,9 +97,14 @@ class DefaultConfigurationRegistry extends ClientLibConfigRegistry
             );
         }
 
-        $this->register(self::ID, compact('navigationMode'));
+        $this->register(static::ID, compact('navigationMode'));
 
         return $this;
+    }
+
+    public function getNavigationMode(): int
+    {
+        return $this->getConfigurationValue(__FUNCTION__);
     }
 
     public function setSubmissionMode(int $submissionMode): self
@@ -93,15 +119,40 @@ class DefaultConfigurationRegistry extends ClientLibConfigRegistry
             );
         }
 
-        $this->register(self::ID, compact('submissionMode'));
+        $this->register(static::ID, compact('submissionMode'));
 
         return $this;
     }
 
+    public function getSubmissionMode(): int
+    {
+        return $this->getConfigurationValue(__FUNCTION__);
+    }
+
     public function setMaxAttempts(int $maxAttempts): self
     {
-        $this->register(self::ID, compact('maxAttempts'));
+        $this->register(static::ID, compact('maxAttempts'));
 
         return $this;
+    }
+
+    public function getMaxAttempts(): int
+    {
+        return $this->getConfigurationValue(__FUNCTION__);
+    }
+
+    private function getConfigurationValue(string $getter)
+    {
+        $configurationKey = lcfirst(substr($getter, 3));
+
+        $configuration = $this->get(static::ID);
+
+        if (!isset($configuration[$configurationKey])) {
+            throw new DomainException(
+                sprintf('%s::%s value was requested, but not defined.', static::class, $configurationKey)
+            );
+        }
+
+        return $configuration[$configurationKey];
     }
 }

--- a/models/classes/test/Template/DefaultConfigurationRegistry.php
+++ b/models/classes/test/Template/DefaultConfigurationRegistry.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\test\Template;
+
+use oat\tao\model\ClientLibConfigRegistry;
+
+class DefaultConfigurationRegistry extends ClientLibConfigRegistry
+{
+    public const ID = 'taoQtiTest/controller/creator/config/defaults';
+
+    public function setCategories(array $categories): self
+    {
+        $this->register(
+            self::ID,
+            [
+                'categories' => $categories,
+            ]
+        );
+
+        return $this;
+    }
+}

--- a/models/classes/test/Template/DefaultConfigurationRegistry.php
+++ b/models/classes/test/Template/DefaultConfigurationRegistry.php
@@ -27,10 +27,32 @@ namespace oat\taoQtiTest\models\test\Template;
 use InvalidArgumentException;
 use oat\tao\model\ClientLibConfigRegistry;
 use qtism\data\NavigationMode;
+use qtism\data\SubmissionMode;
 
 class DefaultConfigurationRegistry extends ClientLibConfigRegistry
 {
     public const ID = 'taoQtiTest/controller/creator/config/defaults';
+
+    public function setPartIdPrefix(string $partIdPrefix): self
+    {
+        $this->register(self::ID, compact('partIdPrefix'));
+
+        return $this;
+    }
+
+    public function setSectionIdPrefix(string $sectionIdPrefix): self
+    {
+        $this->register(self::ID, compact('sectionIdPrefix'));
+
+        return $this;
+    }
+
+    public function setSectionTitlePrefix(string $sectionTitlePrefix): self
+    {
+        $this->register(self::ID, compact('sectionTitlePrefix'));
+
+        return $this;
+    }
 
     public function setCategories(array $categories): self
     {
@@ -54,7 +76,31 @@ class DefaultConfigurationRegistry extends ClientLibConfigRegistry
             );
         }
 
-        $this->register(self::ID, ['navigationMode' => $navigationMode]);
+        $this->register(self::ID, compact('navigationMode'));
+
+        return $this;
+    }
+
+    public function setSubmissionMode(int $submissionMode): self
+    {
+        if (!in_array($submissionMode, SubmissionMode::asArray(), true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expected one of the following values %s, %d given.',
+                    implode(', ', SubmissionMode::asArray()),
+                    $submissionMode
+                )
+            );
+        }
+
+        $this->register(self::ID, compact('submissionMode'));
+
+        return $this;
+    }
+
+    public function setMaxAttempts(int $maxAttempts): self
+    {
+        $this->register(self::ID, compact('maxAttempts'));
 
         return $this;
     }

--- a/models/classes/test/Template/DefaultConfigurationRegistry.php
+++ b/models/classes/test/Template/DefaultConfigurationRegistry.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 
 namespace oat\taoQtiTest\models\test\Template;
 
+use InvalidArgumentException;
 use oat\tao\model\ClientLibConfigRegistry;
+use qtism\data\NavigationMode;
 
 class DefaultConfigurationRegistry extends ClientLibConfigRegistry
 {
@@ -32,12 +34,27 @@ class DefaultConfigurationRegistry extends ClientLibConfigRegistry
 
     public function setCategories(array $categories): self
     {
-        $this->register(
-            self::ID,
-            [
-                'categories' => $categories,
-            ]
-        );
+        $configuration = $this->get(self::ID);
+        $configuration['categories'] = $categories;
+
+        $this->set(self::ID, $configuration);
+
+        return $this;
+    }
+
+    public function setNavigationMode(int $navigationMode): self
+    {
+        if (!in_array($navigationMode, NavigationMode::asArray(), true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expected one of the following values %s, %d given.',
+                    implode(', ', NavigationMode::asArray()),
+                    $navigationMode
+                )
+            );
+        }
+
+        $this->register(self::ID, ['navigationMode' => $navigationMode]);
 
         return $this;
     }

--- a/scripts/install/SetupDefaultTemplateConfiguration.php
+++ b/scripts/install/SetupDefaultTemplateConfiguration.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\scripts\install;
+
+use common_report_Report as Report;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\taoQtiTest\models\test\Template\DefaultConfigurationRegistry;
+use ReflectionMethod;
+
+class SetupDefaultTemplateConfiguration extends ScriptAction
+{
+    public const CATEGORIES = 'categories';
+
+    private const ARRAY_VALUE_DELIMITER = ',';
+
+    private const OPTION_DEFAULT_VALUES = [
+        self::CATEGORIES => '',
+    ];
+
+    protected function provideUsage()
+    {
+        return [
+            'prefix'      => 'h',
+            'longPrefix'  => 'help',
+            'description' => 'Displays this message',
+        ];
+    }
+
+    protected function provideOptions(): array
+    {
+        return [
+            self::CATEGORIES => [
+                'prefix'      => 'c',
+                'longPrefix'  => self::CATEGORIES,
+                'description' => sprintf(
+                    'Test item categories separated by "%s", "%s" by default',
+                    self::ARRAY_VALUE_DELIMITER,
+                    self::OPTION_DEFAULT_VALUES[self::CATEGORIES]
+                ),
+            ],
+        ];
+    }
+
+    protected function provideDescription(): string
+    {
+        return sprintf('Sets `%s` values.', DefaultConfigurationRegistry::class);
+    }
+
+    protected function run(): Report
+    {
+        $registry = $this->propagate(new DefaultConfigurationRegistry());
+
+        $setValues = [];
+
+        foreach (self::OPTION_DEFAULT_VALUES as $optionName => $defaultValue) {
+            $value = $this->getOption($optionName) ?? $defaultValue;
+
+            if (null === $value) {
+                continue;
+            }
+
+            $method = [$registry, 'set' . ucfirst($optionName)];
+
+            if (!is_callable($method)) {
+                continue;
+            }
+
+            $type = $this->getArgumentType($method);
+
+            if ('array' === $type) {
+                $value = $value ? explode(',', $value) : [];
+            } else {
+                settype($value, $type);
+            }
+
+            $method($value);
+
+            $setValues[$optionName] = $value;
+        }
+
+        return $this->createReport($setValues);
+    }
+
+    private function createReport(array $setValues): Report
+    {
+        return $setValues
+            ? Report::createSuccess(
+                sprintf(
+                    "Applied the following configuration to `%s`\n%s",
+                    DefaultConfigurationRegistry::class,
+                    json_encode($setValues)
+                )
+            )
+            : Report::createFailure(
+                sprintf('No values set to `%s`', DefaultConfigurationRegistry::class)
+            );
+    }
+
+    private function getArgumentType(array $method): string
+    {
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $reflection = new ReflectionMethod(...$method);
+
+        $arguments = $reflection->getParameters();
+
+        $firstArgument = reset($arguments);
+
+        if (!$firstArgument) {
+            return 'null';
+        }
+
+        return (string)$firstArgument->getType();
+    }
+}

--- a/scripts/install/SetupDefaultTemplateConfiguration.php
+++ b/scripts/install/SetupDefaultTemplateConfiguration.php
@@ -103,16 +103,7 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
                 'longPrefix'  => self::NAVIGATION_MODE,
                 'description' => sprintf(
                     'Test part navigation mode, %s, %d by default',
-                    implode(
-                        ', ',
-                        array_map(
-                            static function (string $navigationModeLabel, int $navigationModeValue): string {
-                                return "$navigationModeValue – $navigationModeLabel";
-                            },
-                            array_keys(NavigationMode::asArray()),
-                            NavigationMode::asArray()
-                        )
-                    ),
+                    $this->createEnumerableOptionDescription(NavigationMode::asArray()),
                     self::OPTION_DEFAULT_VALUES[self::NAVIGATION_MODE]
                 ),
             ],
@@ -121,16 +112,7 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
                 'longPrefix'  => self::SUBMISSION_MODE,
                 'description' => sprintf(
                     'Test part submission mode, %s, %d by default',
-                    implode(
-                        ', ',
-                        array_map(
-                            static function (string $submissionModeLabel, int $submissionModeValue): string {
-                                return "$submissionModeValue – $submissionModeLabel";
-                            },
-                            array_keys(SubmissionMode::asArray()),
-                            SubmissionMode::asArray()
-                        )
-                    ),
+                    $this->createEnumerableOptionDescription(SubmissionMode::asArray()),
                     self::OPTION_DEFAULT_VALUES[self::SUBMISSION_MODE]
                 ),
             ],
@@ -222,5 +204,18 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
         }
 
         return (string)$firstArgument->getType();
+    }
+
+    private function createEnumerableOptionDescription(array $values): string {
+        return implode(
+            ', ',
+            array_map(
+                static function (int $value, string $label): string {
+                    return "$value – $label";
+                },
+                $values,
+                array_keys($values)
+            )
+        );
     }
 }

--- a/scripts/install/SetupDefaultTemplateConfiguration.php
+++ b/scripts/install/SetupDefaultTemplateConfiguration.php
@@ -27,16 +27,19 @@ namespace oat\taoQtiTest\scripts\install;
 use common_report_Report as Report;
 use oat\oatbox\extension\script\ScriptAction;
 use oat\taoQtiTest\models\test\Template\DefaultConfigurationRegistry;
+use qtism\data\NavigationMode;
 use ReflectionMethod;
 
 class SetupDefaultTemplateConfiguration extends ScriptAction
 {
-    public const CATEGORIES = 'categories';
+    public const CATEGORIES      = 'categories';
+    public const NAVIGATION_MODE = 'navigationMode';
 
     private const ARRAY_VALUE_DELIMITER = ',';
 
     private const OPTION_DEFAULT_VALUES = [
-        self::CATEGORIES => '',
+        self::CATEGORIES      => '',
+        self::NAVIGATION_MODE => NavigationMode::LINEAR,
     ];
 
     protected function provideUsage()
@@ -51,13 +54,31 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
     protected function provideOptions(): array
     {
         return [
-            self::CATEGORIES => [
+            self::CATEGORIES      => [
                 'prefix'      => 'c',
                 'longPrefix'  => self::CATEGORIES,
                 'description' => sprintf(
                     'Test item categories separated by "%s", "%s" by default',
                     self::ARRAY_VALUE_DELIMITER,
                     self::OPTION_DEFAULT_VALUES[self::CATEGORIES]
+                ),
+            ],
+            self::NAVIGATION_MODE => [
+                'prefix'      => 'n',
+                'longPrefix'  => self::NAVIGATION_MODE,
+                'description' => sprintf(
+                    'Test part navigation mode, %s, %d by default',
+                    implode(
+                        ', ',
+                        array_map(
+                            static function (string $navigationModeLabel, int $navigationModeValue): string {
+                                return "$navigationModeValue – $navigationModeLabel";
+                            },
+                            array_keys(NavigationMode::asArray()),
+                            NavigationMode::asArray()
+                        )
+                    ),
+                    self::OPTION_DEFAULT_VALUES[self::NAVIGATION_MODE]
                 ),
             ],
         ];

--- a/scripts/install/SetupDefaultTemplateConfiguration.php
+++ b/scripts/install/SetupDefaultTemplateConfiguration.php
@@ -28,18 +28,29 @@ use common_report_Report as Report;
 use oat\oatbox\extension\script\ScriptAction;
 use oat\taoQtiTest\models\test\Template\DefaultConfigurationRegistry;
 use qtism\data\NavigationMode;
+use qtism\data\SubmissionMode;
 use ReflectionMethod;
 
 class SetupDefaultTemplateConfiguration extends ScriptAction
 {
-    public const CATEGORIES      = 'categories';
-    public const NAVIGATION_MODE = 'navigationMode';
+    public const PART_ID_PREFIX       = 'partIdPrefix';
+    public const SECTION_ID_PREFIX    = 'sectionIdPrefix';
+    public const SECTION_TITLE_PREFIX = 'sectionTitlePrefix';
+    public const CATEGORIES           = 'categories';
+    public const NAVIGATION_MODE      = 'navigationMode';
+    public const SUBMISSION_MODE      = 'submissionMode';
+    public const MAX_ATTEMPTS         = 'maxAttempts';
 
     private const ARRAY_VALUE_DELIMITER = ',';
 
     private const OPTION_DEFAULT_VALUES = [
-        self::CATEGORIES      => '',
-        self::NAVIGATION_MODE => NavigationMode::LINEAR,
+        self::PART_ID_PREFIX       => 'testPart',
+        self::SECTION_ID_PREFIX    => 'assessmentSection',
+        self::SECTION_TITLE_PREFIX => 'Section',
+        self::CATEGORIES           => '',
+        self::NAVIGATION_MODE      => NavigationMode::LINEAR,
+        self::SUBMISSION_MODE      => SubmissionMode::INDIVIDUAL,
+        self::MAX_ATTEMPTS         => 0,
     ];
 
     protected function provideUsage()
@@ -54,7 +65,31 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
     protected function provideOptions(): array
     {
         return [
-            self::CATEGORIES      => [
+            self::PART_ID_PREFIX       => [
+                'prefix'      => 'pi',
+                'longPrefix'  => self::PART_ID_PREFIX,
+                'description' => sprintf(
+                    'Test part ID prefix, "%s" by default',
+                    self::OPTION_DEFAULT_VALUES[self::PART_ID_PREFIX]
+                ),
+            ],
+            self::SECTION_ID_PREFIX    => [
+                'prefix'      => 'si',
+                'longPrefix'  => self::SECTION_ID_PREFIX,
+                'description' => sprintf(
+                    'Test section ID prefix, "%s" by default',
+                    self::OPTION_DEFAULT_VALUES[self::SECTION_ID_PREFIX]
+                ),
+            ],
+            self::SECTION_TITLE_PREFIX => [
+                'prefix'      => 'st',
+                'longPrefix'  => self::SECTION_TITLE_PREFIX,
+                'description' => sprintf(
+                    'Test section title prefix, "%s" by default',
+                    self::OPTION_DEFAULT_VALUES[self::SECTION_TITLE_PREFIX]
+                ),
+            ],
+            self::CATEGORIES           => [
                 'prefix'      => 'c',
                 'longPrefix'  => self::CATEGORIES,
                 'description' => sprintf(
@@ -63,8 +98,8 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
                     self::OPTION_DEFAULT_VALUES[self::CATEGORIES]
                 ),
             ],
-            self::NAVIGATION_MODE => [
-                'prefix'      => 'n',
+            self::NAVIGATION_MODE      => [
+                'prefix'      => 'nm',
                 'longPrefix'  => self::NAVIGATION_MODE,
                 'description' => sprintf(
                     'Test part navigation mode, %s, %d by default',
@@ -79,6 +114,32 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
                         )
                     ),
                     self::OPTION_DEFAULT_VALUES[self::NAVIGATION_MODE]
+                ),
+            ],
+            self::SUBMISSION_MODE      => [
+                'prefix'      => 'sm',
+                'longPrefix'  => self::SUBMISSION_MODE,
+                'description' => sprintf(
+                    'Test part submission mode, %s, %d by default',
+                    implode(
+                        ', ',
+                        array_map(
+                            static function (string $submissionModeLabel, int $submissionModeValue): string {
+                                return "$submissionModeValue – $submissionModeLabel";
+                            },
+                            array_keys(SubmissionMode::asArray()),
+                            SubmissionMode::asArray()
+                        )
+                    ),
+                    self::OPTION_DEFAULT_VALUES[self::SUBMISSION_MODE]
+                ),
+            ],
+            self::MAX_ATTEMPTS         => [
+                'prefix'      => 'm',
+                'longPrefix'  => self::MAX_ATTEMPTS,
+                'description' => sprintf(
+                    'Test element max attempts, %d by default',
+                    self::OPTION_DEFAULT_VALUES[self::MAX_ATTEMPTS]
                 ),
             ],
         ];
@@ -131,7 +192,7 @@ class SetupDefaultTemplateConfiguration extends ScriptAction
                 sprintf(
                     "Applied the following configuration to `%s`\n%s",
                     DefaultConfigurationRegistry::class,
-                    json_encode($setValues)
+                    json_encode($setValues, JSON_PRETTY_PRINT)
                 )
             )
             : Report::createFailure(

--- a/views/js/controller/creator/config/defaults.js
+++ b/views/js/controller/creator/config/defaults.js
@@ -1,0 +1,31 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+define([
+    'lodash',
+    'module',
+], function(
+    _,
+    module
+) {
+    'use strict';
+
+    return (config = {}) => _.defaults(config, module.config())
+});

--- a/views/js/controller/creator/config/defaults.js
+++ b/views/js/controller/creator/config/defaults.js
@@ -27,5 +27,5 @@ define([
 ) {
     'use strict';
 
-    return (config = {}) => _.defaults(config, module.config())
+    return (config = {}) => _.defaults({}, module.config(), config);
 });

--- a/views/js/controller/creator/helpers/categorySelector.js
+++ b/views/js/controller/creator/helpers/categorySelector.js
@@ -101,7 +101,7 @@ define([
 
                 // add preset checkboxes
                 $presetsContainer.append(
-                    presetsTpl(allPresets)
+                    presetsTpl({presetGroups: allPresets})
                 );
 
                 $presetsContainer.on('click', function(e) {

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -57,6 +57,9 @@ define([
         //the categories that are not in the current categories collection should be added to the children
         toAdd = _.difference(selected, currentCategories.propagated);
 
+        model.categories = _.difference(model.categories, toRemove);
+        model.categories = model.categories.concat(toAdd);
+
         //process the modification
         addCategories(model, toAdd);
         removeCategories(model, toRemove);

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -76,11 +76,22 @@ define([
             partial;
 
         if(isValidSectionModel(model)){
+            var itemCount = 0;
+
             categories = _.map(model.sectionParts, function (itemRef){
-                if(itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)){
+                if(itemRef['qti-type'] === 'assessmentItemRef' && ++itemCount && _.isArray(itemRef.categories)){
                     return _.compact(itemRef.categories);
                 }
             });
+
+            if (!itemCount) {
+                return {
+                    all: model.categories,
+                    propagated: model.categories,
+                    partial: []
+                }
+            }
+
             //array of categories
             arrays = _.values(categories);
             union = _.union.apply(null, arrays);

--- a/views/js/controller/creator/templates/category-presets.tpl
+++ b/views/js/controller/creator/templates/category-presets.tpl
@@ -1,5 +1,4 @@
-{{#each this}}
-
+{{#each presetGroups}}
 <h4 class="toggler closed" data-toggle="~ .category-preset-group-{{groupId}}">{{groupLabel}}</h4>
 
 <div class="category-preset-group-{{groupId}} toggled">
@@ -7,7 +6,12 @@
     <div class="grid-row pseudo-label-box category-preset" data-qti-category="{{qtiCategory}}">
         <div class="col-1">
             <label>
-                <input type="checkbox" name="category-preset-{{id}}" value="{{qtiCategory}}"/>
+                <input
+                        type="checkbox"
+                        name="category-preset-{{id}}"
+                        value="{{qtiCategory}}"
+                        {{#includes ../../categories qtiCategory}}checked{{/includes}}
+                />
                 <span class="icon-checkbox"></span>
             </label>
         </div>

--- a/views/js/controller/creator/templates/index.js
+++ b/views/js/controller/creator/templates/index.js
@@ -1,4 +1,5 @@
 define([
+    'taoQtiTest/controller/creator/config/defaults',
     'tpl!taoQtiTest/controller/creator/templates/testpart',
     'tpl!taoQtiTest/controller/creator/templates/section',
     'tpl!taoQtiTest/controller/creator/templates/rubricblock',
@@ -13,6 +14,7 @@ define([
     'tpl!taoQtiTest/controller/creator/templates/category-presets'
 ],
 function(
+    defaults,
     testPart,
     section,
     rubricBlock,
@@ -28,24 +30,26 @@ function(
 ){
     'use strict';
 
+    const applyTemplateConfiguration = (template) => (config) => template(defaults(config));
+
     /**
      * Expose all the templates used by the test creator
      * @exports taoQtiTest/controller/creator/templates/index
      */
     return {
-        'testpart'      : testPart,
-        'section'       : section,
-        'itemref'       : itemRef,
-        'rubricblock'   : rubricBlock,
-        'outcomes'      : outcomes,
-        'properties'    : {
-            'test'      : testProps,
-            'testpart'  : testPartProps,
-            'section'   : sectionProps,
-            'itemref'   : itemRefProps,
-            'itemrefweight'     : itemRefPropsWeight,
-            'rubricblock'       : rubricBlockProps,
-            'categorypresets'  : categoryPresets
+        testpart    : applyTemplateConfiguration(testPart),
+        section     : applyTemplateConfiguration(section),
+        itemref     : applyTemplateConfiguration(itemRef),
+        rubricblock : applyTemplateConfiguration(rubricBlock),
+        outcomes    : applyTemplateConfiguration(outcomes),
+        properties  : {
+            test            : applyTemplateConfiguration(testProps),
+            testpart        : applyTemplateConfiguration(testPartProps),
+            section         : applyTemplateConfiguration(sectionProps),
+            itemref         : applyTemplateConfiguration(itemRefProps),
+            itemrefweight   : applyTemplateConfiguration(itemRefPropsWeight),
+            rubricblock     : applyTemplateConfiguration(rubricBlockProps),
+            categorypresets : applyTemplateConfiguration(categoryPresets)
         }
     };
 });

--- a/views/js/controller/creator/templates/outcomes.tpl
+++ b/views/js/controller/creator/templates/outcomes.tpl
@@ -1,18 +1,16 @@
-    <div class="grid-row">
-        <div class="col-6 header">{{__ 'Identifier'}}</div>
-        <div class="col-3 header">{{__ 'Type'}}</div>
-        <div class="col-3 header">{{__ 'Cardinality'}}</div>
-    </div>
-{{#if this}}
-    {{#each this}}
+<div class="grid-row">
+    <div class="col-6 header">{{__ 'Identifier'}}</div>
+    <div class="col-3 header">{{__ 'Type'}}</div>
+    <div class="col-3 header">{{__ 'Cardinality'}}</div>
+</div>
+{{#each outcomes}}
     <div class="grid-row">
         <div class="col-6 line">{{name}}</div>
         <div class="col-3 line">{{type}}</div>
         <div class="col-3 line">{{cardinality}}</div>
     </div>
-    {{/each}}
 {{else}}
     <div class="grid-row">
         <div class="col-12 line">{{__ 'no outcome declaration found'}}</div>
     </div>
-{{/if}}
+{{/each}}

--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -242,7 +242,15 @@
                 <label for="section-max-attempts">{{__ 'Max Attempts'}}</label>
             </div>
             <div class="col-6">
-                <input id="section-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                <input
+                        id="section-max-attempts"
+                        type="text"
+                        data-increment="1"
+                        data-min="0"
+                        value="{{maxAttempts}}"
+                        data-bind="itemSessionControl.maxAttempts"
+                        data-bind-encoder="number"
+                />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -7,7 +7,7 @@
             <label for="section-identifier">{{__ 'Identifier'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
         </div>
         <div class="col-6">
-            <input type="text" name="section-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable;" />
+            <input type="text" id="section-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable;" />
         </div>
         <div class="col-1 help">
             <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -23,7 +23,7 @@
             <label for="section-title">{{__ 'Title'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
         </div>
         <div class="col-6">
-            <input type="text" name="section-title" data-bind="title" data-validate="$notEmpty" />
+            <input type="text" id="section-title" data-bind="title" data-validate="$notEmpty" />
         </div>
         <div class="col-1 help">
             <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -121,7 +121,7 @@
         </div>
 
         <div class="col-6">
-            <input type="text" name="section-blueprint" />
+            <input type="text" id="section-blueprint" />
         </div>
         <div class="col-1 help">
             <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -138,7 +138,7 @@
                 <label for="category-custom">{{__ 'Categories'}}</label>
             </div>
             <div class="col-6">
-                <input type="text" name="category-custom"/>
+                <input type="text" id="category-custom" name="category-custom"/>
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -176,7 +176,7 @@
                 <label for="section-select">{{__ 'Select'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
             </div>
             <div class="col-6">
-                <input name="section-select" type="text" data-increment="1" data-min="0" value="0" data-bind="selection.select"  data-bind-encoder="number" />
+                <input id="section-select" name="section-select" type="text" data-increment="1" data-min="0" value="0" data-bind="selection.select"  data-bind-encoder="number" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -242,7 +242,7 @@
                 <label for="section-max-attempts">{{__ 'Max Attempts'}}</label>
             </div>
             <div class="col-6">
-                <input name="section-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                <input id="section-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -402,7 +402,7 @@
                 <label for="section-max-time">{{__ 'Maximum Duration'}}</label>
             </div>
             <div class="col-6 duration-group">
-                <input type="text" name="max-time" value="00:00:00" data-duration="HH:mm:ss" data-bind="timeLimits.maxTime" data-bind-encoder="time" />
+                <input type="text" id="section-max-time" name="max-time" value="00:00:00" data-duration="HH:mm:ss" data-bind="timeLimits.maxTime" data-bind-encoder="time" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -242,7 +242,7 @@
                 <label for="section-max-attempts">{{__ 'Max Attempts'}}</label>
             </div>
             <div class="col-6">
-                <input name="section-max-attempts" type="text" data-increment="1" data-min="0" value="1" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                <input name="section-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -81,7 +81,7 @@
                     <label for="testpart-max-attempts">{{__ 'Max Attempts'}}</label>
                 </div>
                 <div class="col-6">
-                    <input name="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="1" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                    <input name="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
                 </div>
                 <div class="col-1 help">
                     <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -63,12 +63,24 @@
             </div>
             <div class="col-6">
                 <label>
-                    <input type="radio" name="testpart-submission-mode" value="0" checked="checked" data-bind="submissionMode" data-bind-encoder="number" />
+                    <input
+                            type="radio"
+                            name="testpart-submission-mode"
+                            {{#equal submissionMode 0}}checked{{/equal}}
+                            value="0"
+                            data-bind="submissionMode"
+                            data-bind-encoder="number"
+                    />
                     <span class="icon-radio"></span>
                     {{__ 'Individual'}}
                 </label>
                 <label>
-                    <input type="radio" name="testpart-submission-mode" value="1"  />
+                    <input
+                            type="radio"
+                            name="testpart-submission-mode"
+                            {{#equal submissionMode 1}}checked{{/equal}}
+                            value="1"
+                    />
                     <span class="icon-radio"></span>
                     {{__ 'Simultaneous'}}
                 </label>

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -105,7 +105,15 @@
                     <label for="testpart-max-attempts">{{__ 'Max Attempts'}}</label>
                 </div>
                 <div class="col-6">
-                    <input id="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                    <input
+                            id="testpart-max-attempts"
+                            type="text"
+                            data-increment="1"
+                            data-min="0"
+                            value="{{maxAttempts}}"
+                            data-bind="itemSessionControl.maxAttempts"
+                            data-bind-encoder="number"
+                    />
                 </div>
                 <div class="col-1 help">
                     <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -9,7 +9,7 @@
                 <label for="testpart-identifier">{{__ 'Identifier'}} <abbr title="{{__ 'Required field'}}">*</abbr></label>
             </div>
             <div class="col-6">
-                <input type="text" name="testpart-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable;" />
+                <input type="text" id="testpart-identifier" data-bind="identifier" data-validate="$notEmpty; $idFormat; $testIdAvailable;" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -81,7 +81,7 @@
                     <label for="testpart-max-attempts">{{__ 'Max Attempts'}}</label>
                 </div>
                 <div class="col-6">
-                    <input name="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                    <input id="testpart-max-attempts" type="text" data-increment="1" data-min="0" value="0" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
                 </div>
                 <div class="col-1 help">
                     <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -99,7 +99,7 @@
                 <div class="col-6">
                     <label>
                         <input type="checkbox" name="testpart-show-feedback" value="true" data-bind="itemSessionControl.showFeedback" data-bind-encoder="boolean" />
-                        <span class="icon-checkbox" />
+                        <span class="icon-checkbox"></span>
                     </label>
                 </div>
                 <div class="col-1 help">
@@ -160,7 +160,7 @@
                 <div class="col-6">
                     <label>
                         <input type="checkbox" name="testpart-allow-comment" value="true" data-bind="itemSessionControl.allowComment" data-bind-encoder="boolean" />
-                        <span class="icon-checkbox" />
+                        <span class="icon-checkbox"></span>
                     </label>
                 </div>
                 <div class="col-1 help">
@@ -179,7 +179,7 @@
                 <div class="col-6">
                     <label>
                         <input type="checkbox" name="testpart-allow-skipping" value="true" checked="checked"  data-bind="itemSessionControl.allowSkipping" data-bind-encoder="boolean"   />
-                        <span class="icon-checkbox" />
+                        <span class="icon-checkbox"></span>
                     </label>
                 </div>
                 <div class="col-1 help">
@@ -198,7 +198,7 @@
                 <div class="col-6">
                     <label>
                         <input type="checkbox" name="testpart-validate-responses" value="true"  data-bind="itemSessionControl.validateResponses" data-bind-encoder="boolean"  />
-                        <span class="icon-checkbox" />
+                        <span class="icon-checkbox"></span>
                     </label>
                 </div>
                 <div class="col-1 help">
@@ -240,7 +240,7 @@
                     <label for="testpart-max-time">{{__ 'Maximum Duration'}}</label>
                 </div>
                 <div class="col-6 duration-group">
-                    <input type="text" name="max-time" value="00:00:00" data-duration="HH:mm:ss" data-bind="timeLimits.maxTime" data-bind-encoder="time" />
+                    <input type="text" id="testpart-max-time" name="max-time" value="00:00:00" data-duration="HH:mm:ss" data-bind="timeLimits.maxTime" data-bind-encoder="time" />
                 </div>
                 <div class="col-1 help">
                     <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
@@ -258,7 +258,7 @@
                 <div class="col-6">
                     <label>
                         <input type="checkbox" name="section-allow-late-submission" value="true" data-bind="timeLimits.allowLateSubmission" data-bind-encoder="boolean" />
-                        <span class="icon-checkbox" />
+                        <span class="icon-checkbox"></span>
                     </label>
                 </div>
                 <div class="col-1 help">

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -26,12 +26,24 @@
             </div>
             <div class="col-6">
                 <label>
-                    <input type="radio" name="testpart-navigation-mode" value="0" checked="checked" data-bind="navigationMode" data-bind-encoder="number" />
+                    <input
+                            type="radio"
+                            name="testpart-navigation-mode"
+                            {{#equal navigationMode 0}}checked{{/equal}}
+                            value="0"
+                            data-bind="navigationMode"
+                            data-bind-encoder="number"
+                    />
                     <span class="icon-radio"></span>
                     {{__ 'Linear'}}
                 </label>
                 <label>
-                    <input type="radio" name="testpart-navigation-mode" value="1"  />
+                    <input
+                            type="radio"
+                            name="testpart-navigation-mode"
+                            {{#equal navigationMode 1}}checked{{/equal}}
+                            value="1"
+                    />
                     <span class="icon-radio"></span>
                     {{__ 'Non Linear'}}
                 </label>

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -24,6 +24,7 @@ define([
     'lodash',
     'uri',
     'i18n',
+    'taoQtiTest/controller/creator/config/defaults',
     'taoQtiTest/controller/creator/views/actions',
     'taoQtiTest/controller/creator/views/itemref',
     'taoQtiTest/controller/creator/views/rubricblock',
@@ -38,6 +39,7 @@ function(
     _,
     uri,
     __,
+    defaults,
     actions,
     itemRefView,
     rubricBlockView,
@@ -55,7 +57,7 @@ function(
      * @param {Object} creatorContext
      * @param {Object} sectionModel - the data model to bind to the test section
      * @param {Object} partModel - the parent data model to inherit
-     * @param {jQueryElement} $section - the section to set up
+     * @param {jQuery} $section - the section to set up
      */
     function setUp (creatorContext, sectionModel, partModel, $section) {
 
@@ -66,6 +68,9 @@ function(
         // set item session control to use test part options if section level isn't set
         if (!sectionModel.itemSessionControl) {
             sectionModel.itemSessionControl = {};
+        }
+        if (!sectionModel.categories) {
+            sectionModel.categories = defaults().categories;
         }
         _.defaults(sectionModel.itemSessionControl, partModel.itemSessionControl);
 
@@ -245,7 +250,7 @@ function(
 
         /**
          * Add a new item ref to the section
-         * @param {jQueryElement} $refList - the element to add the item to
+         * @param {jQuery} $refList - the element to add the item to
          * @param {Number} [index] - the position of the item to add
          * @param {Object} [itemData] - the data to bind to the new item ref
          */
@@ -331,7 +336,7 @@ function(
         /**
          * Set up the category property
          * @private
-         * @param {jQueryElement} $view - the $view object containing the $select
+         * @param {jQuery} $view - the $view object containing the $select
          * @fires modelOverseer#category-change
          */
         function categoriesProperty($view){
@@ -360,7 +365,7 @@ function(
         /**
          * Set up the Blueprint property
          * @private
-         * @param {jQueryElement} $view - the $view object containing the $select
+         * @param {jQuery} $view - the $view object containing the $select
          */
         function blueprintProperty($view){
             var $select = $('[name=section-blueprint]', $view);

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -20,12 +20,13 @@
  */
 define([
     'jquery', 'lodash', 'i18n', 'ui/hider', 'ui/feedback',
+    'taoQtiTest/controller/creator/config/defaults',
     'taoQtiTest/controller/creator/views/actions',
     'taoQtiTest/controller/creator/views/testpart',
     'taoQtiTest/controller/creator/templates/index',
     'taoQtiTest/controller/creator/helpers/qtiTest'
 ],
-function($, _, __, hider, feedback, actions, testPartView, templates, qtiTestHelper){
+function($, _, __, hider, feedback, defaults, actions, testPartView, templates, qtiTestHelper){
     'use strict';
 
     /**
@@ -154,7 +155,7 @@ function($, _, __, hider, feedback, actions, testPartView, templates, qtiTestHel
                         'qti-type' : 'testPart',
                         identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'testPart'),
                         index  : testPartIndex,
-                        navigationMode : 0,
+                        navigationMode : defaults().navigationMode,
                         submissionMode : 0,
                         assessmentSections : [{
                             'qti-type' : 'assessmentSection',

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -159,8 +159,8 @@ function($, _, __, hider, feedback, defaults, actions, testPartView, templates, 
                         submissionMode : 0,
                         assessmentSections : [{
                             'qti-type' : 'assessmentSection',
-                            identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection', 'section'),
-                            title : 'Section 1',
+                            identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection', defaults().sectionIdPrefix),
+                            title : `${defaults().sectionTitlePrefix} 1`,
                             index : 0,
                             sectionParts : []
                         }]

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -101,7 +101,7 @@ function($, _, __, hider, feedback, actions, testPartView, templates, qtiTestHel
             function updateOutcomes() {
                 var $panel = $('.outcome-declarations', $view);
 
-                $panel.html(templates.outcomes(modelOverseer.getOutcomesList()));
+                $panel.html(templates.outcomes({outcomes: modelOverseer.getOutcomesList()}));
             }
 
             $('[name=test-outcome-processing]', $view).select2({

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -156,7 +156,7 @@ function($, _, __, hider, feedback, defaults, actions, testPartView, templates, 
                         identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'testPart', defaults().partIdPrefix),
                         index  : testPartIndex,
                         navigationMode : defaults().navigationMode,
-                        submissionMode : 0,
+                        submissionMode : defaults().submissionMode,
                         assessmentSections : [{
                             'qti-type' : 'assessmentSection',
                             identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection', defaults().sectionIdPrefix),

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -153,7 +153,7 @@ function($, _, __, hider, feedback, defaults, actions, testPartView, templates, 
                     var testPartIndex = $('.testpart').length;
                     cb({
                         'qti-type' : 'testPart',
-                        identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'testPart'),
+                        identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'testPart', defaults().partIdPrefix),
                         index  : testPartIndex,
                         navigationMode : defaults().navigationMode,
                         submissionMode : 0,

--- a/views/js/controller/creator/views/testpart.js
+++ b/views/js/controller/creator/views/testpart.js
@@ -21,11 +21,12 @@
  */
 define([
     'jquery', 'lodash',
+    'taoQtiTest/controller/creator/config/defaults',
     'taoQtiTest/controller/creator/views/actions',
     'taoQtiTest/controller/creator/views/section',
     'taoQtiTest/controller/creator/templates/index',
     'taoQtiTest/controller/creator/helpers/qtiTest'],
-function($, _, actions, sectionView, templates, qtiTestHelper){
+function($, _, defaults, actions, sectionView, templates, qtiTestHelper){
     'use strict';
 
     /**
@@ -33,12 +34,11 @@ function($, _, actions, sectionView, templates, qtiTestHelper){
      *
      * @param {Object} creatorContext
      * @param {Object} partModel - the data model to bind to the test part
-     * @param {jQueryElement} $testPart - the testpart container to set up
+     * @param {jQuery} $testPart - the testpart container to set up
      */
     function setUp (creatorContext, partModel, $testPart){
         var $actionContainer = $('h1', $testPart);
         var modelOverseer = creatorContext.getModelOverseer();
-        var config = modelOverseer.getConfig();
 
         //run setup methods
         actions.properties($actionContainer, 'testpart', partModel, propHandler);
@@ -112,8 +112,8 @@ function($, _, actions, sectionView, templates, qtiTestHelper){
                     var sectionIndex = $('.section', $testPart).length;
                     cb({
                         'qti-type' : 'assessmentSection',
-                        identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection'),
-                        title : 'Section ' + (sectionIndex + 1),
+                        identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection', defaults().sectionIdPrefix),
+                        title : `${defaults().sectionTitlePrefix} ${sectionIndex + 1}`,
                         index : 0,
                         sectionParts : []
                     });


### PR DESCRIPTION
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) fix: align test part's max attempt default value with the template default-template one (`0`)
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) fix(html): expand shorthand `span` tags in `testpart-props.tpl`
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) fix(html): add missing IDs to `input` tags in order to link them with their labels in `testpart-props.tpl`
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) fix: align test section's max attempt default value with the template default-template one (`0`)
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) fix(html): add missing IDs to `input` tags in order to link them with their labels in `section-props.tpl`
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: support default test item categories, configured via `oat\taoQtiTest\models\test\Template\DefaultConfigurationRegistry`
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: inherit user-defined empty section settings when adding a new item.
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) fix: supply an object to `outcomes` template
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) chore: simplify `outcomes.tpl` conditional statements
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) fix(dependencies): add a direct dependency on `qtism/qtism` as it's being used directly.
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: support default test part navigation mode, configured via `oat\taoQtiTest\models\test\Template\DefaultConfigurationRegistry`
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: align `DefaultConfigurationRegistry`-contained values with `AssessmentTestXmlFactory`'s options
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: support newly-added test section's title and ID customization
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: support newly-added test part's ID customization
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: support newly-added test part's submission mode customization
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) feat: support newly-added test part's & section's item max-attempts value customization
- [BSA-167](https://oat-sa.atlassian.net/browse/BSA-167) BREAKING CHANGE: migrate `AssessmentTestXmlFactory` to use `DefaultConfigurationRegistry` as a primary data source

ℹ️ Required by `taoBosaSelor` [#67](https://github.com/oat-sa/extension-tao-bosa-selor/pull/67).