### PR TITLE
TR-2961 textReader asset post-processing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "oat-sa/generis" : ">=15.5.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",
-    "oat-sa/extension-tao-itemqti" : ">=27.0.0",
+    "oat-sa/extension-tao-itemqti" : "dev-bug/TR-2916/text-reader-img-cdn as 100.0.0",
     "oat-sa/extension-tao-test" : ">=15.0.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0"

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "oat-sa/generis" : ">=15.5.0",
     "oat-sa/tao-core" : ">=48.39.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",
-    "oat-sa/extension-tao-itemqti" : "dev-bug/TR-2916/text-reader-img-cdn as 100.0.0",
+    "oat-sa/extension-tao-itemqti" : ">=28.30.0",
     "oat-sa/extension-tao-test" : ">=15.0.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0"

--- a/manifest.php
+++ b/manifest.php
@@ -21,6 +21,7 @@
 
 use oat\tao\model\user\TaoRoles;
 use oat\taoQtiTest\model\Container\TestQtiServiceProvider;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\ServiceProvider\CustomInteractionPostProcessingServiceProvider;
 use oat\taoQtiTest\models\render\ItemsReferencesServiceProvider;
 use oat\taoQtiTest\models\xmlEditor\XmlEditorInterface;
 use oat\taoQtiTest\scripts\install\SetupProvider;
@@ -138,6 +139,7 @@ return [
         'structures' => __DIR__ . DIRECTORY_SEPARATOR . 'actions' . DIRECTORY_SEPARATOR . 'structures.xml',
     ],
     'containerServiceProviders' => [
+        CustomInteractionPostProcessingServiceProvider::class,
         ItemsReferencesServiceProvider::class,
         TestQtiServiceProvider::class,
     ],

