### PR TITLE
fix: also consider `application/octet-stream` as generic type in QtiFlysystemFile

### DIFF
--- a/models/classes/files/QtiFlysystemFile.php
+++ b/models/classes/files/QtiFlysystemFile.php
@@ -48,7 +48,10 @@ class QtiFlysystemFile extends File implements QtiFile
 
         // The parent function will return "text/plain" when the mime type can't be detected. As the last resort,
         // we use the original file name when available to try to detect its mime type.
-        if ($mimeType === 'text/plain' && $this->hasFilename()) {
+        if (
+            in_array($mimeType, ['text/plain', 'application/octet-stream'])
+            && $this->hasFilename()
+        ) {
             $mimeTypeDetector = new ExtensionMimeTypeDetector();
 
             $mimeType = $mimeTypeDetector->detectMimeTypeFromFile($this->getFilename()) ?? $mimeType;


### PR DESCRIPTION
## Ticket
Triggered by https://oat-sa.atlassian.net/browse/TR-3241
Relates to https://oat-sa.atlassian.net/browse/TR-3354

## Summary
The AWS adapter for Flysystem returns a different default type `application/octet-stream` when the mime type can't be detected. This change also considers this type while detecting the mime type by file name.

## How to test
1. Create an item with Audio Recording interaction.
2. Create a test with the item from step 1. and publish it.
3. Launch the test via LTI.
4. Navigate to the item with Audio Recording interaction.
5. Launch the Test in Review mode.
6. Open the item with the Audio interaction for reviewing.

## Sandbox environment
https://infosign-test.lab.taocloud.org/