### PR TITLE
TR-1432 test level timeout outcome fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "~0",
+    "qtism/qtism": "^0.24.11",
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=48.9.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1503,7 +1503,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         switch ($timeOutException->getCode()) {
             case AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW:
                 \common_Logger::i('TIMEOUT: closing the assessment test session');
-                $session->endTestSession();
+                $session->moveThroughAndEndTestSession();
                 break;
 
             case AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW:


### PR DESCRIPTION
Fix outcome variable calculation on test level timeout. 
 
Related to : https://oat-sa.atlassian.net/browse/TR-1432
 
On test level timeout iterate through rest of test items and recalculate test outcome variables.
  
#### How to test
 
1. Create a test with test level timeout value set in authoring (can pick the test package from related jira ticket)
2. Create a delivery with that test
3. Launch the test
3. Do not answer all items and wait for timer to run out
4. Go to the back-office -> Results -> Choose your delivery -> Check the result. Outcome variables that sum MAXSCORE should have correct value. 

#### Dependencies
 
Requires :
 - [x] https://github.com/oat-sa/qti-sdk/pull/286