### PR TITLE
fix: check id of moved items

### DIFF
--- a/views/js/controller/creator/helpers/validators.js
+++ b/views/js/controller/creator/helpers/validators.js
@@ -191,10 +191,24 @@ define([
         }
         return identifiers;
     }
+
+    /**
+     * Gives you a validator that check QTI id format
+     * @param {String} value of identifier
+     * @param {Object} modelOverseer - let's you get the data model
+     * @returns {Boolean} isValid
+     */
+    function checkIfItemIdValid(value, modelOverseer) {
+        const identifiers = extractIdentifiers(modelOverseer.getModel(), qtiTypesForUniqueIds);
+        const key = value.toUpperCase();
+        const counts = _.countBy(identifiers, 'identifier');
+        return qtiIdPattern.test(value) && counts[key] === 1;
+    }
     return {
         qtiTypesForUniqueIds,
         extractIdentifiers,
         registerValidators,
-        validateModel
+        validateModel,
+        checkIfItemIdValid
     };
 });

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -35,7 +35,8 @@ define([
     'taoQtiTest/controller/creator/helpers/sectionBlueprints',
     'taoQtiTest/controller/creator/views/subsection',
     'ui/dialog/confirm',
-    'taoQtiTest/controller/creator/helpers/subsection'
+    'taoQtiTest/controller/creator/helpers/subsection',
+    'taoQtiTest/controller/creator/helpers/validators'
 ], function (
     $,
     _,
@@ -52,7 +53,8 @@ define([
     sectionBlueprint,
     subsectionView,
     confirmDialog,
-    subsectionsHelper
+    subsectionsHelper,
+    validators
 ) {
     'use strict';
 
@@ -271,25 +273,29 @@ define([
             // jquesry issue to select id with dot by '#ab.cd', should be used [id="ab.cd"]
             $(document)
                 .off('add.binder', `[id="${$section.attr('id')}"] > .itemrefs-wrapper .itemrefs`)
-                .on('add.binder', `[id="${$section.attr('id')}"] > .itemrefs-wrapper .itemrefs`, function (e, $itemRef) {
-                    if (
-                        e.namespace === 'binder' &&
-                        $itemRef.hasClass('itemref') &&
-                        !$itemRef.parents('.subsection').length
-                    ) {
-                        const index = $itemRef.data('bind-index');
-                        const itemRefModel = sectionModel.sectionParts[index];
+                .on(
+                    'add.binder',
+                    `[id="${$section.attr('id')}"] > .itemrefs-wrapper .itemrefs`,
+                    function (e, $itemRef) {
+                        if (
+                            e.namespace === 'binder' &&
+                            $itemRef.hasClass('itemref') &&
+                            !$itemRef.parents('.subsection').length
+                        ) {
+                            const index = $itemRef.data('bind-index');
+                            const itemRefModel = sectionModel.sectionParts[index];
 
-                        //initialize the new item ref
-                        itemRefView.setUp(creatorContext, itemRefModel, sectionModel, partModel, $itemRef);
+                            //initialize the new item ref
+                            itemRefView.setUp(creatorContext, itemRefModel, sectionModel, partModel, $itemRef);
 
-                        /**
-                         * @event modelOverseer#item-add
-                         * @param {Object} itemRefModel
-                         */
-                        modelOverseer.trigger('item-add', itemRefModel);
+                            /**
+                             * @event modelOverseer#item-add
+                             * @param {Object} itemRefModel
+                             */
+                            modelOverseer.trigger('item-add', itemRefModel);
+                        }
                     }
-                });
+                );
         }
 
         /**
@@ -363,25 +369,29 @@ define([
             // jquesry issue to select id with dot by '#ab.cd', should be used [id="ab.cd"]
             $(document)
                 .off('add.binder', `[id="${$section.attr('id')}"] > .rublocks .rubricblocks`)
-                .on('add.binder', `[id="${$section.attr('id')}"] > .rublocks .rubricblocks`, function (e, $rubricBlock) {
-                    if (
-                        e.namespace === 'binder' &&
-                        $rubricBlock.hasClass('rubricblock') &&
-                        !$rubricBlock.parents('.subsection').length
-                    ) {
-                        const index = $rubricBlock.data('bind-index');
-                        const rubricModel = sectionModel.rubricBlocks[index] || {};
+                .on(
+                    'add.binder',
+                    `[id="${$section.attr('id')}"] > .rublocks .rubricblocks`,
+                    function (e, $rubricBlock) {
+                        if (
+                            e.namespace === 'binder' &&
+                            $rubricBlock.hasClass('rubricblock') &&
+                            !$rubricBlock.parents('.subsection').length
+                        ) {
+                            const index = $rubricBlock.data('bind-index');
+                            const rubricModel = sectionModel.rubricBlocks[index] || {};
 
-                        $('.rubricblock-binding', $rubricBlock).html('<p>&nbsp;</p>');
-                        rubricBlockView.setUp(creatorContext, rubricModel, $rubricBlock);
+                            $('.rubricblock-binding', $rubricBlock).html('<p>&nbsp;</p>');
+                            rubricBlockView.setUp(creatorContext, rubricModel, $rubricBlock);
 
-                        /**
-                         * @event modelOverseer#rubric-add
-                         * @param {Object} rubricModel
-                         */
-                        modelOverseer.trigger('rubric-add', rubricModel);
+                            /**
+                             * @event modelOverseer#rubric-add
+                             * @param {Object} rubricModel
+                             */
+                            modelOverseer.trigger('rubric-add', rubricModel);
+                        }
                     }
-                });
+                );
         }
 
         /**
@@ -540,15 +550,17 @@ define([
                         );
                         const acceptFunction = () => {
                             // trigger deleted event for each itemfer to run removePropHandler and remove propView
-                            $('.itemrefs .itemref', $itemRefsWrapper).each(function() {
+                            $('.itemrefs .itemref', $itemRefsWrapper).each(function () {
                                 $section.parents('.testparts').trigger('deleted.deleter', [$(this)]);
                             });
                             setTimeout(() => {
                                 // remove all itemrefs
                                 $('.itemrefs', $itemRefsWrapper).empty();
-                                // check itemrefs identifiers, because validation is build on <span id="props-{identifier}"> and each item should have unique id
+                                // check itemrefs identifiers
+                                // because validation is build on <span id="props-{identifier}">
+                                // and each item should have valid and unique id
                                 sectionModel.sectionParts.forEach(itemRef => {
-                                    if (!itemRef.identifier) {
+                                    if(!validators.checkIfItemIdValid(itemRef.identifier, modelOverseer)) {
                                         itemRef.identifier = qtiTestHelper.getAvailableIdentifier(
                                             modelOverseer.getModel(),
                                             'assessmentItemRef',

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -539,10 +539,27 @@ define([
                             defaults().sectionTitlePrefix
                         );
                         const acceptFunction = () => {
-                            $section.data('movedItems', _.clone(sectionModel.sectionParts));
-                            sectionModel.sectionParts = [];
-                            $('.itemrefs', $itemRefsWrapper).empty();
-                            executeAdd();
+                            // trigger deleted event for each itemfer to run removePropHandler and remove propView
+                            $('.itemrefs .itemref', $itemRefsWrapper).each(function() {
+                                $section.parents('.testparts').trigger('deleted.deleter', [$(this)]);
+                            });
+                            setTimeout(() => {
+                                // remove all itemrefs
+                                $('.itemrefs', $itemRefsWrapper).empty();
+                                // check itemrefs identifiers, because validation is build on <span id="props-{identifier}"> and each item should have unique id
+                                sectionModel.sectionParts.forEach(itemRef => {
+                                    if (!itemRef.identifier) {
+                                        itemRef.identifier = qtiTestHelper.getAvailableIdentifier(
+                                            modelOverseer.getModel(),
+                                            'assessmentItemRef',
+                                            'item'
+                                        );
+                                    }
+                                });
+                                $section.data('movedItems', _.clone(sectionModel.sectionParts));
+                                sectionModel.sectionParts = [];
+                                executeAdd();
+                            }, 0);
                         };
                         confirmDialog(confirmMessage, acceptFunction, () => {}, optionsConfirmDialog)
                             .getDom()

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -553,10 +553,27 @@ define([
                             defaults().sectionTitlePrefix
                         );
                         const acceptFunction = () => {
-                            $subsection.data('movedItems', _.clone(subsectionModel.sectionParts));
-                            subsectionModel.sectionParts = [];
-                            $('.itemrefs', $itemRefsWrapper).empty();
-                            executeAdd();
+                            // trigger deleted event for each itemfer to run removePropHandler and remove propView
+                            $('.itemrefs .itemref', $itemRefsWrapper).each(function() {
+                                $subsection.parents('.testparts').trigger('deleted.deleter', [$(this)]);
+                            });
+                            setTimeout(() => {
+                                // remove all itemrefs
+                                $('.itemrefs', $itemRefsWrapper).empty();
+                                // check itemrefs identifiers, because validation is build on <span id="props-{identifier}"> and each item should have unique id
+                                subsectionModel.sectionParts.forEach(itemRef => {
+                                    if (!itemRef.identifier) {
+                                        itemRef.identifier = qtiTestHelper.getAvailableIdentifier(
+                                            modelOverseer.getModel(),
+                                            'assessmentItemRef',
+                                            'item'
+                                        );
+                                    }
+                                });
+                                $subsection.data('movedItems', _.clone(subsectionModel.sectionParts));
+                                subsectionModel.sectionParts = [];
+                                executeAdd();
+                            }, 0);
                         };
                         confirmDialog(confirmMessage, acceptFunction, () => {}, optionsConfirmDialog)
                             .getDom()

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -31,7 +31,8 @@ define([
     'taoQtiTest/controller/creator/helpers/sectionCategory',
     'taoQtiTest/controller/creator/helpers/sectionBlueprints',
     'ui/dialog/confirm',
-    'taoQtiTest/controller/creator/helpers/subsection'
+    'taoQtiTest/controller/creator/helpers/subsection',
+    'taoQtiTest/controller/creator/helpers/validators'
 ], function (
     $,
     _,
@@ -47,7 +48,8 @@ define([
     sectionCategory,
     sectionBlueprint,
     confirmDialog,
-    subsectionsHelper
+    subsectionsHelper,
+    validators
 ) {
     'use strict';
     /**
@@ -554,15 +556,17 @@ define([
                         );
                         const acceptFunction = () => {
                             // trigger deleted event for each itemfer to run removePropHandler and remove propView
-                            $('.itemrefs .itemref', $itemRefsWrapper).each(function() {
+                            $('.itemrefs .itemref', $itemRefsWrapper).each(function () {
                                 $subsection.parents('.testparts').trigger('deleted.deleter', [$(this)]);
                             });
                             setTimeout(() => {
                                 // remove all itemrefs
                                 $('.itemrefs', $itemRefsWrapper).empty();
-                                // check itemrefs identifiers, because validation is build on <span id="props-{identifier}"> and each item should have unique id
+                                // check itemrefs identifiers
+                                // because validation is build on <span id="props-{identifier}">
+                                // and each item should have valid and unique id
                                 subsectionModel.sectionParts.forEach(itemRef => {
-                                    if (!itemRef.identifier) {
+                                    if (!validators.checkIfItemIdValid(itemRef.identifier, modelOverseer)) {
                                         itemRef.identifier = qtiTestHelper.getAvailableIdentifier(
                                             modelOverseer.getModel(),
                                             'assessmentItemRef',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1878

**Precondition:**

- Item created
- Test with one section contained Item created

**Steps to reproduce**

- Open Test in Authoring
- Click on the gear symbol that is located to the right the name of the Item (not to be confused with Section, above that)
- Remove Item Identifier
- Add Subsection
- Click on the gear symbol that is located to the right the name of the Item
- Enter any valid Item ID (e.g. Item_1) and click "Save"

**Actual result:** Some errors appear in Console. The message The test cannot be saved because it currently contains invalid settings.
Please fix the invalid settings and try again.  pops-up. Test cannot be saved.

**Expected result:** No errors in console. Test saved.