--- a/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocator.php
+++ b/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocator.php
@@ -28,9 +28,8 @@ use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\NullCus
 class CustomInteractionPostProcessorAllocator
 {
     public const CUSTOM_INTERACTION_QTI_CLASS = 'customInteraction';
-    /**
-     * @var array
-     */
+
+    /** @var array */
     private $postProcessorMap;
 
     public function __construct(array $postProcessorMap)

--- a/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocator.php
+++ b/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocator.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\render\CustomInteraction;
+
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\Api\CustomInteractionPostProcessorInterface;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\NullCustomInteractionPostProcessor;
+
+class CustomInteractionPostProcessorAllocator
+{
+    public const CUSTOM_INTERACTION_QTI_CLASS = 'customInteraction';
+    /**
+     * @var array
+     */
+    private $postProcessorMap;
+
+    public function __construct(array $postProcessorMap)
+    {
+        $this->postProcessorMap = $postProcessorMap;
+    }
+
+    public function allocatePostProcessor(string $customInteractionIdentifier): CustomInteractionPostProcessorInterface
+    {
+        return $this->postProcessorMap[$customInteractionIdentifier] ?? new NullCustomInteractionPostProcessor();
+    }
+}

--- a/models/classes/render/CustomInteraction/PostProcessor/Api/CustomInteractionPostProcessorInterface.php
+++ b/models/classes/render/CustomInteraction/PostProcessor/Api/CustomInteractionPostProcessorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\Api;
+
+interface CustomInteractionPostProcessorInterface
+{
+    public function postProcess(array $element): array;
+}

--- a/models/classes/render/CustomInteraction/PostProcessor/NullCustomInteractionPostProcessor.php
+++ b/models/classes/render/CustomInteraction/PostProcessor/NullCustomInteractionPostProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor;
+
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\Api\CustomInteractionPostProcessorInterface;
+
+class NullCustomInteractionPostProcessor implements CustomInteractionPostProcessorInterface
+{
+
+    public function postProcess(array $element): array
+    {
+        return $element;
+    }
+}

--- a/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
+++ b/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor;
+
+use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\Api\CustomInteractionPostProcessorInterface;
+
+class TextReaderPostProcessor implements CustomInteractionPostProcessorInterface
+{
+    public const INTERACTION_IDENTIFIER = 'textReaderInteraction';
+    private const CONTENT_PREFIX = 'content-';
+
+    /**
+     * @var ItemAssetsReplacement
+     */
+    private $itemAssetsReplacement;
+
+    public function __construct(ItemAssetsReplacement $itemAssetsReplacement)
+    {
+        $this->itemAssetsReplacement = $itemAssetsReplacement;
+    }
+
+    public function postProcess(array $element): array
+    {
+        foreach ($element['properties'] as $key => &$value) {
+            if (strpos($key, self::CONTENT_PREFIX) === 0) {
+                $value = $this->itemAssetsReplacement->postProcessAssets($value);
+            }
+        }
+
+        return $element;
+    }
+}

--- a/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
+++ b/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
@@ -30,9 +30,7 @@ class TextReaderPostProcessor implements CustomInteractionPostProcessorInterface
     public const INTERACTION_IDENTIFIER = 'textReaderInteraction';
     private const CONTENT_PREFIX = 'content-';
 
-    /**
-     * @var ItemAssetsReplacement
-     */
+    /** @var ItemAssetsReplacement */
     private $itemAssetsReplacement;
 
     public function __construct(ItemAssetsReplacement $itemAssetsReplacement)

--- a/models/classes/render/CustomInteraction/ServiceProvider/CustomInteractionPostProcessingServiceProvider.php
+++ b/models/classes/render/CustomInteraction/ServiceProvider/CustomInteractionPostProcessingServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -15,33 +15,38 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
+
 declare(strict_types=1);
 
-namespace oat\taoQtiTest\models\render;
+namespace oat\taoQtiTest\models\classes\render\CustomInteraction\ServiceProvider;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\taoItems\model\render\ItemAssetsReplacement;
 use oat\taoQtiTest\models\classes\render\CustomInteraction\CustomInteractionPostProcessorAllocator;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\TextReaderPostProcessor;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
-class ItemsReferencesServiceProvider implements ContainerServiceProviderInterface
+class CustomInteractionPostProcessingServiceProvider implements ContainerServiceProviderInterface
 {
     public function __invoke(ContainerConfigurator $configurator): void
     {
         $services = $configurator->services();
 
         $services
-            ->set(UpdateItemContentReferencesService::class, UpdateItemContentReferencesService::class)
+            ->set(TextReaderPostProcessor::class, TextReaderPostProcessor::class)
             ->public()
-            ->args(
-                [
-                    service(ItemAssetsReplacement::SERVICE_ID),
-                    service(CustomInteractionPostProcessorAllocator::class)
-                ]
-            );
+            ->args([
+                service(ItemAssetsReplacement::SERVICE_ID)
+            ]);
+
+        $services
+            ->set(CustomInteractionPostProcessorAllocator::class, CustomInteractionPostProcessorAllocator::class)
+            ->public()
+            ->args([
+                [TextReaderPostProcessor::INTERACTION_IDENTIFIER => service(TextReaderPostProcessor::class)]
+            ]);
     }
 }

--- a/models/classes/render/UpdateItemContentReferencesService.php
+++ b/models/classes/render/UpdateItemContentReferencesService.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace oat\taoQtiTest\models\render;
 
 use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\CustomInteractionPostProcessorAllocator;
 
 class UpdateItemContentReferencesService
 {
@@ -29,21 +30,30 @@ class UpdateItemContentReferencesService
      * @var ItemAssetsReplacement
      */
     private $itemAssetsReplacement;
+    /**
+     * @var CustomInteractionPostProcessorAllocator
+     */
+    private $customInteractionPostProcessorAllocator;
 
-    public function __construct(ItemAssetsReplacement $itemAssetsReplacement)
-    {
+    public function __construct(
+        ItemAssetsReplacement $itemAssetsReplacement,
+        CustomInteractionPostProcessorAllocator $customInteractionPostProcessorAllocator
+    ) {
         $this->itemAssetsReplacement = $itemAssetsReplacement;
+        $this->customInteractionPostProcessorAllocator = $customInteractionPostProcessorAllocator;
     }
 
     public function __invoke(array $itemContent): array
     {
-
-        $jsonAssets = [];
+        if ($this->isQtiItemContent($itemContent)){
+            $itemContent = $this->resolveCustomInteractionPostProcessing($itemContent);
+        }
 
         if (empty($itemContent['assets'])) {
             return $itemContent;
         }
 
+        $jsonAssets = [];
         foreach ($itemContent['assets'] as $type => $assets) {
             foreach ($assets as $key => $asset) {
                 $jsonAssets[$type][$key] = $this->itemAssetsReplacement->postProcessAssets($asset);
@@ -51,6 +61,25 @@ class UpdateItemContentReferencesService
         }
 
         $itemContent['assets'] = $jsonAssets;
+
+        return $itemContent;
+    }
+
+    private function isQtiItemContent($itemContent):bool
+    {
+        return isset($itemContent['type']) && $itemContent['type'] === 'qti';
+    }
+
+    private function resolveCustomInteractionPostProcessing(array $itemContent): array
+    {
+        foreach ($itemContent['data']['body']['elements'] as &$element) {
+            if ($element['qtiClass'] === CustomInteractionPostProcessorAllocator::CUSTOM_INTERACTION_QTI_CLASS) {
+                $postProcessorAllocator = $this->customInteractionPostProcessorAllocator->allocatePostProcessor(
+                    $element['typeIdentifier']
+                );
+                $element = $postProcessorAllocator->postProcess($element);
+            }
+        }
 
         return $itemContent;
     }

--- a/models/classes/render/UpdateItemContentReferencesService.php
+++ b/models/classes/render/UpdateItemContentReferencesService.php
@@ -26,13 +26,9 @@ use oat\taoQtiTest\models\classes\render\CustomInteraction\CustomInteractionPost
 
 class UpdateItemContentReferencesService
 {
-    /**
-     * @var ItemAssetsReplacement
-     */
+    /** @var ItemAssetsReplacement */
     private $itemAssetsReplacement;
-    /**
-     * @var CustomInteractionPostProcessorAllocator
-     */
+    /** @var CustomInteractionPostProcessorAllocator */
     private $customInteractionPostProcessorAllocator;
 
     public function __construct(

--- a/test/unit/models/classes/render/ContentPostprocessorServiceTest.php
+++ b/test/unit/models/classes/render/ContentPostprocessorServiceTest.php
@@ -29,26 +29,19 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ContentPostprocessorServiceTest extends TestCase
 {
-    private $serviceLocator;
-    /**
-     * @var UpdateItemContentReferencesService
-     */
+    /** @var UpdateItemContentReferencesService */
     private $sut;
-    /**
-     * @var ItemAssetsReplacement|MockObject
-     */
+    /** @var ItemAssetsReplacement|MockObject */
     private $itemAssetReplacement;
-    /** @var CustomInteractionPostProcessorAllocator|MockObject */
-    private $customInteractionAllocator;
 
     public function setUp(): void
     {
         $this->itemAssetReplacement = $this->createMock(ItemAssetsReplacement::class);
-        $this->customInteractionAllocator = $this->createMock(CustomInteractionPostProcessorAllocator::class);
+        $customInteractionAllocator = $this->createMock(CustomInteractionPostProcessorAllocator::class);
 
         $this->sut = new UpdateItemContentReferencesService(
             $this->itemAssetReplacement,
-            $this->customInteractionAllocator
+            $customInteractionAllocator
         );
     }
 

--- a/test/unit/models/classes/render/ContentPostprocessorServiceTest.php
+++ b/test/unit/models/classes/render/ContentPostprocessorServiceTest.php
@@ -23,6 +23,7 @@ namespace oat\taoQtiTest\test\unit\models\classes\render;
 
 use oat\generis\test\TestCase;
 use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\CustomInteractionPostProcessorAllocator;
 use oat\taoQtiTest\models\render\UpdateItemContentReferencesService;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -37,12 +38,18 @@ class ContentPostprocessorServiceTest extends TestCase
      * @var ItemAssetsReplacement|MockObject
      */
     private $itemAssetReplacement;
+    /** @var CustomInteractionPostProcessorAllocator|MockObject */
+    private $customInteractionAllocator;
 
     public function setUp(): void
     {
         $this->itemAssetReplacement = $this->createMock(ItemAssetsReplacement::class);
+        $this->customInteractionAllocator = $this->createMock(CustomInteractionPostProcessorAllocator::class);
 
-        $this->sut = new UpdateItemContentReferencesService($this->itemAssetReplacement);
+        $this->sut = new UpdateItemContentReferencesService(
+            $this->itemAssetReplacement,
+            $this->customInteractionAllocator
+        );
     }
 
     public function testPostProcessContent()

--- a/test/unit/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocatorTest.php
+++ b/test/unit/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\models\classes\render\CustomInteraction;
+
+use oat\generis\test\TestCase;
+use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\CustomInteractionPostProcessorAllocator;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\NullCustomInteractionPostProcessor;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\TextReaderPostProcessor;
+
+class CustomInteractionPostProcessorAllocatorTest extends TestCase
+{
+    /**
+     * @var CustomInteractionPostProcessorAllocator
+     */
+    private $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new CustomInteractionPostProcessorAllocator([
+            TextReaderPostProcessor::INTERACTION_IDENTIFIER => new TextReaderPostProcessor(
+                $this->createMock(ItemAssetsReplacement::class)
+            )
+        ]);
+    }
+
+    public function testNullCustomInteractionPostProcessorAllocation(): void
+    {
+        $postProcessor = $this->subject->allocatePostProcessor(uniqid('prefix', true));
+        $this->assertInstanceOf(NullCustomInteractionPostProcessor::class, $postProcessor);
+    }
+
+    public function testTextReaderInteractionPostProcessorAllocation(): void
+    {
+        $postProcessor = $this->subject->allocatePostProcessor(
+            TextReaderPostProcessor::INTERACTION_IDENTIFIER
+        );
+        $this->assertInstanceOf(TextReaderPostProcessor::class, $postProcessor);
+    }
+}

--- a/test/unit/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocatorTest.php
+++ b/test/unit/models/classes/render/CustomInteraction/CustomInteractionPostProcessorAllocatorTest.php
@@ -30,9 +30,7 @@ use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\TextRea
 
 class CustomInteractionPostProcessorAllocatorTest extends TestCase
 {
-    /**
-     * @var CustomInteractionPostProcessorAllocator
-     */
+    /** @var CustomInteractionPostProcessorAllocator */
     private $subject;
 
     public function setUp(): void

--- a/test/unit/models/classes/render/CustomInteraction/PostProcessor/NullCustomInteractionPostProcessorTest.php
+++ b/test/unit/models/classes/render/CustomInteraction/PostProcessor/NullCustomInteractionPostProcessorTest.php
@@ -20,14 +20,30 @@
 
 declare(strict_types=1);
 
-namespace oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor;
+namespace oat\taoQtiTest\test\unit\models\classes\render\CustomInteraction\PostProcessor;
 
-use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\Api\CustomInteractionPostProcessorInterface;
+use oat\generis\test\TestCase;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\NullCustomInteractionPostProcessor;
 
-class NullCustomInteractionPostProcessor implements CustomInteractionPostProcessorInterface
+class NullCustomInteractionPostProcessorTest extends TestCase
 {
-    public function postProcess(array $element): array
+    /**
+     * @var NullCustomInteractionPostProcessor
+     */
+    private $subject;
+
+    public function setUp(): void
     {
-        return $element;
+        $this->subject = new NullCustomInteractionPostProcessor();
+    }
+
+    public function testNullPostProcessing(): void
+    {
+        $element = ['properties' => []];
+        for ($i = 0, $iMax = random_int(1, 10); $i < $iMax; $i++) {
+            $element['properties'][uniqid('prefix', true)] = uniqid((string) $i, true);
+        }
+
+        $this->assertSame($element, $this->subject->postProcess($element));
     }
 }

--- a/test/unit/models/classes/render/CustomInteraction/PostProcessor/NullCustomInteractionPostProcessorTest.php
+++ b/test/unit/models/classes/render/CustomInteraction/PostProcessor/NullCustomInteractionPostProcessorTest.php
@@ -27,9 +27,7 @@ use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\NullCus
 
 class NullCustomInteractionPostProcessorTest extends TestCase
 {
-    /**
-     * @var NullCustomInteractionPostProcessor
-     */
+    /** @var NullCustomInteractionPostProcessor */
     private $subject;
 
     public function setUp(): void

--- a/test/unit/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessorTest.php
+++ b/test/unit/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\models\classes\render\CustomInteraction\PostProcessor;
+
+use oat\generis\test\TestCase;
+use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\TextReaderPostProcessor;
+
+class TextReaderPostProcessorTest extends TestCase
+{
+    private const CONTENT_PREFIX = 'content-';
+    private const CONTENT_REPLACER = 'replaced';
+
+    /**
+     * @var TextReaderPostProcessor
+     */
+    private $subject;
+
+    public function setUp(): void
+    {
+        $itemAssetsReplacement = $this->createMock(ItemAssetsReplacement::class);
+        $itemAssetsReplacement->method('postProcessAssets')->willReturn(self::CONTENT_REPLACER);
+        $this->subject = new TextReaderPostProcessor($itemAssetsReplacement);
+    }
+
+    /**
+     * @dataProvider getCustomInteractionElement
+     */
+    public function testPostProcessing(array $inputElement, array $expectedElement): void
+    {
+        $element = ['properties' => $inputElement];
+        $this->assertSame($expectedElement, $this->subject->postProcess($element)['properties']);
+    }
+
+    public function getCustomInteractionElement(): array
+    {
+        return [
+            'Only data for post-processing' => [
+                [
+                    self::CONTENT_PREFIX . 'first' => uniqid(self::CONTENT_PREFIX, true),
+                    self::CONTENT_PREFIX . 'second' => uniqid(self::CONTENT_PREFIX, true),
+                    self::CONTENT_PREFIX . 'third' => uniqid(self::CONTENT_PREFIX, true),
+                ], [
+                    self::CONTENT_PREFIX . 'first' => self::CONTENT_REPLACER,
+                    self::CONTENT_PREFIX . 'second' => self::CONTENT_REPLACER,
+                    self::CONTENT_PREFIX . 'third' => self::CONTENT_REPLACER,
+                ]
+            ],
+            'Without data for post-processing' => [
+                [
+                    'first' => 'first',
+                    'second' => 'second',
+                    'third' => 'third',
+                ], [
+                    'first' => 'first',
+                    'second' => 'second',
+                    'third' => 'third',
+                ]
+            ],
+            'Mixed data for post-processing' => [
+                [
+                    self::CONTENT_PREFIX . 'first' => uniqid(self::CONTENT_PREFIX, true),
+                    self::CONTENT_PREFIX . 'second' => uniqid(self::CONTENT_PREFIX, true),
+                    self::CONTENT_PREFIX . 'third' => uniqid(self::CONTENT_PREFIX, true),
+                    'first' => 'first',
+                    'second' => 'second',
+                    'third' => 'third',
+                ], [
+                    self::CONTENT_PREFIX . 'first' => self::CONTENT_REPLACER,
+                    self::CONTENT_PREFIX . 'second' => self::CONTENT_REPLACER,
+                    self::CONTENT_PREFIX . 'third' => self::CONTENT_REPLACER,
+                    'first' => 'first',
+                    'second' => 'second',
+                    'third' => 'third',
+                ]
+            ]
+        ];
+    }
+}

--- a/test/unit/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessorTest.php
+++ b/test/unit/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessorTest.php
@@ -31,9 +31,7 @@ class TextReaderPostProcessorTest extends TestCase
     private const CONTENT_PREFIX = 'content-';
     private const CONTENT_REPLACER = 'replaced';
 
-    /**
-     * @var TextReaderPostProcessor
-     */
+    /** @var TextReaderPostProcessor */
     private $subject;
 
     public function setUp(): void


### PR DESCRIPTION
# [TR-2961](https://oat-sa.atlassian.net/browse/TR-2961)

## Summary
Need to create functionality which allow `CustomInteraction`(TextReader) assets post-processing 
 
## How to test
* update extension by branch
* create `item` with `Text Reader` with image
* create `test` with created in prev step `item`
* publish this `test` as local
* run published delivery and check in browser inspector image `src`

For affecting local `env` without `cdn` need to update `taoItems/models/classes/render/NoneItemReplacement.php`
by next code 
```
class NoneItemReplacement extends ConfigurableService implements ItemAssetsReplacement
{


    public function postProcessAssets($string)
    {
        return 'replaced-' . $string;
    }
}
```
depend on https://github.com/oat-sa/extension-tao-itemqti/pull/1975
