### PR TITLE
[Backport] TR-1869 Fix outcome variable calculation on test level timeout

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.3.12',
+    'version' => '40.3.12.1',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1503,7 +1503,7 @@ class QtiRunnerService extends ConfigurableService implements RunnerService
         switch ($timeOutException->getCode()) {
             case AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW:
                 \common_Logger::i('TIMEOUT: closing the assessment test session');
-                $session->endTestSession();
+                $session->moveThroughAndEndTestSession();
                 break;
 
             case AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW:


### PR DESCRIPTION
Backport of [#2053](https://github.com/oat-sa/extension-tao-testqti/pull/2053) (TR-1432)