### PR TITLE
Feature/TR-2836/Set the client timer as default

### DIFF
--- a/config/default/testRunner.conf.php
+++ b/config/default/testRunner.conf.php
@@ -424,9 +424,10 @@ return [
          * This config tells on which TimeLine to rely to compute the assessment test durations.
          * Caution, if the server TimeLine is always filled, the client TimeLine must be explicitly
          * provided by the implementation. If the client TimeLine is missing, the durations will be zeroed.
+         * The default QTI implementation is supplying the item duration on every move.
          * @type string
          */
-        'target' => 'server'
+        'target' => 'client'
     ],
 
     /**

--- a/scripts/cli/TimerMode.php
+++ b/scripts/cli/TimerMode.php
@@ -22,27 +22,85 @@ declare(strict_types=1);
 
 namespace oat\taoQtiTest\scripts\cli;
 
+use common_ext_Extension;
+use common_ext_ExtensionsManager;
+use Exception;
+use InvalidArgumentException;
 use oat\oatbox\extension\script\ScriptAction;
 use oat\oatbox\reporting\Report;
 
+/**
+ * Manage the timer-mode option for the TestRunner.
+ * For the time being these modes are supported:
+ * - 'server': The timer is managed by the server. It starts with the test and ends with it.
+ *   Any interruption occurring on the client will be ignored, unless the test is explicitly
+ *   paused by calling the pause action.
+ * - 'client': The timer is managed by the client application. It is synchronized upon each
+ *   navigation move. In case of interruption, the timer is paused and resumed when the item
+ *   is in the interacting state. Time spent outside will be discarded, like while navigating
+ *   between items or waiting for network. Between synchronisation steps the timer value is
+ *   stored in the client storage. If this storage is emptied, the duration elapsed after the
+ *   last synchronisation will be lost. This may happen if the browser's local storage is cleaned,
+ *   or if the test is resumed from a different browser or computer.
+ *
+ * Usage:
+ *     php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' [options]
+ *
+ *   Optional Arguments:
+ *     -g,       --get        Displays the timer mode
+ *     -s mode, --set mode    Changes the timer mode
+ *     -h,       --help       Prints a help statement
+ *
+ * Examples:
+ * - Displays the current mode:
+ *     php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' -g
+ *     php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' --get
+ *
+ * - Change the timer mode to 'client'
+ *     php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' -s client
+ *     php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' --set client
+ *
+ * - Displays help:
+ *     php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' -h
+ *     php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' --help
+ */
 class TimerMode extends ScriptAction
 {
-    public const SET_TIMER_MODE = 'set';
+    public const CONFIG_FILE = 'testRunner';
+    public const GET_TIMER_MODE = 'show';
+    public const SET_TIMER_MODE = 'mode';
     public const SUPPORTED_MODES = [
         'server',
         'client'
     ];
 
+    protected function provideUsage()
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Prints a help statement'
+        ];
+    }
+
     protected function provideOptions()
     {
         return [
+            self::GET_TIMER_MODE => [
+                'prefix' => 'g',
+                'longPrefix' => 'get',
+                'cast' => 'string',
+                'flag' => true,
+                'required' => false,
+                'description' => 'Displays the timer mode',
+            ],
             self::SET_TIMER_MODE => [
                 'prefix' => 's',
                 'longPrefix' => 'set',
                 'cast' => 'string',
                 'flag' => false,
                 'required' => false,
-                'description' => 'Set the timer mode',
+                'description' => 'Changes the timer mode',
             ],
         ];
     }
@@ -56,52 +114,62 @@ class TimerMode extends ScriptAction
     {
         $report = Report::createInfo(sprintf('The test runner timer mode is currently set to "%s"', $this->getTimerMode()));
 
-        $mode = $this->getOption(self::SET_TIMER_MODE);
-        if ($mode) {
-            if ($this->setTimerMode($mode)) {
-                $report->add(
-                    Report::createSuccess(
-                        sprintf('The test runner timer mode was successfully set to "%s"', $mode)
-                    )
-                );
-            } else {
-                $report->add(
-                    Report::createError(
-                        sprintf('The test runner timer mode "%s" is not supported and it was not applied', $mode)
-                    )
-                );
-            }
+        if ($this->getOption(self::GET_TIMER_MODE)) {
+            return $report;
+        }
+
+        try {
+            $mode = $this->getOption(self::SET_TIMER_MODE);
+
+            $this->validate($mode);
+
+            $this->setTimerMode($mode);
+
+            $report->add(
+                Report::createSuccess(sprintf('The test runner timer mode was successfully set to "%s"', $mode))
+            );
+        } catch (Exception $exception) {
+            $report->add(
+                Report::createError(sprintf('Failed to change the timer mode: %s', $exception->getMessage()))
+            );
         }
 
         return $report;
     }
 
-    private function getExtensionsManagerService()
+    private function validate(?string $mode): void
     {
-        return $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID);
+        if (empty($mode)) {
+            throw new InvalidArgumentException('The timer mode must be provided');
+        }
+
+        if (!in_array($mode, self::SUPPORTED_MODES, true)) {
+            throw new InvalidArgumentException('The timer mode must be one of: ' . implode(', ', self::SUPPORTED_MODES));
+        }
+    }
+
+    private function getExtensionsManagerService(): common_ext_ExtensionsManager
+    {
+        return $this->getServiceLocator()->get(common_ext_ExtensionsManager::SERVICE_ID);
+    }
+
+    private function getExtension(): common_ext_Extension
+    {
+        return $this->getExtensionsManagerService()->getExtensionById('taoQtiTest');
     }
 
     private function getTimerMode(): string
     {
-        /** @var \common_ext_Extension $taoQtiTestExtension */
-        $taoQtiTestExtension = $this->getExtensionsManagerService()->getExtensionById('taoQtiTest');
-        $config = $taoQtiTestExtension->getConfig('testRunner');
+        $config = $this->getExtension()->getConfig(self::CONFIG_FILE);
         return $config['timer']['target'];
     }
 
