### PR TITLE
Feature/nex 2170/register item scrolling plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.1.5',
+    'version' => '40.2.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/migrations/Version202011031024012260_taoQtiTest.php
+++ b/migrations/Version202011031024012260_taoQtiTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoTests\models\runner\plugins\PluginRegistry;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202011031024012260_taoQtiTest extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register Item Scrolling plugin';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        if (!$registry->isRegistered('taoQtiTest/runner/plugins/content/itemScrolling/itemScrolling')) {
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'itemScrolling',
+                'name' => 'Item Scrolling',
+                'module' => 'taoQtiTest/runner/plugins/content/itemScrolling/itemScrolling',
+                'description' => 'Add behavior from enable/disable scrolling option',
+                'category' => 'content',
+                'active' => true,
+                'tags' => [  ]
+            ]));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        if ($registry->isRegistered('taoQtiTest/runner/plugins/content/itemScrolling/itemScrolling')) {
+            $registry->remove('taoQtiTest/runner/plugins/content/itemScrolling/itemScrolling');
+        }
+    }
+}

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -153,6 +153,15 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'category' => 'content',
                 'active' => false,
                 'tags' => [ ]
+            ], [
+                'id' => 'itemScrolling',
+                'name' => 'Item Scrolling',
+                'module' => 'taoQtiTest/runner/plugins/content/itemScrolling/itemScrolling',
+                'bundle' => 'taoQtiTest/loader/testPlugins.min',
+                'description' => 'Add behavior from enable/disable scrolling option',
+                'category' => 'content',
+                'active' => true,
+                'tags' => [ ]
             ]
         ],
         'controls' => [

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.16.8",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.16.8.tgz",
-      "integrity": "sha512-Ffz8aIqZr6FDaSBz/unA6EucVwgsDOKGYYF6jIzNBW0CB0SWgtg6mrrD0yjfraZH6o6gjwvIN+zGvrCqcyniPA=="
+      "version": "github:oat-sa/tao-test-runner-qti-fe#213c882b034ea81bc9b62378ccb49a8ec3c14bc1",
+      "from": "github:oat-sa/tao-test-runner-qti-fe#feature/NEX-2170-enable-scrollable-passages"
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "github:oat-sa/tao-test-runner-qti-fe#213c882b034ea81bc9b62378ccb49a8ec3c14bc1",
-      "from": "github:oat-sa/tao-test-runner-qti-fe#feature/NEX-2170-enable-scrollable-passages"
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.0.tgz",
+      "integrity": "sha512-rsqJiFm2ZVtwzzFRAIxistFtWapArqxH0Yj7LfWY3dIhIdN8737RzXXHyjrXA8+lf3giT5JkiUORpNF/yRDgHA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/NEX-2170-enable-scrollable-passages"
+    "@oat-sa/tao-test-runner-qti": "2.17.0"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.16.8"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/NEX-2170-enable-scrollable-passages"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-2170
Related to: https://github.com/oat-sa/extension-tao-itemqti/pull/1570
- [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/323 **!package.json should be updated**

How to test:
 - run taoUpdate
 - check that `config/taoTests/test_runner_plugin_registry.conf.php` appeared
```
   'taoQtiTest/runner/plugins/content/itemScrolling/itemScrolling' => array(
            'id' => 'itemScrolling',
            'module' => 'taoQtiTest/runner/plugins/content/itemScrolling/itemScrolling',
            'bundle' => 'taoQtiTest/loader/testPlugins.min',
            'position' => null,
            'name' => 'Enable effect from enable/disable scrolling option',
            'description' => 'Add behavior from enable/disable scrolling option',
            'category' => 'content',
            'active' => true,
            'tags' => array(
            )
        ),
```
- go to Item authoring tool
- Select or add textblock
- In properties column activate enable scroll checkbox and set some option.
- Run test preview and if content in text block is bigger then page height there should appear scroll