### PR TITLE
Use `ExtensionMimeTypeDetector` class to detect mime-type by file name when `File::getMimeType` returns `text/plain` in `QtiFlysysttemFile`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
     "oat-sa/extension-tao-itemqti" : ">=28.35.0",
     "oat-sa/extension-tao-test" : ">=15.0.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
-    "oat-sa/extension-tao-outcome" : ">=13.0.0"
+    "oat-sa/extension-tao-outcome" : ">=13.0.0",
+    "league/flysystem": "~1.0"
   },
   "autoload": {
     "psr-4": {

--- a/models/classes/files/QtiFlysystemFile.php
+++ b/models/classes/files/QtiFlysystemFile.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoQtiTest\models\files;
 
+use League\MimeTypeDetection\ExtensionMimeTypeDetector;
 use oat\oatbox\filesystem\File;
 use qtism\common\datatypes\QtiFile;
 use qtism\common\enums\BaseType;
@@ -43,7 +44,17 @@ class QtiFlysystemFile extends File implements QtiFile
     
     public function getMimeType()
     {
-        return parent::getMimeType();
+        $mimeType = parent::getMimeType();
+
+        // The parent function will return "text/plain" when the mime type can't be detected. As the last resort,
+        // we use the original file name when available to try to detect its mime type.
+        if ($mimeType === 'text/plain' && $this->hasFilename()) {
+            $mimeTypeDetector = new ExtensionMimeTypeDetector();
+
+            $mimeType = $mimeTypeDetector->detectMimeTypeFromFile($this->getFilename()) ?? $mimeType;
+        }
+
+        return $mimeType;
     }
     
     public function hasFilename()


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-3354

## Summary
The mime type of some files can not be detected properly from file headers and the current file name doesn't have the file extension. This change uses the original file name to try to detect the mime-type for those scenarios.

## How to test
1. Create an item with Audio Recording interaction.
2. Create a test with the item from step 1. and publish it.
3. Launch the test via LTI.
4. Navigate to the item with Audio Recording interaction.
5. Launch the Test in Review mode.
6. Open the item with the Audio interaction for reviewing.

## Sandbox environment
https://delivery.test-infosign.playground.kitchen.it.taocloud.org