### PR TITLE
Fix/tr 422/announce flagged items in the end test warning

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.3.11',
+    'version' => '40.3.12',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.2.tgz",
-      "integrity": "sha512-SbadkF9dXqyCpL823VvD8KMRTwyimH5NR1LghRqkvpgbrW0hVa51E4qU6f8V+ShAO7xCY8N1AItz3Wc9sWsFyQ=="
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.3.tgz",
+      "integrity": "sha512-ZfOhVD9yv+K0oMu1+bBccS/7IvsTs+evwThg4O/34m28f01qmMxZOdAqaQ18sjBqhxSWInw+2LZerjWHQiXxuA=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-422/announce-flagged-items-in-the-end-test-warning"
+    "@oat-sa/tao-test-runner-qti": "2.18.3"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "^2.18.2"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-422/announce-flagged-items-in-the-end-test-warning"
   }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-422

Requires: 
 - [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/346
 - [x] once the companion has been merged, update package.json accordingly

Make sure the flagged items are mentioned in the exit message, even if all items have been answered.

How to test:
- Setup a test with the option `Display End Test Warning` and `Display Unanswered Warning`, at least on the last item. Also make sure the options `Enable Review Screen` and `Enable Mark for Review` are enabled for all items. You can also import the test package linked in the ticket.
    <img width="301" alt="image" src="https://user-images.githubusercontent.com/1500098/105076927-07571180-5a8c-11eb-851a-e280c76a99fe.png">
- Publish the test, then take it, answering all questions but one, and flagging at least one question
- Try to finish the test: a dialog should warn you about unanswered and flagged items
    <img width="517" alt="image" src="https://user-images.githubusercontent.com/1500098/105077694-2c984f80-5a8d-11eb-9f51-8baa543f5b8d.png">
- Move back, answer the items, then try to finish the test: a dialog should warn you about flagged items
    <img width="517" alt="image" src="https://user-images.githubusercontent.com/1500098/105077752-3f128900-5a8d-11eb-8e1d-b7a98c23c82c.png">


