### PR TITLE
Fix/tr 83/prevent the next button to be clicked twice

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.2.0',
+    'version' => '40.2.1',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.0.tgz",
-      "integrity": "sha512-rsqJiFm2ZVtwzzFRAIxistFtWapArqxH0Yj7LfWY3dIhIdN8737RzXXHyjrXA8+lf3giT5JkiUORpNF/yRDgHA=="
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.1.tgz",
+      "integrity": "sha512-4xXdBuiIfLQT/2dqcQt4F5NJwr8T4rP1PWIdWi0WN7E0qvqyVgl5XY9g5kyXEHMdcAbIa0OGr2A9TdLUTLZdhg=="
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.17.0"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-83/prevent-the-next-button-to-be-clicked-twice"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-83/prevent-the-next-button-to-be-clicked-twice"
+    "@oat-sa/tao-test-runner-qti": "2.17.1"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-83

Requires: 
 - [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/325
 - [x] update `package.json` with the right version once the companion PR has been merged, released and published

Update the dependency `@oat-sa/tao-test-runner-qti` to make sure the `Next` button cannot be clicked twice in a row.