### PR TITLE
feature: TR-892 support RTL items in LTR tests

### DIFF
--- a/migrations/Version202107081239332260_taoQtiTest.php
+++ b/migrations/Version202107081239332260_taoQtiTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoTests\models\runner\plugins\PluginRegistry;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202107081239332260_taoQtiTest extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'added taoQtiTest/runner/plugins/content/accessibility/rtlHandler plugin';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        $registry->register(TestPlugin::fromArray([
+            'id' => 'rtlHandler',
+            'name' => 'RTL handler',
+            'module' => 'taoQtiTest/runner/plugins/content/accessibility/rtlHandler',
+            'bundle' => 'taoQtiTest/loader/testPlugins.min',
+            'description' => 'Supply for items configured with RTL language in scope of LTR tests',
+            'category' => 'content',
+            'active' => true,
+            'tags' => []
+        ]));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        $registry->remove('taoQtiTest/runner/plugins/content/accessibility/rtlHandler');
+    }
+}

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.22.1.tgz",
-      "integrity": "sha512-qf6SecDFWKpcK4w7G46opa1t1T7O6cTXSoVdmzRmv/dKOr0KGGl/WIQ5aQodHyPa/abi8tYpp+/rRyhPXIFWxg=="
+      "version": "github:oat-sa/tao-test-runner-qti-fe#c3aac364feedac33f73a4c96d4300cb6ed95277b",
+      "from": "github:oat-sa/tao-test-runner-qti-fe#feature/TR-982/support-rtl-items"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.22.1"
+    "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#feature/TR-982/support-rtl-items"
   }
 }


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/TR-892

**Changes:**
- using `rtlHandler` plugin to support RTL items in LTR tests
- migration added to activate plugin

**How to check:**
- checkout necessary branch of `taoQtiTest`
- go to views dir and run `npm install` 
- go to root dir of your project and run taoUpdate script to apply migration
- register any language to check as RTL in `config/tao/client_lib_config_registry.conf.php` (en-GB  as example)
```
    'config' => array(
        'util/locale' => array(
            'decimalSeparator' => '.',
            'thousandsSeparator' => '',
            'rtl' => array(
                'ar-arb',
                'en-GB'
            )
        ),
```
- import test with pre-defined RTL language for any item
- walk trought imported test and ensure it rendered as RTL

**Requires:**
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/417