### PR TITLE
Fix/TR-375/inconsistent item duration

### DIFF
--- a/models/classes/runner/RunnerParamParserTrait.php
+++ b/models/classes/runner/RunnerParamParserTrait.php
@@ -116,7 +116,7 @@ trait RunnerParamParserTrait
      */
     protected function endItemTimer($timestamp = null)
     {
-        if ($this->getRequestParameter('itemDuration')) {
+        if ($this->hasRequestParameter('itemDuration')) {
             $serviceContext    = $this->getServiceContext();
             $itemDuration      = $this->getRequestParameter('itemDuration');
             return $this->getRunnerService()->endTimer($serviceContext, $itemDuration, $timestamp);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-375

Requires: 
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1984 (or use the integration branch [integration/TR-502/TR-375/inconsistent-item-duration](https://github.com/oat-sa/extension-tao-testqti/tree/integration/TR-502/TR-375/inconsistent-item-duration))
 - [ ] the timer target to be set to `client` (in config file `config/taoQtiTest/testRunner.conf.php`)
    ```php
        'timer' => array(
            'target' => 'client'
        ),
    ```
 - [ ] the pre-caching feature to be activated (cf: [activate the pre-caching](https://oat-sa.atlassian.net/wiki/spaces/DLV/pages/573931533/Analysis+of+the+autoPause+plugin#Migration-script))

**Summary**
Make sure the item duration is properly updated when the time range is closed.

**Description**
When the connectivity is lost the user can continue to take the test for a few items thanks to the pre-caching feature. Once the connection is back, the actions performed offline are synchronized back to the server. The chronology is rebuilt from the durations recorded by the client, the timestamp being computed from the reconnection timestamp.

For each item, the total duration is computed once and stored in a cache. This is ok when only one action is processed per request. However, with the synchronization service several actions can be processed in a row. And the cache needs to be updated after each change, otherwise, it will contain inaccurate values.

With this PR, the duration cache is updated when the time range is closed for the current item. 

**How to test**
- apply the companion PRs (use the integration branch to have all changes at once)
- make sure the timer target is `client` and the pre-caching is activated
- take a test (better to have one with several items, the ticket contains a sample)
- disconnect the network, then pass 2 or 3 items
- reconnect the network
- go to the backoffice, open the results page, and check each item got the expected duration
