### PR TITLE
fix: TR-1206 disallow reload page on opened error popup

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,1 +1,18 @@
-{}
+{
+  "name": "@oat-sa/tao-testqti",
+  "version": "0.4.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@oat-sa/tao-test-runner": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.8.1.tgz",
+      "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
+    },
+    "@oat-sa/tao-test-runner-qti": {
+      "version": "2.20.4-1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.20.4-1.tgz",
+      "integrity": "sha512-VUNKHhgnzZo1QSzFaQjS4RnEYOlI3nkoOGirDXYcHw0olNBboq9ayCcsMJMYVOPN+lHhoj639PGNZAPwMbYsqA=="
+    }
+  }
+}

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,18 +1,1 @@
-{
-  "name": "@oat-sa/tao-testqti",
-  "version": "0.4.2",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@oat-sa/tao-test-runner": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.8.1.tgz",
-      "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
-    },
-    "@oat-sa/tao-test-runner-qti": {
-      "version": "2.20.4",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.20.4.tgz",
-      "integrity": "sha512-sb8t3WQTwLawfXPbjtb12JpLOrU9UHsGODWW0Xk/PIgbTWUv2iz3xcAr+61pQtHiQhgIhcIgv4uf+IGRY+QMCg=="
-    }
-  }
-}
+{}

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.20.4"
+    "@oat-sa/tao-test-runner-qti": "2.20.4.1"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.20.4.1"
+    "@oat-sa/tao-test-runner-qti": "2.20.4-1"
   }
 }


### PR DESCRIPTION
backport tr-1206 to 41.2.5
remove changes, just using updated test-runner-qti-fe