### PR TITLE
Fix/tr 3670/pause closed de

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -666,7 +666,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
     {
         try {
             $this->validateSecurityToken();
-            $this->checkDeliveryExecutionInteractionAccessibility();
+            $this->validateDeliveryExecutionInteractionAccessibility();
 
             $command = new TimeoutCommand(
                 $this->getServiceContext(),
@@ -952,7 +952,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
      * @throws QtiRunnerClosedException
      * @throws common_exception_NotFound
      */
-    private function checkDeliveryExecutionInteractionAccessibility(): void
+    private function validateDeliveryExecutionInteractionAccessibility(): void
     {
         $executionId = $this->getSessionId();
         $deliveryExecution = $this->getDeliveryExecutionService()->getDeliveryExecution($executionId);

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -744,6 +744,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
     {
         try {
             $this->validateSecurityToken();
+            $this->validateDeliveryExecutionInteractionAccessibility();
 
             $command = new PauseCommand($this->getServiceContext());
 


### PR DESCRIPTION
# [TR-3670](https://oat-sa.atlassian.net/browse/TR-3670)

## Summary 
It's a potential fix for initial bug report, also it's actual fix for potential 500 error.
more details provided by [this](https://oat-sa.atlassian.net/browse/TR-3670?focusedCommentId=182508) comment

## How to test
* update CGen instance by PR source branch
* install [extension-tao-test-runner-plugins](https://github.com/oat-sa/extension-tao-test-runner-plugins)
* configure `taoTestRunnerPlugins/runner/plugins/security/blurPause` in  `config/taoTests/test_runner_plugin_registry.conf.php` by next value 
```PHP
'taoTestRunnerPlugins/runner/plugins/security/blurPause' => array(
    'id' => 'blurPause',
    'module' => 'taoTestRunnerPlugins/runner/plugins/security/blurPause',
    'bundle' => 'taoTestRunnerPlugins/loader/testPlugins.min',
    'position' => null,
    'name' => 'Blur Pause',
    'description' => 'Pause the test when leaving the test window',
    'category' => 'security',
    'active' => true,
    'tags' => array()
)
```
* publish provided test or create new with time limit
[test_1_1650558140.zip](https://github.com/oat-sa/extension-tao-testqti/files/8532722/test_1_1650558140.zip)
 * in execution process allow timeout happens and after waiting few second focus on another tab
 * valid error popup should be provided

## TAE
https://oat-sa.atlassian.net/browse/TR-3670?focusedCommentId=182509