### PR TITLE
Feature/TR-121/Add a plugin to pause on error

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.2.5',
+    'version' => '40.3.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/migrations/Version202011181534582260_taoQtiTest.php
+++ b/migrations/Version202011181534582260_taoQtiTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoTests\models\runner\plugins\PluginRegistry;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202011181534582260_taoQtiTest extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register Pause-on-Error plugin';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        if (!$registry->isRegistered('taoQtiTest/runner/plugins/controls/connectivity/pauseOnError')) {
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'pauseOnError',
+                'name' => 'Reacts to errors',
+                'module' => 'taoQtiTest/runner/plugins/controls/connectivity/pauseOnError',
+                'bundle' => 'taoQtiTest/loader/testPlugins.min',
+                'description' => 'When an error occurs, lets the user pause the test or reload the page',
+                'category' => 'controls',
+                'active' => false,
+                'tags' => [ 'core', 'technical' ]
+            ]));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        if ($registry->isRegistered('taoQtiTest/runner/plugins/controls/connectivity/pauseOnError')) {
+            $registry->remove('taoQtiTest/runner/plugins/controls/connectivity/pauseOnError');
+        }
+    }
+}

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -202,6 +202,15 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'active' => true,
                 'tags' => [ 'core', 'technical' ]
             ], [
+                'id' => 'pauseOnError',
+                'name' => 'Reacts to errors',
+                'module' => 'taoQtiTest/runner/plugins/controls/connectivity/pauseOnError',
+                'bundle' => 'taoQtiTest/loader/testPlugins.min',
+                'description' => 'When an error occurs, lets the user pause the test or reload the page',
+                'category' => 'controls',
+                'active' => false,
+                'tags' => [ 'core', 'technical' ]
+            ], [
                 'id' => 'testState',
                 'name' => 'Test state',
                 'module' => 'taoQtiTest/runner/plugins/controls/testState/testState',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.17.5",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.17.5.tgz",
-      "integrity": "sha512-ta4uMkYa+32ADcroirmPM8YDY05xMtVlRdnbhTeMVvb2ZNVFU9u6GIYx+kckMrYRK8ecicjwJZ/AFu5x4ZhKHQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.0.tgz",
+      "integrity": "sha512-uNP2oeXGLQhAEvW3xvlf8FzlD0AgUuqCngqxsbC0sdd/fBFtvWeol0nU/sP3WJlXovAPlgS14B1XLzGOPqoBLQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/TR-121/add-pause-on-error-plugin"
+    "@oat-sa/tao-test-runner-qti": "2.18.0"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.17.5"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/TR-121/add-pause-on-error-plugin"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-121

Requires: 
 - [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/337
 - [x] once the PR has been merged and released, update the dependency version in `package.json` and `package-lock.json`.

Add a plugin that displays a message upon error. It then allows either to pause the test or to reload the page.
Note: the plugin is installed disabled and needs to be activated.

How to test:
- update TAO
- install the npm dependencies
```
cd taoQtiTest/views
npm i
```
- activate the plugin in the config (`config/taoTests/test_runner_plugin_registry.conf.php`, search for `pauseOnError` and set `active` to `true`)
- take a test and trigger an error (example: you may throw an exception in the getItem action)

The following dialog should be presented:
<img width="514" alt="image" src="https://user-images.githubusercontent.com/1500098/99552644-8614cd00-29bd-11eb-8978-5313ce167f08.png">

Clicking on `RELOAD THE PAGE`, or on the close button, or on the overlay, or escaping should reload the page.
Clicking on `PAUSE THE TEST` should actually pause the test. In this case, an additional message should be displayed:
<img width="512" alt="image" src="https://user-images.githubusercontent.com/1500098/99552883-cc6a2c00-29bd-11eb-9503-f9e86ebad6ac.png">
