### PR TITLE
Feature/aut 1854/testpart category presets

### DIFF
--- a/views/js/controller/creator/helpers/testPartCategory.js
+++ b/views/js/controller/creator/helpers/testPartCategory.js
@@ -1,0 +1,173 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+define([
+    'lodash',
+    'i18n',
+    'taoQtiTest/controller/creator/helpers/sectionCategory',
+    'core/errorHandler'
+], function(_, __, sectionCategory, errorHandler) {
+    'use strict';
+
+    const _ns = '.testPartCategory';
+
+    /**
+     * Check if the given object is a valid testPart model object
+     *
+     * @param {object} model
+     * @returns {boolean}
+     */
+    function isValidTestPartModel(model) {
+        return _.isObject(model)
+            && model['qti-type'] === 'testPart'
+            && _.isArray(model.assessmentSections)
+            && model.assessmentSections.every(section => sectionCategory.isValidSectionModel(section));
+    }
+
+    /**
+     * Set an array of categories to the testPart model (affects the children itemRef, and after propagation, the section models)
+     *
+     * @param {object} model
+     * @param {array} selected - all categories active for the whole testPart
+     * @param {array} partial - only categories in an indeterminate state
+     * @returns {undefined}
+     */
+    function setCategories(model, selected, partial = []) {
+
+        const currentCategories = getCategories(model);
+
+        // partial = partial || [];
+
+        //the categories that are no longer in the new list of categories should be removed
+        const toRemove = _.difference(currentCategories.all, selected.concat(partial));
+
+        //the categories that are not in the current categories collection should be added to the children
+        const toAdd = _.difference(selected, currentCategories.propagated);
+
+        model.categories = _.difference(model.categories, toRemove);
+        model.categories = model.categories.concat(toAdd);
+
+        //process the modification
+        addCategories(model, toAdd);
+        removeCategories(model, toRemove);
+    }
+
+    /**
+     * Get the categories assigned to the testPart model, inferred by its internal itemRefs
+     *
+     * @param {object} model
+     * @returns {object}
+     */
+    function getCategories(model) {
+        if (!isValidTestPartModel(model)) {
+            return errorHandler.throw(_ns, 'invalid tool config format');
+        }
+
+        let itemCount = 0;
+
+        // Should be: [[i1c], [i2c], [i3c], ...]
+        const categories = _.flatten(
+            _.map(model.assessmentSections, function(section) {
+                return _.map(section.sectionParts, function(itemRef) {
+                    if (itemRef['qti-type'] === 'assessmentItemRef' && ++itemCount && _.isArray(itemRef.categories)) {
+                        return _.compact(itemRef.categories); // [i1c]
+                    }
+                });
+            }),
+            true // flatten depth: 1
+        );
+
+        if (!itemCount) {
+            return createCategories(model.categories, model.categories);
+        }
+
+        //array of categories
+        const arrays = _.values(categories);
+        const union = _.union.apply(null, arrays);
+
+        //categories that are common to all itemRef
+        const propagated = _.intersection.apply(null, arrays);
+
+        //the categories that are only partially covered on the section level : complementary of "propagated"
+        const partial = _.difference(union, propagated);
+
+        return createCategories(union, propagated, partial);
+    }
+
+    /**
+     * Add an array of categories to a testPart model (affects the children itemRef, and after propagation, the section models)
+     *
+     * @param {object} model
+     * @param {array} categories
+     * @returns {undefined}
+     */
+    function addCategories(model, categories) {
+        if (isValidTestPartModel(model)) {
+            _.each(model.assessmentSections, function(section) {
+                _.each(section.sectionParts, function(itemRef) {
+                    if (itemRef['qti-type'] === 'assessmentItemRef') {
+                        if (!_.isArray(itemRef.categories)) {
+                            itemRef.categories = [];
+                        }
+                        itemRef.categories = _.union(itemRef.categories, categories);
+                    }
+                });
+            });
+        } else {
+            errorHandler.throw(_ns, 'invalid tool config format');
+        }
+    }
+
+    /**
+     * Remove an array of categories from a testPart model (affects the children itemRef, and after propagation, the section models)
+     *
+     * @param {object} model
+     * @param {array} categories
+     * @returns {undefined}
+     */
+    function removeCategories(model, categories) {
+        if (isValidTestPartModel(model)) {
+            _.each(model.assessmentSections, function(section) {
+                _.each(section.sectionParts, function(itemRef) {
+                    if (itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)) {
+                        itemRef.categories = _.difference(itemRef.categories, categories);
+                    }
+                });
+            });
+        } else {
+            errorHandler.throw(_ns, 'invalid tool config format');
+        }
+    }
+
+    function createCategories(all = [], propagated = [], partial = []) {
+        return _.mapValues({
+            all: all,
+            propagated: propagated,
+            partial: partial
+        }, function(categories) {
+            return categories.sort();
+        });
+    }
+
+    return {
+        isValidTestPartModel : isValidTestPartModel,
+        setCategories : setCategories,
+        getCategories : getCategories,
+        addCategories : addCategories,
+        removeCategories : removeCategories
+    };
+});

