### PR TITLE
fix: clean tmp folder after publishing the delivery

### DIFF
--- a/models/classes/QtiTestFileCleaner.php
+++ b/models/classes/QtiTestFileCleaner.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+
+namespace oat\taoQtiTest\models;
+
+use qtism\common\Resolver;
+use qtism\data\ExtendedAssessmentItemRef;
+use qtism\data\ExtendedAssessmentSection;
+use qtism\data\QtiDocument;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\oatbox\service\ConfigurableService;
+use qtism\data\TestPart;
+
+/**
+ * Cleaner service for cleanup the leftovers.
+ */
+class QtiTestFileCleaner extends ConfigurableService
+{
+    const SERVICE_ID = 'taoQtiTest/QtiTestCleaner';
+
+    public function cleanAfterCompilation(QtiDocument $document, Resolver $itemResolver): void
+    {
+        $fss = $this->getFileSystem();
+
+        $filePaths = $this->getDocumentItemsFilePaths($document, $itemResolver);
+
+        foreach ($filePaths as $filePath) {
+            $fss->getDirectory('/tmp')->getFile($filePath)->delete();
+        }
+    }
+
+    /**
+     * @return string[] paths of leftover xml files (e,g. '/tmp.3937826056e0543c6233a83d9964a59d.xml')
+     */
+    private function getDocumentItemsFilePaths(QtiDocument $document, Resolver $itemResolver): array
+    {
+        $filePaths = [];
+        foreach ($document->getDocumentComponent()->getComponents() as $childComponentLvl1) {
+            if($childComponentLvl1 instanceof TestPart) {
+                foreach ($childComponentLvl1->getComponents() as $childComponentLvl2) {
+                    if($childComponentLvl2 instanceof ExtendedAssessmentSection) {
+                        foreach ($childComponentLvl2->getComponents() as $childComponentLvl3) {
+                            if($childComponentLvl3 instanceof ExtendedAssessmentItemRef) {
+                                $filePaths[] = $itemResolver->resolve($childComponentLvl3->getHref());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $filePaths;
+    }
+
+    private function getFileSystem(): FileSystemService
+    {
+        return $this->getServiceLocator()->get(FileSystemService::SERVICE_ID);
+    }
+}

--- a/models/classes/class.QtiTestCompiler.php
+++ b/models/classes/class.QtiTestCompiler.php
@@ -477,6 +477,7 @@ class taoQtiTest_models_classes_QtiTestCompiler extends taoTests_models_classes_
         $originalDoc = $testService->getDoc($test);
 
         $compiledDoc = XmlCompactDocument::createFromXmlAssessmentTestDocument($originalDoc, $resolver, $resolver);
+        $this->getQtiTestFileCleaner()->cleanAfterCompilation($compiledDoc, $resolver);
         common_Logger::t("QTI Test XML transformed in a compact version.");
 
         return $compiledDoc;
@@ -1096,5 +1097,10 @@ class taoQtiTest_models_classes_QtiTestCompiler extends taoTests_models_classes_
     protected function useCssScoping()
     {
         return $this->settingCssScope;
+    }
+
+    protected function getQtiTestFileCleaner(): QtiTestFileCleaner
+    {
+        return $this->getServiceLocator()->get(\oat\taoQtiTest\models\QtiTestFileCleaner::SERVICE_ID);
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-237

There were .xml files after publishing the delivery in /tmp folder which contain an info about items and sections in the test.
Also some empty folders (e.g. tmp1335343).