### PR TITLE
chore(version): require qtism/qtism v0.25.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "^0.24.11",
+    "qtism/qtism": "^0.25.0",
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=48.9.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",


### PR DESCRIPTION
# [TR-1351](https://oat-sa.atlassian.net/browse/TR-1351)

- Support of 'list' type in a record, fix incorrect response in case of 'list' types
