### PR TITLE
fix TR-502 add-offline-flag-to-first-synced-item

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "github:oat-sa/tao-test-runner-qti-fe#298a695a0b8d4b8ed6050ba0810b5e26c9b40ce7",
-      "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-502_add-offline-flag-to-first-synced-item"
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.20.4.tgz",
+      "integrity": "sha512-sb8t3WQTwLawfXPbjtb12JpLOrU9UHsGODWW0Xk/PIgbTWUv2iz3xcAr+61pQtHiQhgIhcIgv4uf+IGRY+QMCg=="
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.20.3.tgz",
-      "integrity": "sha512-g8/pmMmSGE2lfompOdV5mRXkJ+3pb5+y1oBuiu3qoWIj3P3XRe1qg7pFOI3KHhUHGYUlVP8UDHsIIaiELzriqg=="
+      "version": "github:oat-sa/tao-test-runner-qti-fe#298a695a0b8d4b8ed6050ba0810b5e26c9b40ce7",
+      "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-502_add-offline-flag-to-first-synced-item"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.20.3"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-502_add-offline-flag-to-first-synced-item"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-502_add-offline-flag-to-first-synced-item"
+    "@oat-sa/tao-test-runner-qti": "2.20.4"
   }
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-502

Requires:
- [x] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/376
- [x] Update package version in `package.json` and `package-lock.json`