### PR TITLE
[Fix] ADF-545 Remove duplicated css

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "git+https://github.com/oat-sa/tao-test-runner-qti-fe.git#4149371015784ac08da1aae66d3e35e790191c9d",
-      "from": "git+https://github.com/oat-sa/tao-test-runner-qti-fe.git#fix/ADF-545/search-icons-regression"
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.23.4.tgz",
+      "integrity": "sha512-5ZwtqYEiNYI0Plk/MH60d4WyWVVd6f2ew4rajtH3U4GH4Q7Ta3umIbHUms5xHauApo5aia7/FJNUmUhxqgS9Xg=="
     }
   }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.23.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.23.3.tgz",
-      "integrity": "sha512-xB5t4iuz1UUjMcoJ555Xq+TZSkEjKfG6t/Wxiq/BDq06i9eCksQWEtJ6yb7ZcMuCwARrgsWTw4y9BdYn1M/MVg=="
+      "version": "git+https://github.com/oat-sa/tao-test-runner-qti-fe.git#4149371015784ac08da1aae66d3e35e790191c9d",
+      "from": "git+https://github.com/oat-sa/tao-test-runner-qti-fe.git#fix/ADF-545/search-icons-regression"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "git+https://github.com/oat-sa/tao-test-runner-qti-fe#fix/ADF-545/search-icons-regression"
+    "@oat-sa/tao-test-runner-qti": "2.23.4"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.23.3"
+    "@oat-sa/tao-test-runner-qti": "git+https://github.com/oat-sa/tao-test-runner-qti-fe#fix/ADF-545/search-icons-regression"
   }
 }

--- a/views/scss/test-runner.scss
+++ b/views/scss/test-runner.scss
@@ -1,6 +1,5 @@
 @import "inc/bootstrap";
 @import "inc/loading-bar";
-@import "inc/action-bars";
 @import "inc/section-container";
 @import "inc/navigator";
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-545

Remove duplicated css (scss imports from tao-core) to avoid regressions in future when old code from tao-core gets bundled because we don't have a way to control such dependency version.

Related PR
https://github.com/oat-sa/tao-test-runner-qti-fe/pull/424