### PR TITLE
Feat: submit default responses for non-presented items on test timeout

### DIFF
--- a/helpers/class.TestSession.php
+++ b/helpers/class.TestSession.php
@@ -530,14 +530,16 @@ class taoQtiTest_helpers_TestSession extends AssessmentTestSession
     /**
      * Skip the current item.
      *
+     * @param bool $allowUntouchedItems whether to allow skipping items in state INITIAL (not ever seen yet by the TT)
+     *
      * @throws AssessmentTestSessionException If the test session is not running or it is the last route item of the testPart but the SIMULTANEOUS submission mode is in force and not all responses were provided.
      * @qtism-test-interaction
      * @qtism-test-duration-update
      */
-    public function skip()
+    public function skip($allowUntouchedItems = false)
     {
         $sessionMemento = $this->getSessionMemento();
-        parent::skip();
+        parent::skip($allowUntouchedItems);
         $this->triggerEventChange($sessionMemento);
     }
 

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1133,6 +1133,18 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
     }
 
     /**
+     * @param RunnerServiceContext $context
+     * @param $scope
+     * @param $ref
+     * @return boolean
+     * @throws \common_Exception
+     */
+    public function autoSkip(RunnerServiceContext $context, $scope, $ref)
+    {
+        return $this->move($context, 'autoSkip', $scope, $ref);
+    }
+
+    /**
      * Handles a test timeout
      * @param RunnerServiceContext $context
      * @param $scope
@@ -1502,6 +1514,11 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         $isLinear = $session->getCurrentNavigationMode() === NavigationMode::LINEAR;
         switch ($timeOutException->getCode()) {
             case AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW:
+                while (!$session->getRoute()->isLast()) {
+                    $this->autoSkip($context, 'item', null);
+                    //$this->persist($context);
+                }
+
                 \common_Logger::i('TIMEOUT: closing the assessment test session');
                 $session->endTestSession();
                 break;

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1516,7 +1516,6 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
             case AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW:
                 while (!$session->getRoute()->isLast()) {
                     $this->autoSkipWithDefaultResponse($context, 'item', null);
-                    //$this->persist($context);
                 }
 
                 \common_Logger::i('TIMEOUT: closing the assessment test session');
@@ -1525,6 +1524,10 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
 
             case AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW:
                 if ($isLinear) {
+                    while (!$session->getRoute()->isLastOfTestPart()) {
+                        $this->autoSkipWithDefaultResponse($context, 'item', null);
+                    }
+
                     \common_Logger::i('TIMEOUT: moving to the next test part');
                     $session->moveNextTestPart();
                 } else {

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1139,7 +1139,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
      * @return boolean
      * @throws \common_Exception
      */
-    public function autoSkip(RunnerServiceContext $context, $scope, $ref)
+    public function autoSkipWithDefaultResponse(RunnerServiceContext $context, $scope, $ref)
     {
         return $this->move($context, 'autoSkip', $scope, $ref);
     }
@@ -1515,7 +1515,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         switch ($timeOutException->getCode()) {
             case AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW:
                 while (!$session->getRoute()->isLast()) {
-                    $this->autoSkip($context, 'item', null);
+                    $this->autoSkipWithDefaultResponse($context, 'item', null);
                     //$this->persist($context);
                 }
 

--- a/models/classes/runner/navigation/QtiRunnerNavigationAutoSkipItem.php
+++ b/models/classes/runner/navigation/QtiRunnerNavigationAutoSkipItem.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoQtiTest\models\runner\navigation;
+
+use oat\taoQtiTest\models\runner\RunnerServiceContext;
+
+/**
+ * Class QtiRunnerAutoSkipItem
+ * @package oat\taoQtiTest\models\runner\navigation
+ */
+class QtiRunnerNavigationAutoSkipItem implements RunnerNavigation
+{
+    /**
+     * Do the auto move
+     * @param RunnerServiceContext $context
+     * @param mixed $ref
+     * @return boolean
+     * @throws \common_Exception
+     */
+    public function move(RunnerServiceContext $context, $ref)
+    {
+        $session = $context->getTestSession();
+        $session->skip(true);
+        $session->moveNext(true);
+        return true;
+    }
+}


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TR-1432

Submit default responses for non-presented items on test timeout by imitating skip for all remaining items.

Relies on https://github.com/oat-sa/qti-sdk/pull/282

How to test:
1) Create a test with a global timeout value set in Authoring
2) Create a delivery with that test, you may allow Guest Mode optionally to get to the test quicker
3) Pass the test with timer violation
4) Go to the back-office -> Results -> Choose your delivery -> Check the result. All items should be there. You may also want to check all the other storages we have for test results (e.g. SQL `variable_storage`)