### PR TITLE
TR-3588 multiple timeout request handling

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -26,6 +26,7 @@
 
 use oat\libCat\exception\CatEngineConnectivityException;
 use oat\tao\model\routing\AnnotationReader\security;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoDelivery\model\RuntimeService;
 use oat\taoQtiTest\model\Service\ExitTestCommand;
@@ -665,6 +666,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
     {
         try {
             $this->validateSecurityToken();
+            $this->checkDeliveryExecutionInteractionAccessibility();
 
             $command = new TimeoutCommand(
                 $this->getServiceContext(),
@@ -944,6 +946,19 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
         }
 
         $this->returnJson($response, $code);
+    }
+
+    /**
+     * @throws QtiRunnerClosedException
+     * @throws common_exception_NotFound
+     */
+    private function checkDeliveryExecutionInteractionAccessibility(): void
+    {
+        $executionId = $this->getSessionId();
+        $deliveryExecution = $this->getDeliveryExecutionService()->getDeliveryExecution($executionId);
+        if ($deliveryExecution->getState()->getUri() === DeliveryExecutionInterface::STATE_FINISHED) {
+            throw new QtiRunnerClosedException();
+        }
     }
 
     /**


### PR DESCRIPTION
# [TR-3588](https://oat-sa.atlassian.net/browse/TR-3588)

## Summary
Runner timeout endpoint  died with 500 and type error in case of multiple timeout request for 2 or timers ended in 1 time and one of them should end execution.
## How to test
* create delivery with 2 or more timers with the same time limit
* execute this delivery and wait until timers expires
* all request will handled without 500 and type errors

## TAE
https://oat-sa.atlassian.net/browse/TR-3588?focusedCommentId=179125