### PR TITLE
fix: add mandatory visible true for new sections

### DIFF
--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -162,7 +162,8 @@ function($, _, __, hider, feedback, defaults, actions, testPartView, templates, 
                             identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection', defaults().sectionIdPrefix),
                             title : `${defaults().sectionTitlePrefix} 1`,
                             index : 0,
-                            sectionParts : []
+                            sectionParts : [],
+                            visible: true
                         }]
                     });
                 }

--- a/views/js/controller/creator/views/testpart.js
+++ b/views/js/controller/creator/views/testpart.js
@@ -115,7 +115,8 @@ function($, _, defaults, actions, sectionView, templates, qtiTestHelper){
                         identifier : qtiTestHelper.getAvailableIdentifier(modelOverseer.getModel(), 'assessmentSection', defaults().sectionIdPrefix),
                         title : `${defaults().sectionTitlePrefix} ${sectionIndex + 1}`,
                         index : 0,
-                        sectionParts : []
+                        sectionParts : [],
+                        visible: true
                     });
                 }
             });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-85

Added `visible: true` for new created sections

**Steps to reproduce:**

- Go to Tests tab.
- Create a new test and go to Authoring.
- Add a new section or test part.
- Add any item there and click Save.

Actual result: An error message shows up, test is not saved.
Expected result: Test is saved, no errors occur.


