### PR TITLE
Fix/ms 596/select2 paddings on focus

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.2.1',
+    'version' => '40.2.2',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.2.tgz",
-      "integrity": "sha512-b5Jjzeb+25ybWjBuqOHXPdn7Bagc7cDKRKq3czJV1n5CsYg3CNSlxog64YK68zp8/4jcK2YmVSAiwLQ9E9OMrg=="
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.3.tgz",
+      "integrity": "sha512-qYXmO8UT8Dmm7/+PDkvc3jSILpIz0JeTYoSjxX/AbFEdZ5mrzmvupDbDTNCBR2NQ1xdRqD6rV4bASTXqKf13ZA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/MS-596/prevent-appling-naviagation-plugin-styles-on-select2-dropdown"
+    "@oat-sa/tao-test-runner-qti": "2.17.3"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.17.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/MS-596/prevent-appling-naviagation-plugin-styles-on-select2-dropdown"
   }
 }


### PR DESCRIPTION
**Related to task:** https://oat-sa.atlassian.net/browse/MS-596
https://github.com/oat-sa/tao-test-runner-qti-fe/pull/329

**Description:** Remove padding from focused select2
**Requires:** 
- [x] Release https://github.com/oat-sa/tao-test-runner-qti-fe/pull/329
- [x] Update versions in package*.json files

**How to test:** 
Install generate `tao-test-runner-qti-fe` and generate css files by running `grunt taoqtitestsass`
**Steps to reproduce:** 
- Create an item with "Inline choice"
- Create a test and delivery
- Open delivery as TT

*Expected behavior:* Dropdown on focus has no empty spaces