### PR TITLE
Fix [CON-203] - Color of arrowheads does not match with color of lines

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.3.12',
+    'version' => '40.3.13',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@oat-sa/tao-test-runner": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.5.0.tgz",
-      "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.8.1.tgz",
+      "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.3.tgz",
-      "integrity": "sha512-ZfOhVD9yv+K0oMu1+bBccS/7IvsTs+evwThg4O/34m28f01qmMxZOdAqaQ18sjBqhxSWInw+2LZerjWHQiXxuA=="
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.4.tgz",
+      "integrity": "sha512-kQ0OBlea90wEOwQTfzxu5mAdb6BL/EnTLhQNUQN+9y3G+4xhZCIXqo/9gAkzxvGkRaDAN/IsJe3tAIG6BRbaJQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-testqti",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Tao Test Qti",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "license": "GPL-2.0",
   "dependencies": {
-    "@oat-sa/tao-test-runner": "0.5.0",
-    "@oat-sa/tao-test-runner-qti": "2.18.3"
+    "@oat-sa/tao-test-runner": "0.8.1",
+    "@oat-sa/tao-test-runner-qti": "2.18.4"
   }
 }


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/CON-203

**Related work**

https://github.com/oat-sa/extension-tao-itemqti/issues/1577

**Description**

The color of all arrowheads (including axis arrowheads) changes, when we change the current line or add new. So, it will always inherit the color from the last path created with the arrow-end/ arrow-start attribute set.
 
![imagen](https://user-images.githubusercontent.com/34692207/104584984-aed6dd00-5663-11eb-9173-732e4fc5c82c.png)

The full description of [issue](https://github.com/oat-sa/extension-tao-itemqti)/issues/1577

Also, it looks like the PCI settings are broken on the construct side. When trying to open Lines options an error pops up in the console.

![imagen](https://user-images.githubusercontent.com/34692207/104585059-ca41e800-5663-11eb-939c-19309c432365.png)

**AC**

- [x] Fix arrow head color
- [ ] Fix error in console of PCI settings