### PR TITLE
chore: update oat-sa/tao-test-runer-qti to version 2.28.0

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     },
     "@oat-sa/tao-test-runner-qti": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.27.0.tgz",
-      "integrity": "sha512-K0xLf5SqnNquPoOtHkMx3XqF0i9w3Zm3BZdL9WR3I4vnvAy4V1hwgqGj2+ns0i9h2yamCd0YRmd61IzXvy2L5w=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.28.0.tgz",
+      "integrity": "sha512-TDnVpixCBDpPvjf2EBZBKcXTXyAqcqWyN9aUE/exAeJirf5/NdR+xVponNRhQ3UUKwW22ty35KdJt8lX4k++ZQ=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@oat-sa/tao-test-runner": "0.8.1",
-    "@oat-sa/tao-test-runner-qti": "2.27.0"
+    "@oat-sa/tao-test-runner-qti": "2.28.0"
   }
 }


### PR DESCRIPTION
# [TR-2500](https://oat-sa.atlassian.net/browse/TR-2500)

## Changelog
- chore: update oat-sa/tao-test-runer-qti to version [2.28.0](https://github.com/oat-sa/tao-test-runner-qti-fe/tree/v2.28.0)
