### PR TITLE
feat: add configuration variable to omit pause message

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -691,4 +691,10 @@ return [
      * @type boolean
      */
     'enable-read-aloud-text-to-speech' => false,
+
+    /**
+     * If 'skip-paused-assesment-dialog' is true, the pause message is not displayed when pausing the test.
+     * @type boolean
+     */
+    'skip-paused-assesment-dialog' => false,
 ];

--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -693,8 +693,8 @@ return [
     'enable-read-aloud-text-to-speech' => false,
 
     /**
-     * If 'skip-paused-assesment-dialog' is true, the pause message is not displayed when pausing the test.
+     * If 'skip-paused-assessment-dialog' is true, the pause message is not displayed when pausing the test.
      * @type boolean
      */
-    'skip-paused-assesment-dialog' => false,
+    'skip-paused-assessment-dialog' => false,
 ];

--- a/models/classes/runner/config/QtiRunnerConfig.php
+++ b/models/classes/runner/config/QtiRunnerConfig.php
@@ -135,6 +135,7 @@ class QtiRunnerConfig extends ConfigurableService implements RunnerConfig
                 'toolStateServerStorage' => isset($rawConfig['tool-state-server-storage']) ? $rawConfig['tool-state-server-storage'] : [],
                 'forceEnableLinearNextItemWarning' => isset($rawConfig['force-enable-linear-next-item-warning']) ? $rawConfig['force-enable-linear-next-item-warning'] : false,
                 'enableLinearNextItemWarningCheckbox' => isset($rawConfig['enable-linear-next-item-warning-checkbox']) ? $rawConfig['enable-linear-next-item-warning-checkbox'] : true,
+                'skipPausedAssessmentDialog' => isset($rawConfig['skip-paused-assessment-dialog']) ? $rawConfig['skip-paused-assessment-dialog'] : false,
             ];
         }
 


### PR DESCRIPTION
# [TR-2500](https://oat-sa.atlassian.net/browse/TR-2500)

## Changelog
- feat: add configuration variable to omit pause message

## How to test
1. Go to the [kitchen](http://test-tr-bosa.playground.kitchen.it.taocloud.org:41921)
2. Run a proctored assessment as a test taker
3. Authorize the assessment as a proctor
4. Pause the assessment as the test taker
5. Pause the assessment as the test taker
6. Observe that it does not show the message to the test-taker and reload the page