### PR TITLE
Feature/AUT-848/BRS feature flag

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,6 +24,7 @@ use oat\taoQtiTest\scripts\update\Updater;
 use oat\taoQtiTest\scripts\install\SetupProvider;
 use oat\taoQtiTest\models\xmlEditor\XmlEditorInterface;
 use oat\taoQtiTest\scripts\install\CreateTestSessionFilesystem;
+use oat\taoQtiTest\scripts\install\DisableBRSinTestAuthoring;
 use oat\taoQtiTest\scripts\install\RegisterCreatorServices;
 use oat\taoQtiTest\scripts\install\RegisterFrontendPaths;
 use oat\taoQtiTest\scripts\install\RegisterQtiCategoryPresetProviders;
@@ -89,6 +90,7 @@ return [
             RegisterQtiPackageExporter::class,
             SetupProvider::class,
             SetupDefaultTemplateConfiguration::class,
+            DisableBRSinTestAuthoring::class
         ],
     ],
     'update' => Updater::class,

--- a/migrations/Version202107210931372260_taoQtiTest.php
+++ b/migrations/Version202107210931372260_taoQtiTest.php
@@ -18,9 +18,6 @@ use oat\oatbox\service\exception\InvalidServiceManagerException;
 final class Version202107210931372260_taoQtiTest extends AbstractMigration
 {
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return 'Disable feature flag BRS (search by metadata) within Test Authoring';

--- a/migrations/Version202107210931372260_taoQtiTest.php
+++ b/migrations/Version202107210931372260_taoQtiTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use common_ext_ExtensionsManager as ExtensionsManager;
+use common_exception_Error as Error;
+use oat\taoQtiTest\scripts\install\DisableBRSinTestAuthoring;
+use common_ext_ExtensionException as ExtensionException;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202107210931372260_taoQtiTest extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Disable feature flag BRS (search by metadata) within Test Authoring';
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->propagate(new DisableBRSinTestAuthoring())([]);
+    }
+
+    /**
+     * @param Schema $schema
+     *
+     * @throws Error
+     * @throws InvalidServiceManagerException
+     * @throws ExtensionException
+     */
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+         /** @var ExtensionsManager $extensionManager */
+         $extensionManager = $this->getServiceManager()->get(ExtensionsManager::SERVICE_ID);
+         $extension = $extensionManager->getExtensionById('tao');
+ 
+         $config = $extension->getConfig('client_lib_config_registry');
+         unset($config['taoQtiTest/controller/creator/views/item']);
+ 
+         $extension->setConfig('client_lib_config_registry', $config);
+
+    }
+}

--- a/migrations/Version202107210931372260_taoQtiTest.php
+++ b/migrations/Version202107210931372260_taoQtiTest.php
@@ -51,6 +51,5 @@ final class Version202107210931372260_taoQtiTest extends AbstractMigration
          unset($config['taoQtiTest/controller/creator/views/item']);
  
          $extension->setConfig('client_lib_config_registry', $config);
-
     }
 }

--- a/migrations/Version202107210931372260_taoQtiTest.php
+++ b/migrations/Version202107210931372260_taoQtiTest.php
@@ -35,8 +35,6 @@ final class Version202107210931372260_taoQtiTest extends AbstractMigration
     }
 
     /**
-     * @param Schema $schema
-     *
      * @throws Error
      * @throws InvalidServiceManagerException
      * @throws ExtensionException

--- a/migrations/Version202107210931372260_taoQtiTest.php
+++ b/migrations/Version202107210931372260_taoQtiTest.php
@@ -31,7 +31,6 @@ final class Version202107210931372260_taoQtiTest extends AbstractMigration
      */
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->propagate(new DisableBRSinTestAuthoring())([]);
     }
 
@@ -44,7 +43,6 @@ final class Version202107210931372260_taoQtiTest extends AbstractMigration
      */
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
          /** @var ExtensionsManager $extensionManager */
          $extensionManager = $this->getServiceManager()->get(ExtensionsManager::SERVICE_ID);
          $extension = $extensionManager->getExtensionById('tao');

--- a/migrations/Version202107210931372260_taoQtiTest.php
+++ b/migrations/Version202107210931372260_taoQtiTest.php
@@ -26,9 +26,6 @@ final class Version202107210931372260_taoQtiTest extends AbstractMigration
         return 'Disable feature flag BRS (search by metadata) within Test Authoring';
     }
 
