### PR TITLE
fix: worng pop up shows when leaving changed test without errors

### DIFF
--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -112,9 +112,7 @@ define([
             //back button
             $back.on('click', e => {
                 e.preventDefault();
-                if (!$back.hasClass('disabled')) {
-                    creatorContext.trigger('creatorclose');
-                }
+                creatorContext.trigger('creatorclose');
             });
 
             //preview button

--- a/views/js/controller/creator/helpers/changeTracker.js
+++ b/views/js/controller/creator/helpers/changeTracker.js
@@ -155,9 +155,14 @@ define([
 
                 testCreator
                     .on(`ready${eventNS} saved${eventNS}`, () => this.init())
-                    .before(`creatorclose${eventNS}`, () => this.confirmBefore('leaveWhenInvalid').then(whatToDo => {
-                        this.ifWantSave(whatToDo);
-                    }))
+                    .before(`creatorclose${eventNS}`, () => {
+                        let leavingStatus = 'leave';
+                        if(testCreator.isTestHasErrors()) {
+                            leavingStatus ='leaveWhenInvalid';
+                        }
+                        return this.confirmBefore(leavingStatus).then(whatToDo => {
+                            this.ifWantSave(whatToDo);
+                        })})
                     .before(`preview${eventNS}`, () => this.confirmBefore('preview').then(whatToDo => {
                         if(testCreator.isTestHasErrors()){
                             feedback().warning(`${__('The test cannot be saved because it currently contains invalid settings.\n' +


### PR DESCRIPTION
Related to Issue: https://oat-sa.atlassian.net/browse/AUT-2017

Fix : pop up when leaving test with changes but without errors incorrect fix/AUT-2017/wrong-pop-up-shows-when-leaving-changed-test-withouth-errors?expand=1

**SETPS to test:**
• Checkout to branch:  fix/AUT-2017/wrong-pop-up-shows-when-leaving-changed-test-withouth-errors
• Create a test (or use an already created one)
•  Make some changes without saving and press "manage tests" to go back

**ACTUAL RESULT:**
pop up shows "`If you leave the test, your changes will not be saved due to invalid test settings. Are you sure you wish to leave?"`

**EXPECTED RESULT:**
pop up shows`"The test has unsaved changes, are you sure you want to leave?"`
![image](https://user-images.githubusercontent.com/60346520/163818450-35f532b1-b12b-4a45-843d-4d28c684a0aa.png)

And all unit tests should pass
![image](https://user-images.githubusercontent.com/60346520/163816184-43db1d85-f96c-4afa-91f3-4c45976443a3.png)
