### PR TITLE
fix: categories assigned incorrectly in Test authoring

### DIFF
--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -243,8 +243,7 @@ define([
                                 defaultItemData.itemSessionControl = _.clone(sectionModel.itemSessionControl);
                             }
 
-                            //the itemRef should also "inherit" the categories set at the item level
-                            const categories = sectionCategory.getCategories(sectionModel);
+                            //the itemRef should also "inherit" default categories set at the item level
                             defaultItemData.categories = _.clone(defaults().categories) || [];
 
                             _.forEach(selection, function (item) {

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -245,7 +245,7 @@ define([
 
                             //the itemRef should also "inherit" the categories set at the item level
                             const categories = sectionCategory.getCategories(sectionModel);
-                            defaultItemData.categories = _.clone(categories.propagated) || [];
+                            defaultItemData.categories = _.clone(defaults().categories) || [];
 
                             _.forEach(selection, function (item) {
                                 const itemData = _.defaults(

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -248,7 +248,7 @@ define([
 
                             //the itemRef should also "inherit" the categories set at the item level
                             const categories = sectionCategory.getCategories(subsectionModel);
-                            defaultItemData.categories = _.clone(categories.propagated) || [];
+                            defaultItemData.categories = _.clone(defaults().categories) || [];
 
                             _.forEach(selection, function (item) {
                                 const itemData = _.defaults(

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -246,8 +246,7 @@ define([
                                 defaultItemData.itemSessionControl = _.clone(subsectionModel.itemSessionControl);
                             }
 
-                            //the itemRef should also "inherit" the categories set at the item level
-                            const categories = sectionCategory.getCategories(subsectionModel);
+                            //the itemRef should also "inherit"  default categories set at the item level
                             defaultItemData.categories = _.clone(defaults().categories) || [];
 
                             _.forEach(selection, function (item) {


### PR DESCRIPTION
Related to Issue: https://oat-sa.atlassian.net/browse/AUT-1459

Fix  categories assigned incorrectly during Test authoring

**Preconditions:**

- To have a class(folder) created in items with an added exposed property, defined as multiple choice:

![image](https://user-images.githubusercontent.com/60346520/163158916-4f4dde5a-1e98-4290-8c25-09ed0a3759d9.png)
Create various items with different properties from list:
![image](https://user-images.githubusercontent.com/60346520/163159198-85da62ab-087b-4118-80bc-63e9e66335b1.png)



**SETPS to test:**
• Checkout to branch: fix/AUT-1459/categories-assigned-incorrectly-during-test-authoring
• Create a new test and add the items one by one
•  Repeat this also for a section with subsections.
• Then check the section and item properties


**ACTUAL RESULT:**
The first item  properties are duplicated for all items and show as present for all at section level

**EXPECTED RESULT:**
All items keep their original properties and the section shows all properties present as partial, at section level

![image](https://user-images.githubusercontent.com/60346520/163160564-15d529a1-56bd-48a8-a1d3-70fad3f5f7b3.png)
![image](https://user-images.githubusercontent.com/60346520/163160861-4a15668c-1e29-4d1a-96ba-397f5dc8b3d9.png)
![image](https://user-images.githubusercontent.com/60346520/163161038-fe1c593d-9f00-4492-8d3e-8a67470ac027.png)
