### PR TITLE
Backport tr3670 in feb lts -  validation delivery accessibility at unexpected request of test runner `pause`

### DIFF
--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -666,7 +666,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
     {
         try {
             $this->validateSecurityToken();
-            $this->checkDeliveryExecutionInteractionAccessibility();
+            $this->validateDeliveryExecutionInteractionAccessibility();
 
             $command = new TimeoutCommand(
                 $this->getServiceContext(),
@@ -952,7 +952,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
      * @throws QtiRunnerClosedException
      * @throws common_exception_NotFound
      */
-    private function checkDeliveryExecutionInteractionAccessibility(): void
+    private function validateDeliveryExecutionInteractionAccessibility(): void
     {
         $executionId = $this->getSessionId();
         $deliveryExecution = $this->getDeliveryExecutionService()->getDeliveryExecution($executionId);

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -744,6 +744,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
     {
         try {
             $this->validateSecurityToken();
+            $this->validateDeliveryExecutionInteractionAccessibility();
 
             $command = new PauseCommand($this->getServiceContext());
 


### PR DESCRIPTION
backport of #2250 for https://github.com/oat-sa/tao-community february lts