### PR TITLE
fix/AUT-396/unclickable properties

### DIFF
--- a/views/js/controller/creator/views/itemref.js
+++ b/views/js/controller/creator/views/itemref.js
@@ -257,9 +257,15 @@ function(
          * @param {propView} propView - the view object
          */
         function propHandler (propView) {
+            const removePropHandler = function removePropHandler(e, $deletedNode){
+                const validIds = [
+                    $itemRef.attr('id'),
+                    $itemRef.parents('.section').attr('id'),
+                    $itemRef.parents('.testpart').attr('id')
+                ];
+                const deletedNodeId = $deletedNode.attr('id');
 
-            var removePropHandler = function removePropHandler(){
-                if(propView !== null){
+                if (propView !== null && validIds.includes(deletedNodeId)) {
                     propView.destroy();
                 }
             };
@@ -268,9 +274,7 @@ function(
             weightsProperty(propView);
             timeLimitsProperty(propView);
 
-            $itemRef.parents('.testpart').on('delete', removePropHandler);
-            $itemRef.parents('.section').on('delete', removePropHandler);
-            $itemRef.on('delete', removePropHandler);
+            $itemRef.parents('.testparts').on('deleted.deleter', removePropHandler);
         }
     }
 

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -132,8 +132,9 @@ function(
                 }
             });
 
-            $section.parents('.testpart').on('deleted.deleter', removePropHandler);
-            $section.on('deleted.deleter', removePropHandler);
+            // deleted.deleter event fires only on the parent nodes (testparts, sections, etc)
+            // Since it "bubles" we can subsctibe only to the highest parent node
+            $section.parents('.testparts').on('deleted.deleter', removePropHandler);
 
             //section level category configuration
             categoriesProperty($view);
@@ -142,8 +143,20 @@ function(
                 blueprintProperty($view);
             }
 
-            function removePropHandler(){
-                if(propView !== null){
+            function removePropHandler(e, $deletedNode) {
+                const validIds = [
+                    $section.parents('.testpart').attr('id'),
+                    $section.attr('id')
+                ];
+
+                const deletedNodeId = $deletedNode.attr('id');
+                // We have to check id of a deleted node, because
+                // 1. Event fires after child node was deleted, but e.stopPropagation doesn't help
+                // because currentTarget is always document
+                // 2. We have to subscribe to the parent node and it's posiible that another section was removed even from another testpart
+                // Subscription to the .sections selector event won't help because sections element might contain several children.
+
+                if (propView !== null && validIds.includes(deletedNodeId)){
                     propView.destroy();
                 }
             }

--- a/views/js/controller/creator/views/testpart.js
+++ b/views/js/controller/creator/views/testpart.js
@@ -71,8 +71,8 @@ function($, _, defaults, actions, sectionView, templates, qtiTestHelper){
             });
 
             //destroy it when it's testpart is removed
-            $testPart.on('delete', function(){
-                if(propView !== null){
+            $testPart.parents('.testparts').on('deleted.deleter', function(e, $deletedNode) {
+                if ((propView !== null) && ($deletedNode.attr('id') === $testPart.attr('id'))) {
                     propView.destroy();
                 }
             });


### PR DESCRIPTION
Related: [AUT-396](https://oat-sa.atlassian.net/browse/AUT-396)

## Description

### Problem 1
Some elements subscribed on the `delete` event. The `delete` event fires right away user pressed the delete button. But then he might change his mind and press the undo. As a result property form was removed, and the gear button becomes unclickable

### Problem 2
`deleted.deleter` event fires only on the parent level. So subscriptions to `.tespart` and `.section` don't work. Result: when we remove an entity (section, testpart, or item) property form isn't removed

### Problem 3
`deleter.delete` "bubbles", but we can stop it, because currentTarget is always document. So when we subscribe on the `.testpart` `deleted.deleter` event every child element removal triggers it. To solve it we should know which node exactly was removed

## Required PR

oat-sa/tao-core-ui-fe#279

## How to test
1. Create a test
2. Go to authorize page
3. Add some test parts, sections and items to it

### Test cases:
#### Items
**I**
1. Open item form
2. Delete item
3. Check that the item property form was deleted after the `undo` message disappears

**||**
1. Open an item property form & delete the item
2. Press `undo` in the feedback message
3. Check that button that opened the property form remains clickable

**|||**
1. Open several items / sections / testparts forms
2. delete one item
3. the rest items gear buttons should remain clicakable

**IV**
1. Open item form
2. Delete parent section / testpart
3. Check that the item form was removed after the `undo` message disappears

#### Sections

**I**
1. Open some sections forms
2. Delete item
3. Check that sections gear buttons remained clickable

**II**
1. Open section form
2. Delete this section / parent test part
3. Check that form was removed

**III**
1. Open section form
2. Delete  this section / parent test part
3. Click `undo`
4. Check that the gear button remains clickable

#### Testpart
Same as section cases

## Review checklist
- [ ]  New code is covered by tests (if applicable)
- [ ]  Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ]  New code is respecting code style rules
- [ ]  New code is respecting best practices
- [ ]  New code is not subject to concurrency issues (if applicable)
- [ ]  Feature is working correctly on my local machine (if applicable)
- [ ]  Acceptance criteria are respected
- [ ]  Pull request title and description are meaningful
