### PR TITLE
Fix/CON-33/update item scrolling plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.2.4',
+    'version' => '40.2.5',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.4.tgz",
-      "integrity": "sha512-Hgi1LRRzpm/IeYvdjmU5vkJS0K9WqXnlqIeWeMg1GNs0e6HYALoQTFgrCR7c4kqu3iAXO0m+NHTR550Jb3ud5Q=="
+      "version": "github:oat-sa/tao-test-runner-qti-fe#7155aa340c8a2e7ec9659f924a886fc4322ecd72",
+      "from": "github:oat-sa/tao-test-runner-qti-fe#fix/CON-33/update-item-scrolling-plugin"
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "github:oat-sa/tao-test-runner-qti-fe#7155aa340c8a2e7ec9659f924a886fc4322ecd72",
-      "from": "github:oat-sa/tao-test-runner-qti-fe#fix/CON-33/update-item-scrolling-plugin"
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.5.tgz",
+      "integrity": "sha512-ta4uMkYa+32ADcroirmPM8YDY05xMtVlRdnbhTeMVvb2ZNVFU9u6GIYx+kckMrYRK8ecicjwJZ/AFu5x4ZhKHQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/CON-33/update-item-scrolling-plugin"
+    "@oat-sa/tao-test-runner-qti": "2.17.5"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.17.4"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/CON-33/update-item-scrolling-plugin"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-33

- [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/335 **UPDATE package.json after merge**

Fixed issue with Save - update `container.body` after Active Include widget exit
Added support for new UI test runner - added classes `tao-overflow-y` for height `tao-full-height` and other

How to test:

1. create passage
2. create item with this passage
3. enable scroll for passage and save item
4. go to test Preview and check that passage is scrollable