### PR TITLE
feature: TR-199 custom tabstops order for bottom toolbar

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.3.13',
+    'version' => '40.3.14',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,8 +1,29 @@
 {
   "name": "@oat-sa/tao-testqti",
   "version": "0.4.2",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@oat-sa/tao-testqti",
+      "version": "0.4.2",
+      "license": "GPL-2.0",
+      "dependencies": {
+        "@oat-sa/tao-test-runner": "0.8.1",
+        "@oat-sa/tao-test-runner-qti": "2.18.5"
+      }
+    },
+    "node_modules/@oat-sa/tao-test-runner": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.8.1.tgz",
+      "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
+    },
+    "node_modules/@oat-sa/tao-test-runner-qti": {
+      "version": "2.18.5",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.5.tgz",
+      "integrity": "sha512-tz/nJn8r94dm0LSQAVHRC2yZFXOVOfBO6jmKPP5nG19OdjBxCuWXXDt2gRknavEk1EXdkKs/KPccJavbjpqmuw=="
+    }
+  },
   "dependencies": {
     "@oat-sa/tao-test-runner": {
       "version": "0.8.1",
@@ -10,9 +31,9 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.18.4",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.4.tgz",
-      "integrity": "sha512-kQ0OBlea90wEOwQTfzxu5mAdb6BL/EnTLhQNUQN+9y3G+4xhZCIXqo/9gAkzxvGkRaDAN/IsJe3tAIG6BRbaJQ=="
+      "version": "2.18.5",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.5.tgz",
+      "integrity": "sha512-tz/nJn8r94dm0LSQAVHRC2yZFXOVOfBO6jmKPP5nG19OdjBxCuWXXDt2gRknavEk1EXdkKs/KPccJavbjpqmuw=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qtinui-fe#feature/TR-199-nfer-rebl-bottombar-reverse-tab-order"
+    "@oat-sa/tao-test-runner-qti": "2.18.5"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.18.4"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qtinui-fe#feature/TR-199-nfer-rebl-bottombar-reverse-tab-order"
   }
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-199

- add custom keyboard navigation to bottom bar

Required: 
- https://github.com/oat-sa/extension-tao-nfer/pull/245
- https://github.com/oat-sa/tao-test-runner-qti-fe/pull/350

How to check:
 - create delivery with more than one test item and REBL theme enabled
 - check the focusable elements order is according to task