### PR TITLE
fix: value of the max item attempts input in test authoring

### DIFF
--- a/views/js/controller/creator/templates/itemref-props.tpl
+++ b/views/js/controller/creator/templates/itemref-props.tpl
@@ -132,7 +132,7 @@
                 <label for="itemref-max-attempts">{{__ 'Max Attempts'}}</label>
             </div>
             <div class="col-6">
-                <input name="itemref-max-attempts" type="text" data-increment="1" data-min="0" value="1" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
+                <input name="itemref-max-attempts" type="text" data-increment="1" data-min="0" value="{{maxAttempts}}" data-bind="itemSessionControl.maxAttempts" data-bind-encoder="number" />
             </div>
             <div class="col-1 help">
                 <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-284

**Description**
When more than 1 test part is added into test, Max Attempts option in 'Item Session Control' section is set to '1' by default for all parts starting from part 2.

**How to test**
1. Log in as Admin
2. Choose 'Tests' tab and click 'New test' button under tests tree
3. Create at least 2 parts in test and add items into each test part
4. Click 'Settings' (gears icon) button next to any item of part 2, unfold 'Item Session Control' section and observe Max Attempts
5. Max Attempts should be inherited from the test section ('0' by default)
