### PR TITLE
Fix/tr 81/item duration shifted to next item

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.2.1',
+    'version' => '40.2.2',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.1.tgz",
-      "integrity": "sha512-4xXdBuiIfLQT/2dqcQt4F5NJwr8T4rP1PWIdWi0WN7E0qvqyVgl5XY9g5kyXEHMdcAbIa0OGr2A9TdLUTLZdhg=="
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.2.tgz",
+      "integrity": "sha512-b5Jjzeb+25ybWjBuqOHXPdn7Bagc7cDKRKq3czJV1n5CsYg3CNSlxog64YK68zp8/4jcK2YmVSAiwLQ9E9OMrg=="
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-81/item-duration-shifted-to-next-item"
+    "@oat-sa/tao-test-runner-qti": "2.17.2"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.17.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-81/item-duration-shifted-to-next-item"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-81

Requires:
- [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/330
- [x] update the dependency in `package.json` and `package-lock.json`

Update dependency to `oat-sa/tao-test-runner-qti`.

