### PR TITLE
fix: do not fail pause action on suspended test session

### DIFF
--- a/model/Service/PauseService.php
+++ b/model/Service/PauseService.php
@@ -50,7 +50,6 @@ class PauseService
 
         $this->saveItemResponse($command, $serviceContext);
 
-        $this->runnerService->check($serviceContext);
         $serviceContext->init();
 
         $result = $this->runnerService->pause($serviceContext);

--- a/test/unit/model/Service/PauseServiceTest.php
+++ b/test/unit/model/Service/PauseServiceTest.php
@@ -80,6 +80,17 @@ class PauseServiceTest extends TestCase
         $this->assertEquals($expectedResponse->toArray(), $response->toArray());
     }
 
+    public function testPauseActionIsSuccessfulForAlreadyPausedSessions()
+    {
+        $this->runnerService->expects($this->never())->method('check');
+
+        $expectedResponse = ActionResponse::success();
+
+        $response = $this->executeAction();
+
+        $this->assertEquals($expectedResponse->toArray(), $response->toArray());
+    }
+
     public function testSavesItemResponse(): void
     {
         $this->itemResponseRepository->expects($this->once())


### PR DESCRIPTION
Pause action on suspended test sessions should not fail.
 
Related to : https://oat-sa.atlassian.net/browse/TR-3258
 
Small change to remove the check.
  
#### How to test
 
- Start a delivery as a test taker
- In separate browser session login as a Proctor and pause the previously started test session
- As a test taker, either:
  - move to the next item
  - or if synchronization channel is configured - wait for the next background sync
- Test taker should see a popup informing about suspended test session, instead of an error flash message. In case [TR-2500](https://oat-sa.atlassian.net/browse/TR-2500) feature is installed as well and flag `skip-paused-assessment-dialog == true`, then test taker won't see any popup and will be redirected to "Authorization" screen immediately.
 
 