-    /**
-     * @param Schema $schema
-     */
     public function up(Schema $schema): void
     {
         $this->propagate(new DisableBRSinTestAuthoring())([]);

--- a/scripts/install/DisableBRSinTestAuthoring.php
+++ b/scripts/install/DisableBRSinTestAuthoring.php
@@ -36,8 +36,6 @@ use oat\oatbox\service\exception\InvalidServiceManagerException;
 class DisableBRSinTestAuthoring extends InstallAction
 {
     /**
-     * @param array $params
-     *
      * @throws Error
      * @throws InvalidServiceManagerException
      * @throws ExtensionException

--- a/scripts/install/DisableBRSinTestAuthoring.php
+++ b/scripts/install/DisableBRSinTestAuthoring.php
@@ -42,7 +42,7 @@ class DisableBRSinTestAuthoring extends InstallAction
      * @throws InvalidServiceManagerException
      * @throws ExtensionException
      */
-    public function __invoke($params)
+    public function __invoke($params): void
     {
         /** @var ExtensionsManager $extensionManager */
         $extensionManager = $this->getServiceManager()->get(ExtensionsManager::SERVICE_ID);

--- a/scripts/install/DisableBRSinTestAuthoring.php
+++ b/scripts/install/DisableBRSinTestAuthoring.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\scripts\install;
+
+use common_exception_Error as Error;
+use oat\oatbox\extension\InstallAction;
+use common_ext_ExtensionsManager as ExtensionsManager;
+use common_ext_ExtensionException as ExtensionException;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+
+/**
+ * Class DisableBRSinTestAuthoring
+ *
+ * @package oat\taoQtiTest\scripts\install
+ */
+class DisableBRSinTestAuthoring extends InstallAction
+{
+    /**
+     * @param array $params
+     *
+     * @throws Error
+     * @throws InvalidServiceManagerException
+     * @throws ExtensionException
+     */
+    public function __invoke($params)
+    {
+        /** @var ExtensionsManager $extensionManager */
+        $extensionManager = $this->getServiceManager()->get(ExtensionsManager::SERVICE_ID);
+        $extension = $extensionManager->getExtensionById('tao');
+
+        $config = $extension->getConfig('client_lib_config_registry');
+        $config['taoQtiTest/controller/creator/views/item'] = [
+            'BRS' => false,
+        ];
+
+        $extension->setConfig('client_lib_config_registry', $config);
+    }
+}

--- a/views/js/controller/creator/views/item.js
+++ b/views/js/controller/creator/views/item.js
@@ -20,13 +20,14 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
+    'module',
     'jquery',
     'i18n',
     'core/logger',
     'taoQtiTest/provider/testItems',
     'ui/resource/selector',
     'ui/feedback'
-], function ($, __, loggerFactory, testItemProviderFactory, resourceSelectorFactory, feedback) {
+], function (module, $, __, loggerFactory, testItemProviderFactory, resourceSelectorFactory, feedback) {
     'use strict';
 
     /**
@@ -56,6 +57,7 @@ define([
      * @param {jQueryElement} $container - where to append the view
      */
     return function itemView($container) {
+        const filters = module.config().BRS || false; // feature flag BRS (search by metadata) in Test Authoring
         const selectorConfig = {
             type: __('items'),
             selectionMode: resourceSelectorFactory.selectionModes.multiple,
@@ -67,7 +69,8 @@ define([
                     uri: ITEM_URI,
                     type: 'class'
                 }
-            ]
+            ],
+            filters
         };
 
         //set up the resource selector with one root class Item in classSelector


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-848

Create feature flag for the `search by properties` values within Test Authoring. By default it will be disabled.

How to test:

1. switch branch
2. run taoUpdate `php ./tao/scripts/taoUpdate.php`
3. check `config/tao/client_lib_config_registry.conf.php` should be
 ```
 'taoQtiTest/controller/creator/views/item' => array(
             'BRS' => false
         )
 ```
4. enable feature `'BRS' => true`
5. check search in Test Authoring

![image](https://user-images.githubusercontent.com/25976342/126516155-bd8f0392-a4d7-4728-9e25-87ccf2eee79e.png)
