### PR TITLE
fix: params deleteClassFromRoot

### DIFF
--- a/views/cypress/tests/authoring/test-authoring.spec.js
+++ b/views/cypress/tests/authoring/test-authoring.spec.js
@@ -73,7 +73,8 @@ describe('Test authoring', () => {
                 selectors.deleteClass,
                 selectors.deleteConfirm,
                 className,
-                selectors.deleteTestUrl
+                selectors.deleteTestUrl,
+                false
             );
         });
     });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1169
Depends https://github.com/oat-sa/tao-core/pull/3230

Stabilised old tests

How to test:
1. remove temporary delivery tests `ltiDeliveryProvider/views/cypress` `taoQtiTest/views/cypress/test/delivery` or exclude them
2. `cd tao/views`
3. `npm run cy:run`