### PR TITLE
chore: update @oat-sa/tao-test-runner-qti to 2.19.0

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,29 +1,8 @@
 {
   "name": "@oat-sa/tao-testqti",
   "version": "0.4.2",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "@oat-sa/tao-testqti",
-      "version": "0.4.2",
-      "license": "GPL-2.0",
-      "dependencies": {
-        "@oat-sa/tao-test-runner": "0.8.1",
-        "@oat-sa/tao-test-runner-qti": "2.18.8"
-      }
-    },
-    "node_modules/@oat-sa/tao-test-runner": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.8.1.tgz",
-      "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
-    },
-    "node_modules/@oat-sa/tao-test-runner-qti": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.8.tgz",
-      "integrity": "sha512-HNQpF1D7RB1cV/RPwHlhjOJH/zt+mhakEJQUCin8vX4jz+QVN2q9EWWQxp3jpe+1pouSgU2zailL+c8uQ4b1GQ=="
-    }
-  },
   "dependencies": {
     "@oat-sa/tao-test-runner": {
       "version": "0.8.1",
@@ -31,9 +10,9 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.18.8.tgz",
-      "integrity": "sha512-HNQpF1D7RB1cV/RPwHlhjOJH/zt+mhakEJQUCin8vX4jz+QVN2q9EWWQxp3jpe+1pouSgU2zailL+c8uQ4b1GQ=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.19.0.tgz",
+      "integrity": "sha512-6k/oLZBTW0hwvTREoI+LsQL3/UfNizd6j7Dh0+a4+g1ya6Z4lcyQmDSDwmen+hsYrkYH1QPLTXCKQN7/5GQFcw=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.18.8"
+    "@oat-sa/tao-test-runner-qti": "2.19.0"
   }
 }


### PR DESCRIPTION
Chore for version update to "@oat-sa/tao-test-runner-qti": "2.19.0"