### PR TITLE
Fix/TR-777/Add missing portableElements field in sync action

### DIFF
--- a/models/classes/runner/synchronisation/action/NextItemData.php
+++ b/models/classes/runner/synchronisation/action/NextItemData.php
@@ -85,6 +85,7 @@ class NextItemData extends TestRunnerAction
         $itemRef = $this->getRunnerService()->getItemHref($serviceContext, $itemIdentifier);
         $itemData = $this->getRunnerService()->getItemData($serviceContext, $itemRef);
         $baseUrl = $this->getRunnerService()->getItemPublicUrl($serviceContext, $itemRef);
+        $portableElements = $this->getRunnerService()->getItemPortableElements($serviceContext, $itemRef);
 
         $itemState = $this->getRunnerService()->getItemState($serviceContext, $itemIdentifier);
         if ($itemState === null || !count($itemState)) {
@@ -96,6 +97,7 @@ class NextItemData extends TestRunnerAction
             'itemData' => $itemData,
             'itemState' => $itemState,
             'itemIdentifier' => $itemIdentifier,
+            'portableElements' => $portableElements
         ];
     }
 

--- a/test/unit/models/classes/runner/synchronisation/action/NextItemDataTest.php
+++ b/test/unit/models/classes/runner/synchronisation/action/NextItemDataTest.php
@@ -74,6 +74,7 @@ class NextItemDataTest extends TestCase
                     'itemData' => null,
                     'itemState' => new stdClass(),
                     'itemIdentifier' => 'expectedItemDefinition',
+                    'portableElements' => null,
                 ]
             ],
             'success' => true,
@@ -112,12 +113,14 @@ class NextItemDataTest extends TestCase
                     'itemData' => null,
                     'itemState' => $state1,
                     'itemIdentifier' => $itemId1,
+                    'portableElements' => null,
                 ],
                 [
                     'baseUrl' => null,
                     'itemData' => null,
                     'itemState' => $storedState2,
                     'itemIdentifier' => $itemId2,
+                    'portableElements' => null,
                 ],
             ]
         ], $subject->process());


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-777

Usually, when an item contains a PCI the data payload sent to the client contains a `portableElements` property, giving the catalog of the PCI embedded by the item.

The `getNextItemData` action in behalf of the synchronisation mode (pre-caching) was not supplying such property. This PR aims at aligning the synchronisation mode with the regular mode (see the [getItemData](https://github.com/oat-sa/extension-tao-testqti/blob/4e5346077994d6991fcf8f632c7dfa5fc1138d53/actions/class.Runner.php#L466) method).

How to test:
- run the unit test (`./vendor/bin/phpunit taoQtiTest/test/unit/models/classes/runner/synchronisation/action/NextItemDataTest.php`)
- take a test having some PCI and with the pre-caching mode activated (see the linked ticket)

Note: `phpunit` `~8.5` is required, you may need to update your composer file.