### PR TITLE
Act 483/fix/check if current item exists

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.1.3',
+    'version' => '40.1.4',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -44,6 +44,7 @@ use qtism\data\AssessmentItemRef;
 use qtism\data\NavigationMode;
 use qtism\runtime\storage\binary\AbstractQtiBinaryStorage;
 use qtism\runtime\storage\binary\BinaryAssessmentTestSeeker;
+use qtism\runtime\tests\AssessmentTestSession;
 use qtism\runtime\tests\RouteItem;
 use oat\oatbox\event\EventManager;
 use oat\taoQtiTest\models\event\SelectAdaptiveNextItemEvent;
@@ -431,6 +432,10 @@ class QtiRunnerServiceContext extends RunnerServiceContext
         return $catEngine;
     }
 
+    /**
+     * @return AssessmentTestSession
+     * @throws \common_exception_Error
+     */
     public function getTestSession()
     {
         if (!$this->testSession) {
@@ -652,7 +657,7 @@ class QtiRunnerServiceContext extends RunnerServiceContext
      *
      * This method returns the current AssessmentItemRef object depending on the test $context.
      *
-     * @return \qtism\data\ExtendedAssessmentItemRef
+     * @return \qtism\data\ExtendedAssessmentItemRef|false
      */
     public function getCurrentAssessmentItemRef()
     {

--- a/models/classes/runner/RunnerParamParserTrait.php
+++ b/models/classes/runner/RunnerParamParserTrait.php
@@ -162,7 +162,8 @@ trait RunnerParamParserTrait
                 ? json_decode($this->getRequestParameter('itemResponse'), true)
                 : null;
 
-            if ($serviceContext->getCurrentAssessmentItemRef()->getIdentifier() !== $itemDefinition) {
+            $currentAssessmentItemRef = $serviceContext->getCurrentAssessmentItemRef();
+            if ($currentAssessmentItemRef && $serviceContext->getCurrentAssessmentItemRef()->getIdentifier() !== $itemDefinition) {
                 throw new QtiRunnerItemResponseException(__('Item response identifier does not match current item'));
             }
 


### PR DESCRIPTION
At time of saving item response there is a check that item identifier in response is equal current item in the test session. 

In case if test session is already closed (timeout, terminated by proctor or script etc.) attempt to save item response causes PHP fatal error because `getCurrentAssessmentItemRef` returns `false`:
```
PHP Fatal error: Uncaught Error: Call to a member function getIdentifier() on boolean in /var/www/html/taoplatform/taoQtiTest/models/classes/runner/RunnerParamParserTrait.php:165
Stack trace:
#0 /var/www/html/taoplatform/taoQtiTest/models/classes/runner/synchronisation/action/Move.php(72): oat\taoQtiTest\models\runner\synchronisation\TestRunnerAction->saveItemResponses(false)
#1 /var/www/html/taoplatform/taoQtiTest/models/classes/runner/synchronisation/synchronisationService/ResponseGenerator.php(157): oat\taoQtiTest\models\runner\synchronisation\action\Move->process()
#2 /var/www/html/taoplatform/taoQtiTest/models/classes/runner/synchronisation/SynchronisationService.php(67): oat\taoQtiTest\models\runner\synchronisation\synchronisationService\ResponseGenerator->getActionResponse(Object(oat\taoQtiTest\models\runner\synchronisation\action\Move), 1596114943.7091, 0, Object(oat\taoQtiTest\models\runner\QtiRunnerServiceContext))
```