### PR TITLE
Bugfix TR-3532 async result transmission

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "qtism/qtism": "^0.25.0",
-    "oat-sa/generis" : ">=15.5.0",
+    "oat-sa/generis" : ">=15.17.1",
     "oat-sa/tao-core" : ">=48.71.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",
     "oat-sa/extension-tao-itemqti" : ">=28.35.0",


### PR DESCRIPTION
# [TR-3532](https://oat-sa.atlassian.net/browse/TR-3532)

## Summary 
clear `QtiFlysystemFile` from Injected `Flysystem` client at async result transmission

## Depends on
https://github.com/oat-sa/generis/pull/979

## How to test
- install `oat-sa/lib-generis-aws`
- configure `config/generis/awsClient.conf.php` and `config/generis/filesystem.conf.php` corresponding [this article](https://oat-sa.atlassian.net/wiki/spaces/INFOSIGN/pages/1651376266/Setup+S3+Filesystem+persistence)
- configure asynchronous result variables transmission but next command
```bash
sudo -u www-data php index.php 'oat\taoQtiTest\scripts\tools\ResultVariableTransmissionEvenHandlerSwitcher' -c 'oat\taoQtiTest\models\classes\eventHandler\ResultTransmissionEventHandler\AsynchronousResultTransmissionEventHandler'
```
- create delivery for test with audio record item
- execute this delivery 
- no error will be provided and results with record will be available on result page