### PR TITLE
fix: update SDK dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "^0.25.0",
+    "qtism/qtism": "dev-fix/TR-2459/review_navigation_timeout",
     "oat-sa/generis" : ">=15.5.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "dev-fix/TR-2459/review_navigation_timeout",
+    "qtism/qtism": "dev-fix/TR-2459/review_navigation_timeout as ^0.25.0",
     "oat-sa/generis" : ">=15.5.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-2459

deployed at http://test-tr-2459-timeouts.playground.kitchen.it.taocloud.org:49181/

Depends on: 

- [ ] https://github.com/oat-sa/qti-sdk/pull/303
