### PR TITLE
feat: move test state to cold storage on test finish

### DIFF
--- a/config/default/QtiTestListenerService.conf.php
+++ b/config/default/QtiTestListenerService.conf.php
@@ -20,6 +20,7 @@
 
 return new oat\taoQtiTest\models\QtiTestListenerService(
     [
-        oat\taoQtiTest\models\QtiTestListenerService::OPTION_ARCHIVE_EXCLUDE => []
+        oat\taoQtiTest\models\QtiTestListenerService::OPTION_ARCHIVE_EXCLUDE => [],
+        oat\taoQtiTest\models\QtiTestListenerService::OPTION_ARCHIVE_ENABLED => true
     ]
 );

--- a/migrations/Version202105311622466947_taoQtiTest.php
+++ b/migrations/Version202105311622466947_taoQtiTest.php
@@ -38,8 +38,10 @@ final class Version202105311622466947_taoQtiTest extends AbstractMigration
 
         // add config
         $extension = $this->getExtension();
-        $config = $extension->getConfig('QtiTestListenerService')->getOptions();
-        $config[QtiTestListenerService::OPTION_ARCHIVE_ENABLED] = true;
+
+        /** @var QtiTestListenerService $config */
+        $config = $extension->getConfig('QtiTestListenerService');
+        $config->setOption(QtiTestListenerService::OPTION_ARCHIVE_ENABLED, true);
         $extension->setConfig('QtiTestListenerService', $config);
     }
 
@@ -57,10 +59,13 @@ final class Version202105311622466947_taoQtiTest extends AbstractMigration
 
         // remove config
         $extension = $this->getExtension();
-        $config = $extension->getConfig('QtiTestListenerService')->getOptions();
 
-        if (array_key_exists(QtiTestListenerService::OPTION_ARCHIVE_ENABLED, $config)) {
-            unset($config[QtiTestListenerService::OPTION_ARCHIVE_ENABLED]);
+        /** @var QtiTestListenerService $config */
+        $config = $extension->getConfig('QtiTestListenerService');
+        $options = $config->getOptions();
+        if (array_key_exists(QtiTestListenerService::OPTION_ARCHIVE_ENABLED, $options)) {
+            unset($options[QtiTestListenerService::OPTION_ARCHIVE_ENABLED]);
+            $config->setOptions($options);
         }
 
         $extension->setConfig('QtiTestListenerService', $config);

--- a/migrations/Version202105311622466947_taoQtiTest.php
+++ b/migrations/Version202105311622466947_taoQtiTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\event\EventManager;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiTest\models\event\AfterAssessmentTestSessionClosedEvent;
+use oat\taoQtiTest\models\QtiTestListenerService;
+use common_ext_Extension as Extension;
+use common_ext_ExtensionsManager as ExtensionsManager;
+use common_ext_ExtensionException as ExtensionException;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202105311622466947_taoQtiTest extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register AfterAssessmentTestSessionClosedEvent listener + set new config OPTION_ARCHIVE_ENABLED';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+
+        $eventManager->attach(
+            AfterAssessmentTestSessionClosedEvent::class,
+            [QtiTestListenerService::class, 'archiveState']
+        );
+
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+
+        // add config
+        $extension = $this->getExtension();
+        $config = $extension->getConfig('QtiTestListenerService')->getOptions();
+        $config[QtiTestListenerService::OPTION_ARCHIVE_ENABLED] = true;
+        $extension->setConfig('QtiTestListenerService', $config);
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+
+        $eventManager->detach(
+            AfterAssessmentTestSessionClosedEvent::class,
+            [QtiTestListenerService::class, 'archiveState']
+        );
+
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+
+        // remove config
+        $extension = $this->getExtension();
+        $config = $extension->getConfig('QtiTestListenerService')->getOptions();
+
+        if (array_key_exists(QtiTestListenerService::OPTION_ARCHIVE_ENABLED, $config)) {
+            unset($config[QtiTestListenerService::OPTION_ARCHIVE_ENABLED]);
+        }
+
+        $extension->setConfig('QtiTestListenerService', $config);
+    }
+
+    /**
+     * @throws ExtensionException
+     *
+     * @return Extension
+     */
+    private function getExtension(): Extension
+    {
+        /** @var ExtensionsManager $extensionManager */
+        $extensionManager = $this->getServiceLocator()->get(ExtensionsManager::SERVICE_ID);
+
+        return $extensionManager->getExtensionById('taoQtiTest');
+    }
+}