-    private function setTimerMode(string $mode): bool
+    private function setTimerMode(string $mode): void
     {
-        if (in_array($mode, self::SUPPORTED_MODES, true)) {
-
-            /** @var \common_ext_Extension $taoQtiTestExtension */
-            $taoQtiTestExtension = $this->getExtensionsManagerService()->getExtensionById('taoQtiTest');
-            $config = $taoQtiTestExtension->getConfig('testRunner');
-            $config['timer']['target'] = $mode;
-            $taoQtiTestExtension->setConfig('testRunner', $config);
-
-            return true;
-        }
-
-        return false;
+        $taoQtiTestExtension = $this->getExtension();
+        $taoQtiTestExtension->setConfig(
+            self::CONFIG_FILE,
+            array_replace_recursive($taoQtiTestExtension->getConfig(self::CONFIG_FILE), ['timer' => ['target' => $mode]])
+        );
     }
 }

--- a/scripts/cli/TimerMode.php
+++ b/scripts/cli/TimerMode.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\scripts\cli;
+
+use oat\oatbox\extension\script\ScriptAction;
+use oat\oatbox\reporting\Report;
+
+class TimerMode extends ScriptAction
+{
+    public const SET_TIMER_MODE = 'set';
+    public const SUPPORTED_MODES = [
+        'server',
+        'client'
+    ];
+
+    protected function provideOptions()
+    {
+        return [
+            self::SET_TIMER_MODE => [
+                'prefix' => 's',
+                'longPrefix' => 'set',
+                'cast' => 'string',
+                'flag' => false,
+                'required' => false,
+                'description' => 'Set the timer mode',
+            ],
+        ];
+    }
+
+    protected function provideDescription()
+    {
+        return 'This command sets the test runner timer mode';
+    }
+
+    protected function run()
+    {
+        $report = Report::createInfo(sprintf('The test runner timer mode is currently set to "%s"', $this->getTimerMode()));
+
+        $mode = $this->getOption(self::SET_TIMER_MODE);
+        if ($mode) {
+            if ($this->setTimerMode($mode)) {
+                $report->add(
+                    Report::createSuccess(
+                        sprintf('The test runner timer mode was successfully set to "%s"', $mode)
+                    )
+                );
+            } else {
+                $report->add(
+                    Report::createError(
+                        sprintf('The test runner timer mode "%s" is not supported and it was not applied', $mode)
+                    )
+                );
+            }
+        }
+
+        return $report;
+    }
+
+    private function getExtensionsManagerService()
+    {
+        return $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID);
+    }
+
+    private function getTimerMode(): string
+    {
+        /** @var \common_ext_Extension $taoQtiTestExtension */
+        $taoQtiTestExtension = $this->getExtensionsManagerService()->getExtensionById('taoQtiTest');
+        $config = $taoQtiTestExtension->getConfig('testRunner');
+        return $config['timer']['target'];
+    }
+
+    private function setTimerMode(string $mode): bool
+    {
+        if (in_array($mode, self::SUPPORTED_MODES, true)) {
+
+            /** @var \common_ext_Extension $taoQtiTestExtension */
+            $taoQtiTestExtension = $this->getExtensionsManagerService()->getExtensionById('taoQtiTest');
+            $config = $taoQtiTestExtension->getConfig('testRunner');
+            $config['timer']['target'] = $mode;
+            $taoQtiTestExtension->setConfig('testRunner', $config);
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/scripts/cli/TimerMode.php
+++ b/scripts/cli/TimerMode.php
@@ -100,7 +100,7 @@ class TimerMode extends ScriptAction
                 'cast' => 'string',
                 'flag' => false,
                 'required' => false,
-                'description' => 'Changes the timer mode',
+                'description' => 'Changes the timer mode (valid values: "server", "client")',
             ],
         ];
     }


### PR DESCRIPTION
### BREAKING CHANGE
**This is considered as a breaking change as every new installation of TAO will be configured with client-side timers.**

### Description
Related to: https://oat-sa.atlassian.net/browse/TR-2836

Change the default configuration for the timer handling to `client`.
This means from new installed TAO, the test runner will process the timer value given by the client instead of only relying on the server controlled timers.

The benefit is the timer countdown will be fine grained, taking care of the client interruptions like page refresh or the navigation between items. It will also prevent the timer to silently continue on the sever when the page is closed. As the timer is also stored locally in the client, the next time the page will open, the timer will be resumed at the latest recorded position.

With the server timer, these kind of interruptions were not taken into account. Especially, when the page is closed, the timer is not paused and continues to decrease on the background, so that the next time the page is open, the timer will have a lesser value or it may be timed out.

**Note:** this PR does not update the configuration for existing installs. To do so, a command-line script is supplied: `php index.php '\oat\taoQtiTest\scripts\cli\TimerMode'`. Without parameters, it will display the current setting.

To set a different timer mode, use the `-s` or `--set` parameter together with the new value, like: `php index.php '\oat\taoQtiTest\scripts\cli\TimerMode' -s client`

### How to test
- Install the extension or run the CLI script to change the mode.
- Take a test having a timer
- Close the page, then reopen it later, the timer should resume at the exact place it was left (a second could have elapsed due to time rounding since the timer is internally managed in milliseconds but displayed in seconds)