### PR TITLE
feat: handling section properties when creating sub-sections

### DIFF
--- a/views/js/controller/creator/helpers/subsection.js
+++ b/views/js/controller/creator/helpers/subsection.js
@@ -64,6 +64,15 @@ define(['jquery', 'lodash'], function ($, _) {
         return $subsection.parents('.subsection').first();
     }
     /**
+     * Get parent section of this subsection
+     *
+     * @param {JQueryElement} $subsection
+     * @returns {boolean}
+     */
+    function getParentSection($subsection) {
+        return $subsection.parents('.section');
+    }
+    /**
      * Get parent container('.subsections') for this subsection
      *
      * @param {JQueryElement} $subsection
@@ -79,6 +88,7 @@ define(['jquery', 'lodash'], function ($, _) {
         getSubsections,
         getSubsectionContainer,
         getSiblingSubsections,
-        getParentSubsection
+        getParentSubsection,
+        getParentSection
     };
 });

--- a/views/js/controller/creator/templates/index.js
+++ b/views/js/controller/creator/templates/index.js
@@ -74,7 +74,7 @@ function(
             itemrefweight   : applyTemplateConfiguration(itemRefPropsWeight),
             rubricblock     : applyTemplateConfiguration(rubricBlockProps),
             categorypresets : applyTemplateConfiguration(categoryPresets),
-            subsection  : applyTemplateConfiguration(subsection)
+            subsection  : applyTemplateConfiguration(sectionProps)
 
         }
     };

--- a/views/js/controller/creator/views/actions.js
+++ b/views/js/controller/creator/views/actions.js
@@ -205,36 +205,18 @@ define([
      * Hides/shows container for adding items inside a section checking if there is at least
      * one subsection inside of it. As delete subsection event is triggered before subsection
      * container is actually removed from section container, we need to have conditional flow
-     * @param {Object | null} sectionModel - section model
-     * @param {Object} sectionContainer - section jquery container
+     * @param {jQueryElement} sectionContainer - section jquery container
      * @param {boolean} subsectionDeleted - if subsection was deleted
-     * @param {boolean} undoSubsectionDeletion - if subsection was recreated with undo action
      */
-    function displayItemWrapper(
-        sectionModel,
-        sectionContainer,
-        subsectionDeleted = false,
-        undoSubsectionDeletion = false
-    ) {
-        const $elt = $('.itemrefs-wrapper:first', sectionContainer);
-        if (subsectionDeleted) {
-            if (subsectionsHelper.getSubsections(sectionContainer).length > 1) {
-                $elt.hide();
-            } else {
+    function displayItemWrapper($section, subsectionDeleted = false) {
+        const $elt = $('.itemrefs-wrapper:first', $section);
+        const subsectionsCount = subsectionsHelper.getSubsections($section).length;
+        if (subsectionsCount) {
+            if (subsectionDeleted && subsectionsCount === 1) {
                 $elt.show();
-            }
-        } else if (undoSubsectionDeletion) {
-            if (subsectionsHelper.getSubsections(sectionContainer).length >= 1) {
-                $elt.hide();
             } else {
-                $elt.show();
+                $elt.hide();
             }
-        } else if (
-            sectionModel.sectionParts &&
-            sectionModel.sectionParts.length > 0 &&
-            sectionModel.sectionParts[0]['qti-type'] === 'assessmentSection'
-        ) {
-            $elt.hide();
         } else {
             $elt.show();
         }
@@ -253,18 +235,47 @@ define([
     }
 
     /**
+     * Hides/shows category-presets (Test Navigation, Navigation Warnings, Test-Taker Tools)
+     * Hide category-presets for section that contains subsections
+     * @param {propView} propView - the view object
+     * @param {boolean} subsectionDeleted - if subsection was deleted
+     * @fires propertiesView#set-default-categories
+     */
+    function displayCategoryPresets($section, subsectionDeleted) {
+        const id = $section.attr('id');
+        const $propertiesView = $(`.test-creator-props #section-props-${id}`);
+        if (!$propertiesView.length) {
+            // property view is not setup
+            return;
+        }
+        const $elt = $propertiesView.find('.category-presets');
+        const subsectionsCount = subsectionsHelper.getSubsections($section).length;
+        if (subsectionsCount) {
+            if (subsectionDeleted && subsectionsCount === 1) {
+                $elt.show();
+            } else {
+                $elt.hide();
+                $propertiesView.trigger('set-default-categories');
+            }
+        } else {
+            $elt.show();
+        }
+    }
+
+    /**
      * The actions gives you shared behavior for some actions.
      *
      * @exports taoQtiTest/controller/creator/views/actions
      */
     return {
-        properties: properties,
-        move: move,
-        removable: removable,
-        movable: movable,
-        disable: disable,
-        enable: enable,
-        displayItemWrapper: displayItemWrapper,
-        updateDeleteSelector: updateDeleteSelector
+        properties,
+        move,
+        removable,
+        movable,
+        disable,
+        enable,
+        displayItemWrapper,
+        updateDeleteSelector,
+        displayCategoryPresets
     };
 });

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -87,7 +87,7 @@ define([
         }
         actions.properties($titleWithActions, 'section', sectionModel, propHandler);
         actions.move($titleWithActions, 'sections', 'section');
-        actions.displayItemWrapper(sectionModel, $section);
+        actions.displayItemWrapper($section);
 
         subsections();
         itemRefs();
@@ -150,6 +150,8 @@ define([
             if (typeof sectionModel.hasBlueprint !== 'undefined') {
                 blueprintProperty($view);
             }
+
+            actions.displayCategoryPresets($section);
 
             function removePropHandler(e, $deletedNode) {
                 const validIds = [$section.parents('.testpart').attr('id'), $section.attr('id')];
@@ -397,6 +399,11 @@ define([
                 updateFormState(categorySelector);
             });
 
+            $view.on('set-default-categories', function () {
+                sectionModel.categories = defaults().categories;
+                updateFormState(categorySelector);
+            });
+
             categorySelector.on('category-change', function (selected, indeterminate) {
                 sectionCategory.setCategories(sectionModel, selected, indeterminate);
 
@@ -559,7 +566,8 @@ define([
                         //initialize the new test part
                         subsectionView.setUp(creatorContext, subsectionModel, sectionModel, $subsection);
 
-                        actions.displayItemWrapper(sectionModel, $section);
+                        actions.displayItemWrapper($section);
+                        actions.displayCategoryPresets($section);
 
                         /**
                          * @event modelOverseer#section-add
@@ -590,8 +598,9 @@ define([
                     $parent = $target.parents('.sections');
                     actions.disable($parent.find('.section'), 'h2');
                 } else if ($target.hasClass('subsection') && subsectionsHelper.isFistLevelSubsection($target)) {
-                    $parent = $target.parents('.section');
-                    actions.displayItemWrapper(null, $parent, true);
+                    $parent = subsectionsHelper.getParentSection($target);
+                    actions.displayItemWrapper($parent, true);
+                    actions.displayCategoryPresets($parent, true);
                 }
             })
             .on('add change undo.deleter deleted.deleter', function (e) {
@@ -609,7 +618,9 @@ define([
                     ($target.hasClass('subsection') || $target.hasClass('subsections')) &&
                     subsectionsHelper.isFistLevelSubsection($target)
                 ) {
-                    actions.displayItemWrapper(null, $target.parents('.section'), false, true);
+                    const $parent = subsectionsHelper.getParentSection($target);
+                    actions.displayItemWrapper($parent);
+                    actions.displayCategoryPresets($parent);
                 }
             })
             .on('open.toggler', '.rub-toggler', function (e) {

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -545,6 +545,9 @@ define([
                             .css('display', 'flex')
                             .css('flex-direction', 'row-reverse');
                     } else {
+                        if (!sectionModel.sectionParts.length && sectionModel.categories.length) {
+                            $section.data('movedCategories', _.clone(sectionModel.categories));
+                        }
                         executeAdd();
                     }
                 }
@@ -562,6 +565,11 @@ define([
                         // first level of subsection
                         const subsectionIndex = $subsection.data('bind-index');
                         const subsectionModel = sectionModel.sectionParts[subsectionIndex];
+
+                        if ($section.data('movedCategories')) {
+                            subsectionModel.categories = $section.data('movedCategories');
+                            $section.removeData('movedCategories');
+                        }
 
                         //initialize the new test part
                         subsectionView.setUp(creatorContext, subsectionModel, sectionModel, $subsection);

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -93,7 +93,8 @@ define([
         rubricBlocks();
         addRubricBlock();
 
-        if (subsectionsHelper.isNestedSubsection($subsection)) { // prevent adding a third subsection level
+        if (subsectionsHelper.isNestedSubsection($subsection)) {
+            // prevent adding a third subsection level
             $('.add-subsection', $subsection).hide();
             $('.add-subsection + .tlb-separator', $subsection).hide();
         } else {
@@ -539,22 +540,32 @@ define([
                     });
                 },
                 checkAndCallAdd: function (executeAdd) {
-                    if (subsectionModel.sectionParts[0] && qtiTestHelper.filterQtiType(subsectionModel.sectionParts[0], 'assessmentItemRef')) {
+                    if (
+                        subsectionModel.sectionParts[0] &&
+                        qtiTestHelper.filterQtiType(subsectionModel.sectionParts[0], 'assessmentItemRef')
+                    ) {
                         // subsection has item(s)
                         const subsectionIndex = $('.subsection', $subsection).length;
-                        const confirmMessage = __('The items contained in <b>%s</b> will be moved into the new <b>%s</b>. Do you wish to proceed?', subsectionModel.title, `${defaults().sectionTitlePrefix} ${subsectionIndex + 1}`);
+                        const confirmMessage = __(
+                            'The items contained in <b>%s</b> will be moved into the new <b>%s</b>. Do you wish to proceed?',
+                            subsectionModel.title,
+                            `${defaults().sectionTitlePrefix} ${subsectionIndex + 1}`
+                        );
                         const acceptFunction = () => {
                             $subsection.data('movedItems', _.clone(subsectionModel.sectionParts));
                             subsectionModel.sectionParts = [];
                             $('.itemrefs', $itemRefsWrapper).empty();
                             executeAdd();
-                        }
-                        confirmDialog(confirmMessage, acceptFunction,() => {}, optionsConfirmDialog)
+                        };
+                        confirmDialog(confirmMessage, acceptFunction, () => {}, optionsConfirmDialog)
                             .getDom()
                             .find('.buttons')
                             .css('display', 'flex')
                             .css('flex-direction', 'row-reverse');
                     } else {
+                        if (!subsectionModel.sectionParts.length && subsectionModel.categories.length) {
+                            $subsection.data('movedCategories', _.clone(subsectionModel.categories));
+                        }
                         executeAdd();
                     }
                 }
@@ -572,6 +583,11 @@ define([
                         // second level of subsection){
                         const sub2sectionIndex = $sub2section.data('bind-index');
                         const sub2sectionModel = subsectionModel.sectionParts[sub2sectionIndex];
+
+                        if ($subsection.data('movedCategories')) {
+                            sub2sectionModel.categories = $subsection.data('movedCategories');
+                            $subsection.removeData('movedCategories');
+                        }
 
                         //initialize the new test part
                         setUp(creatorContext, sub2sectionModel, subsectionModel, $sub2section);

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -84,7 +84,7 @@ define([
         }
         actions.properties($titleWithActions, 'section', subsectionModel, propHandler);
         actions.move($titleWithActions, 'subsections', 'subsection');
-        actions.displayItemWrapper(subsectionModel, $subsection);
+        actions.displayItemWrapper($subsection);
         actions.updateDeleteSelector($titleWithActions);
 
         subsections();
@@ -154,6 +154,8 @@ define([
             if (typeof subsectionModel.hasBlueprint !== 'undefined') {
                 blueprintProperty($view);
             }
+
+            actions.displayCategoryPresets($subsection);
 
             function removePropHandler(e, $deletedNode) {
                 const validIds = [$subsection.parents('.testpart').attr('id'), $subsection.attr('id')];
@@ -414,6 +416,11 @@ define([
                 updateFormState(categorySelector);
             });
 
+            $view.on('set-default-categories', function () {
+                subsectionModel.categories = defaults().categories;
+                updateFormState(categorySelector);
+            });
+
             categorySelector.on('category-change', function (selected, indeterminate) {
                 sectionCategory.setCategories(subsectionModel, selected, indeterminate);
 
@@ -569,7 +576,8 @@ define([
                         //initialize the new test part
                         setUp(creatorContext, sub2sectionModel, subsectionModel, $sub2section);
 
-                        actions.displayItemWrapper(subsectionModel, $subsection);
+                        actions.displayItemWrapper($subsection);
+                        actions.displayCategoryPresets($subsection);
 
                         /**
                          * @event modelOverseer#section-add
@@ -598,7 +606,9 @@ define([
                 if ($target.hasClass('subsection')) {
                     actions.disable(subsectionsHelper.getSiblingSubsections($target), 'h2');
                     if (subsectionsHelper.isNestedSubsection($target)) {
-                        actions.displayItemWrapper(null, subsectionsHelper.getParentSubsection($target), true);
+                        const $parent = subsectionsHelper.getParentSubsection($target);
+                        actions.displayItemWrapper($parent, true);
+                        actions.displayCategoryPresets($parent, true);
                     }
                 }
             })
@@ -610,18 +620,10 @@ define([
                     actions.movable($subsections, 'subsection', 'h2');
 
                     if (e.type === 'undo' && subsectionsHelper.isNestedSubsection($target)) {
-                        actions.displayItemWrapper(null, subsectionsHelper.getParentSubsection($target), false, true);
+                        const $parent = subsectionsHelper.getParentSubsection($target);
+                        actions.displayItemWrapper($parent);
+                        actions.displayCategoryPresets($parent);
                     }
-                }
-            })
-            .on('open.toggler', '.rub-toggler', function (e) {
-                if (e.namespace === 'toggler') {
-                    $(this).parents('h2').addClass('active');
-                }
-            })
-            .on('close.toggler', '.rub-toggler', function (e) {
-                if (e.namespace === 'toggler') {
-                    $(this).parents('h2').removeClass('active');
                 }
             });
     }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1301

**What to test:**
AC1 - Adding the 1st nested section => hide the following section settings from the parent section, author shall not be able to configure those on parent section .
Test Navigation
Navigation Warnings
Test-Taker Tools

AC2 - Removing all nested level sections and the parent becomes empty => make available the following section settings that where hidden when the section had child sections.
Test Navigation
Navigation Warnings
Test-Taker Tools

AC3 - Default section setting after removal of all sub-sections => shall render the section with the default settings as those of creating a new section.