--- a/models/classes/QtiTestListenerService.php
+++ b/models/classes/QtiTestListenerService.php
@@ -39,7 +39,9 @@ use qtism\runtime\tests\AssessmentTestSession;
 class QtiTestListenerService extends ConfigurableService
 {
     const SERVICE_ID = 'taoQtiTest/QtiTestListenerService';
-    
+
+    const OPTION_ARCHIVE_ENABLED = 'archive-enabled';
+
     const OPTION_ARCHIVE_EXCLUDE = 'archive-exclude';
     
     /**
@@ -123,6 +125,11 @@ class QtiTestListenerService extends ConfigurableService
      */
     public function archiveState(AfterAssessmentTestSessionClosedEvent $event)
     {
+        if (!$this->getOption(self::OPTION_ARCHIVE_ENABLED)) {
+            \common_Logger::d('Item State archive is not enabled');
+            return;
+        }
+
         $archivingExclusions = $this->getOption(self::OPTION_ARCHIVE_EXCLUDE);
 
         $session = $event->getSession();

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -243,9 +243,9 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         \common_Logger::d("Persisting QTI Assessment Test Session '${sessionId}'...");
         $context->getStorage()->persist($testSession);
         if ($this->isTerminated($context)) {
-            /** @var StorageManager $serviceService */
-            $serviceService = $this->getServiceManager()->get(StorageManager::SERVICE_ID);
-            $serviceService->persist();
+            /** @var StorageManager $storageManager */
+            $storageManager = $this->getServiceManager()->get(StorageManager::SERVICE_ID);
+            $storageManager->persist();
 
             $userId = \common_session_SessionManager::getSession()->getUser()->getIdentifier();
             $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -243,6 +243,10 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         \common_Logger::d("Persisting QTI Assessment Test Session '${sessionId}'...");
         $context->getStorage()->persist($testSession);
         if ($this->isTerminated($context)) {
+            /** @var StorageManager $serviceService */
+            $serviceService = $this->getServiceManager()->get(StorageManager::SERVICE_ID);
+            $serviceService->persist();
+
             $userId = \common_session_SessionManager::getSession()->getUser()->getIdentifier();
             $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
             $eventManager->trigger(new AfterAssessmentTestSessionClosedEvent($testSession, $userId));

--- a/scripts/install/SetupEventListeners.php
+++ b/scripts/install/SetupEventListeners.php
@@ -22,6 +22,7 @@ namespace oat\taoQtiTest\scripts\install;
 
 use oat\oatbox\extension\InstallAction;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoQtiTest\models\event\AfterAssessmentTestSessionClosedEvent;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
 use oat\taoQtiTest\models\QtiTestListenerService;
 
@@ -37,5 +38,6 @@ class SetupEventListeners extends InstallAction
     {
         $this->registerEvent(DeliveryExecutionState::class, [QtiTestListenerService::SERVICE_ID, 'executionStateChanged']);
         $this->registerEvent(QtiTestStateChangeEvent::class, [QtiTestListenerService::SERVICE_ID, 'sessionStateChanged']);
+        $this->registerEvent(AfterAssessmentTestSessionClosedEvent::class, [QtiTestListenerService::SERVICE_ID, 'archiveState']);
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1105

Test:

1. switch `taoQtiTest` extension to the proper branch
2. run migration `php tao/scripts/taoUpdate.php`
3. check `data/stateBackup` folder and clear if needed
4. launch and finish any test
5. after finishing the item and timer states should be stored in `data/stateBackup`

Also, you can turn it off in `config/taoQtiTest/QtiTestListenerService.conf.php` and test again.