--- a/views/js/controller/creator/templates/testpart-props.tpl
+++ b/views/js/controller/creator/templates/testpart-props.tpl
@@ -94,6 +94,26 @@
             </div>
         </div>
 
+        <div class="categories">
+            <div class="grid-row">
+                <div class="col-5">
+                    <label for="category-custom">{{__ 'Categories'}}</label>
+                </div>
+                <div class="col-6">
+                    <input type="text" id="category-custom" name="category-custom"/>
+                </div>
+                <div class="col-1 help">
+                    <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
+                    <div class="tooltip-content">
+                        {{__ 'Test part level category enables configuring the categories of its composing items all at once. A category in gray means that all items have that category. A category in white means that only a few items have that category.'}}
+                    </div>
+                </div>
+            </div>
+
+            <!-- some user features (Test Navigation, Test Taker Tools, etc.) are in fact implemented as categories. They will appear here: -->
+            <div class="category-presets"></div>
+        </div>
+
         <h4 class="toggler closed" data-toggle="~ .testpart-item-session-control">{{__ 'Item Session Control'}}</h4>
 
 

--- a/views/js/controller/creator/views/actions.js
+++ b/views/js/controller/creator/views/actions.js
@@ -235,23 +235,32 @@ define([
     /**
      * Hides/shows category-presets (Test Navigation, Navigation Warnings, Test-Taker Tools)
      * Hide category-presets for section that contains subsections
-     * @param {jQueryElement} $section
+     * @param {jQueryElement} $authoringContainer
+     * @param {string} [scope='section'] // can also be 'testpart'
      * @fires propertiesView#set-default-categories
      */
-    function displayCategoryPresets($section) {
-        const id = $section.attr('id');
-        const $propertiesView = $(`.test-creator-props #section-props-${id}`);
+    function displayCategoryPresets($authoringContainer, scope = 'section') {
+        const id = $authoringContainer.attr('id');
+        const $propertiesView = $(`.test-creator-props #${scope}-props-${id}`);
         if (!$propertiesView.length) {
             // property view is not setup
             return;
         }
         const $elt = $propertiesView.find('.category-presets');
-        const subsectionsCount = subsectionsHelper.getSubsections($section).length;
-        if (subsectionsCount) {
-            $elt.hide();
-            $propertiesView.trigger('set-default-categories');
-        } else {
-            $elt.show();
+        switch (scope) {
+            case 'testpart':
+                $elt.show();
+                break;
+
+            case 'section':
+                const subsectionsCount = subsectionsHelper.getSubsections($authoringContainer).length;
+                if (subsectionsCount) {
+                    $elt.hide();
+                    $propertiesView.trigger('set-default-categories');
+                } else {
+                    $elt.show();
+                }
+                break;
         }
     }
 

--- a/views/js/controller/creator/views/testpart.js
+++ b/views/js/controller/creator/views/testpart.js
@@ -26,8 +26,10 @@ define([
     'taoQtiTest/controller/creator/views/actions',
     'taoQtiTest/controller/creator/views/section',
     'taoQtiTest/controller/creator/templates/index',
-    'taoQtiTest/controller/creator/helpers/qtiTest'
-], function ($, _, defaults, actions, sectionView, templates, qtiTestHelper) {
+    'taoQtiTest/controller/creator/helpers/qtiTest',
+    'taoQtiTest/controller/creator/helpers/testPartCategory',
+    'taoQtiTest/controller/creator/helpers/categorySelector'
+], function ($, _, defaults, actions, sectionView, templates, qtiTestHelper, testPartCategory, categorySelectorFactory) {
     'use strict';
 
     /**
@@ -76,6 +78,11 @@ define([
                     propView.destroy();
                 }
             });
+
+            //testPart level category configuration
+            categoriesProperty($view);
+
+            actions.displayCategoryPresets($testPart, 'testpart');
         }
 
         /**
@@ -120,6 +127,7 @@ define([
                         sectionParts: [],
                         visible: true
                     });
+                    // TODO: new section to inherit categories from testPart?
                 }
             });
 
@@ -142,6 +150,40 @@ define([
                         modelOverseer.trigger('section-add', sectionModel);
                     }
                 });
+        }
+
+        /**
+         * Set up the category property
+         * @private
+         * @param {jQuery} $view - the $view object containing the $select
+         * @fires modelOverseer#category-change
+         */
+        function categoriesProperty($view) {
+            const categories = testPartCategory.getCategories(partModel);
+            const categorySelector = categorySelectorFactory($view);
+
+            categorySelector.createForm(categories.all);
+            updateFormState(categorySelector);
+
+            $view.on('propopen.propview', function () {
+                updateFormState(categorySelector);
+            });
+
+            $view.on('set-default-categories', function () {
+                partModel.categories = defaults().categories;
+                updateFormState(categorySelector);
+            });
+
+            categorySelector.on('category-change', function (selected, indeterminate) {
+                testPartCategory.setCategories(partModel, selected, indeterminate);
+
+                modelOverseer.trigger('category-change');
+            });
+        }
+
+        function updateFormState(categorySelector) {
+            const categories = testPartCategory.getCategories(partModel);
+            categorySelector.updateFormState(categories.propagated, categories.partial);
         }
     }
 

--- a/views/js/test/creator/helpers/testPartCategory/test.html
+++ b/views/js/test/creator/helpers/testPartCategory/test.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Authoring - TestPart Category Helper</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+
+        <script  type="text/javascript">
+            QUnit.config.autostart = false;
+            require(['/tao/ClientConfig/config'], function() {
+                require(['taoQtiTest/test/creator/helpers/testPartCategory/test'], function() {
+                    QUnit.config.reorder = false;
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="tools-container"></div>
+        </div>
+    </body>
+</html>

--- a/views/js/test/creator/helpers/testPartCategory/test.js
+++ b/views/js/test/creator/helpers/testPartCategory/test.js
@@ -1,0 +1,180 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+define([
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/testPartCategory'
+], function(_, testPartCategory) {
+    'use strict';
+
+    const _testPartModel = {
+        'qti-type': 'testPart',
+        assessmentSections: [
+            {
+                'qti-type': 'assessmentSection',
+                sectionParts: [
+                    {
+                        'qti-type': 'assessmentItemRef',
+                        categories: ['A', 'B']
+                    },
+                    {
+                        'qti-type': 'assessmentItemRef',
+                        categories: ['A', 'B']
+                    }
+                ]
+            },
+            {
+                'qti-type': 'assessmentSection',
+                sectionParts: [
+                    {
+                        'qti-type': 'assessmentItemRef',
+                        categories: ['A', 'B', 'C', 'D']
+                    },
+                    {
+                        'qti-type': 'assessmentItemRef',
+                        categories: ['A', 'B', 'D', 'E', 'F']
+                    }
+                ]
+            },
+        ]
+    };
+
+    QUnit.test('isValidTestPartModel', function(assert) {
+        assert.ok(testPartCategory.isValidTestPartModel(_testPartModel));
+
+        assert.notOk(testPartCategory.isValidTestPartModel({
+            'qti-type': 'assessmentItemRef',
+            categories: ['A', 'B', 'C', 'D']
+        }));
+
+        assert.notOk(testPartCategory.isValidTestPartModel({
+            'qti-type': 'assessmentSection',
+            sectionParts: []
+        }));
+
+        assert.notOk(testPartCategory.isValidTestPartModel({
+            'qti-type': 'testPart',
+            assessmentSections: null
+        }));
+
+        assert.notOk(testPartCategory.isValidTestPartModel({
+            'qti-type': 'testPart',
+            assessmentSections: [
+                {
+                    'qti-type': 'assessmentSection',
+                    sectionParts: null
+                }
+            ]
+        }));
+    });
+
+    QUnit.test('getCategories', function(assert) {
+        const testPartModel = _.cloneDeep(_testPartModel);
+        const categories = testPartCategory.getCategories(testPartModel);
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+    });
+
+    QUnit.test('addCategories', function(assert) {
+        const testPartModel = _.cloneDeep(_testPartModel);
+        let categories = testPartCategory.getCategories(testPartModel);
+
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //Add a new category
+        testPartCategory.addCategories(testPartModel, ['G']);
+        categories = testPartCategory.getCategories(testPartModel);
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //Try adding an exiting one
+        testPartCategory.addCategories(testPartModel, ['A', 'C']);
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F', 'G'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B', 'G'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+    });
+
+    QUnit.test('removeCategories', function(assert) {
+        const testPartModel = _.cloneDeep(_testPartModel);
+        let categories = testPartCategory.getCategories(testPartModel);
+
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //Remove one element from the propagated categories
+        testPartCategory.removeCategories(testPartModel, ['A']);
+        categories = testPartCategory.getCategories(testPartModel);
+        assert.deepEqual(categories.all, ['B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //Remove one element from the partial categories
+        testPartCategory.removeCategories(testPartModel, ['F']);
+        categories = testPartCategory.getCategories(testPartModel);
+        assert.deepEqual(categories.all, ['B', 'C', 'D', 'E'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E'], 'partial categories found');
+
+        //Remove one element on each group of categories (propagated+partial)
+        testPartCategory.removeCategories(testPartModel, ['B', 'D']);
+        categories = testPartCategory.getCategories(testPartModel);
+        assert.deepEqual(categories.all, ['C', 'E'], 'all categories found');
+        assert.deepEqual(categories.propagated, [], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'E'], 'partial categories found');
+    });
+
+    QUnit.test('setCategories', function(assert) {
+        const testPartModel = _.cloneDeep(_testPartModel);
+        let categories = testPartCategory.getCategories(testPartModel);
+
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        //Remove B, E and F and add G
+        testPartCategory.setCategories(testPartModel, ['A', 'G'], ['C', 'D']);
+
+        //Check result
+        categories = testPartCategory.getCategories(testPartModel);
+        assert.deepEqual(categories.all, ['A', 'C', 'D', 'G'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'G'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D'], 'partial categories found');
+    });
+
+    QUnit.test('setCategories: handle indeterminated/partial add and removal', function(assert) {
+        const testPartModel = _.cloneDeep(_testPartModel);
+        let categories = testPartCategory.getCategories(testPartModel);
+
+        assert.deepEqual(categories.all, ['A', 'B', 'C', 'D', 'E', 'F'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['A', 'B'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['C', 'D', 'E', 'F'], 'partial categories found');
+
+        // Remove A, propagate C, remove F, add G
+        testPartCategory.setCategories(testPartModel, ['B', 'C', 'G'], ['D', 'E']);
+
+        //Check result
+        categories = testPartCategory.getCategories(testPartModel);
+        assert.deepEqual(categories.all, ['B', 'C', 'D', 'E', 'G'], 'all categories found');
+        assert.deepEqual(categories.propagated, ['B', 'C', 'G'], 'propagated categories found');
+        assert.deepEqual(categories.partial, ['D', 'E'], 'partial categories found');
+    });
+});


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-1854

Authoring functionality common to sections is duplicated for testParts.

Nearly all the code "looks new" in the diff. Just to make it crystal clear where it came from:
- `sectionCategory.js` -> duplicated to (new file) `testPartCategory.js`
- `section-props.tpl` -> small block copied to `testPart-props.tpl`
- `section.js` -> a few parts copied to `testpart.js`
- `actions.displayCategoryPresets()` became polymorphic
- unit tests were also able to be duplicated