### PR TITLE
Fix/pr 28/end item timer in pause communication action

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.2.4',
+    'version' => '40.2.5',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.2.5',
+    'version' => '40.2.6',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/runner/synchronisation/action/Pause.php
+++ b/models/classes/runner/synchronisation/action/Pause.php
@@ -49,7 +49,9 @@ class Pause extends TestRunnerAction
             $serviceContext = $this->getServiceContext();
 
             $this->saveToolStates();
-
+            if ($this->shouldTimerStopOnPause()) {
+                $this->endItemTimer($this->getTime());
+            }
             if ($this->getRequestParameter('offline') === true) {
                 $this->setOffline();
             }
@@ -64,5 +66,17 @@ class Pause extends TestRunnerAction
         }
 
         return $response;
+    }
+
+    private function shouldTimerStopOnPause(): bool
+    {
+        $isTerminated = $this->getRunnerService()->isTerminated($this->getServiceContext());
+        if (!$isTerminated) {
+            $timerTarget = $this->getRunnerService()->getTestConfig()->getConfigValue('timer.target');
+            if ($timerTarget === 'client') {
+                return  true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/PR-28

Problem:
If test runner is configured to use client timer and messages communication, item timer is not stopped on `pause` action, as it's done in test runner [`pause` endpoint](https://github.com/oat-sa/extension-tao-testqti/blob/develop/actions/class.Runner.php#L814).

How to test: 
- start delivery execution (can be proctored)
- pause delivery execution (test runner plugins or proctor pause)
- check that item timer is stopped. Technical, can be checked in test session's timer, or that event was triggered and delivery monitoring updated with correct value (if proctoring is used).