### PR TITLE
fix: Fixed QTI duration class name.

### DIFF
--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -21,6 +21,7 @@
 
 use oat\taoQtiTest\models\runner\RunnerService;
 use oat\taoQtiTest\models\runner\time\TimerLabelFormatterService;
+use qtism\common\datatypes\QtiDuration;
 use qtism\data\NavigationMode;
 use qtism\data\SubmissionMode;
 use qtism\runtime\common\Container;
@@ -1268,7 +1269,7 @@ class taoQtiTest_helpers_TestRunnerUtils
 
     /**
      * Gets the amount of seconds with the microseconds as fractional part from a Duration instance.
-     * @param \qtism\common\datatypes\Duration $duration
+     * @param QtiDuration $duration
      * @return float|null
      */
     public static function getDurationWithMicroseconds($duration)

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -28,7 +28,6 @@ use oat\taoQtiTest\models\runner\time\QtiTimer;
 use oat\taoQtiTest\models\runner\time\QtiTimerFactory;
 use oat\taoQtiTest\models\cat\CatService;
 use oat\taoTests\models\runner\time\TimePoint;
-use qtism\common\datatypes\Duration;
 use qtism\common\datatypes\QtiDuration;
 use qtism\data\AssessmentSection;
 use qtism\data\TestPart;
@@ -273,7 +272,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
      * Gets the timer duration for a particular identifier
      * @param string|array $identifier
      * @param int $target
-     * @return Duration
+     * @return QtiDuration
      * @throws \oat\taoTests\models\runner\time\InconsistentCriteriaException
      */
     public function getTimerDuration($identifier, $target = 0)
@@ -301,7 +300,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     /**
      * Gets the total duration for the current item in the TestSession
      * @param int $target
-     * @return Duration
+     * @return QtiDuration
      * @throws \oat\taoTests\models\runner\time\InconsistentCriteriaException
      */
     public function computeItemTime($target = 0)
@@ -313,7 +312,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     /**
      * Gets the total duration for the current section in the TestSession
      * @param int $target
-     * @return Duration
+     * @return QtiDuration
      * @throws \oat\taoTests\models\runner\time\InconsistentCriteriaException
      */
     public function computeSectionTime($target = 0)
@@ -327,7 +326,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     /**
      * Gets the total duration for the current test part in the TestSession
      * @param int $target
-     * @return Duration
+     * @return QtiDuration
      * @throws \oat\taoTests\models\runner\time\InconsistentCriteriaException
      */
     public function computeTestPartTime($target = 0)
@@ -340,7 +339,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     /**
      * Gets the total duration for the whole assessment test
      * @param int $target
-     * @return Duration
+     * @return QtiDuration
      * @throws \oat\taoTests\models\runner\time\InconsistentCriteriaException
      */
     public function computeTestTime($target = 0)

--- a/test/unit/models/classes/runner/time/TimerAdjustmentServiceTest.php
+++ b/test/unit/models/classes/runner/time/TimerAdjustmentServiceTest.php
@@ -29,7 +29,7 @@ use oat\taoQtiTest\models\runner\time\QtiTimeConstraint;
 use oat\taoQtiTest\models\runner\time\QtiTimer;
 use oat\taoQtiTest\models\runner\time\TimerAdjustmentService;
 use oat\taoTests\models\runner\time\TimerAdjustmentMapInterface;
-use qtism\common\datatypes\Duration;
+use qtism\common\datatypes\QtiDuration;
 use qtism\data\AssessmentItemRef;
 use qtism\data\AssessmentTest;
 use qtism\data\QtiIdentifiable;
@@ -245,7 +245,7 @@ class TimerAdjustmentServiceTest extends TestCase
      */
     private function mockTimeConstraint(string $sourceId, int $maximumRemainingTime): QtiTimeConstraint
     {
-        $durationMock = $this->createMock(Duration::class);
+        $durationMock = $this->createMock(QtiDuration::class);
         $durationMock->method('getSeconds')
             ->willReturn($maximumRemainingTime);
 


### PR DESCRIPTION
Fixed QTI duration class name in tests and phpdoc.
No functionality change.