### PR TITLE
fix: add specificity to disable function, only disabling specific icon

### DIFF
--- a/views/js/controller/creator/views/actions.js
+++ b/views/js/controller/creator/views/actions.js
@@ -189,7 +189,12 @@ define([
      * @param {String} actionContainerElt - the element name that contains the actions
      */
     function disable($container, actionContainerElt) {
-        $container.children(actionContainerElt).find('[data-delete],.move-up,.move-down').addClass(disabledClass);
+
+        if(actionContainerElt === 'h1'){
+            $($container.children(actionContainerElt).prevObject).find('[data-delete],.move-up,.move-down').addClass(disabledClass);
+        } else {
+            $($container.children(actionContainerElt).context).find('[data-delete],.move-up,.move-down').addClass(disabledClass);
+        }
     }
 
     /**

--- a/views/js/controller/creator/views/actions.js
+++ b/views/js/controller/creator/views/actions.js
@@ -190,7 +190,7 @@ define([
      */
     function disable($container, actionContainerElt) {
 
-        if ($container.length <= 2){
+        if ($container.length <= 2 && !$($container.prevObject.context).hasClass('itemref')){
         $container.children(actionContainerElt).find('[data-delete]').addClass(disabledClass);
         }
     }

--- a/views/js/controller/creator/views/actions.js
+++ b/views/js/controller/creator/views/actions.js
@@ -190,7 +190,7 @@ define([
      */
     function disable($container, actionContainerElt) {
 
-        if ($container.length <= 2 && !$($container.prevObject.context).hasClass('itemref')){
+        if ($container.length <= 2){
         $container.children(actionContainerElt).find('[data-delete]').addClass(disabledClass);
         }
     }

--- a/views/js/controller/creator/views/actions.js
+++ b/views/js/controller/creator/views/actions.js
@@ -190,10 +190,8 @@ define([
      */
     function disable($container, actionContainerElt) {
 
-        if(actionContainerElt === 'h1'){
-            $($container.children(actionContainerElt).prevObject).find('[data-delete],.move-up,.move-down').addClass(disabledClass);
-        } else {
-            $($container.children(actionContainerElt).context).find('[data-delete],.move-up,.move-down').addClass(disabledClass);
+        if ($container.length <= 2){
+        $container.children(actionContainerElt).find('[data-delete]').addClass(disabledClass);
         }
     }
 

--- a/views/js/controller/creator/views/itemref.js
+++ b/views/js/controller/creator/views/itemref.js
@@ -300,7 +300,6 @@ function(
                 var $target = $(e.target);
                 if($target.hasClass('itemref')){
                     $parent = $target.parents('.itemrefs');
-                    actions.disable($parent.find('.itemref'), '.actions');
                 }
             })
             .on('add change undo.deleter deleted.deleter', '.itemrefs',  function(e){

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -646,7 +646,6 @@ define([
             .on('delete', function (e) {
                 const $target = $(e.target);
                 if ($target.hasClass('subsection')) {
-                    actions.disable(subsectionsHelper.getSiblingSubsections($target), 'h2');
                     const $parent = subsectionsHelper.getParent($target);
                     setTimeout(() => {
                         actions.displayItemWrapper($parent);

--- a/views/js/controller/creator/views/testpart.js
+++ b/views/js/controller/creator/views/testpart.js
@@ -158,7 +158,7 @@ define([
             .on('delete', function (e) {
                 const $target = $(e.target);
                 if ($target.hasClass('testpart')) {
-                    actions.disable($('.testpart'), 'h1');
+                    actions.disable($(e.target.id), 'h1');
                 }
             })
             .on('add change undo.deleter deleted.deleter', function (e) {


### PR DESCRIPTION
Related to Issue: https://oat-sa.atlassian.net/browse/AUT-1502

Fix all icons inactive when deleting one item, section or test part.

**SETPS to test:**
• Checkout to branch: fix/AUT-1502/all-bin-icons-inactive-after-one-removed
• Create a test and add test parts, sections, subsections and items
• Delete any of the elements in the test.

**ACTUAL RESULT:**
All bin elements for that type of elements go disabled for a few seconds but still clickable.

**EXPECTED RESULT:**
'Trash bin' icons remain visually enabled unless only 1 element (item/section/part) is left.
Only the selected bin icon for the deleted element goes inactive for a few seconds before being deleted


CHANGES:
Increased specificity in selectors for disabling function