### PR TITLE
fix/AUT-2073/html-entities-decode

### DIFF
--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -162,11 +162,7 @@ class taoQtiTest_models_classes_QtiTestConverter
                         $array[$property->getName()][] = $item;
                     }
                 } else {
-                    if(is_string($value)) {   
-                        $array[$property->getName()] = html_entity_decode($value);
-                    }else{
-                        $array[$property->getName()] = $value;
-                    }
+                    $array[$property->getName()] = is_string($value) ? html_entity_decode($value) : $value;
                 }
             }
         }

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -142,7 +142,6 @@ class taoQtiTest_models_classes_QtiTestConverter
             $value = $this->getValue($component, $property);
             if ($value !== null) {
                 $key = $property->getName();
-                error_log($property->getName());
                 if ($value instanceof QtiComponentCollection) {
                     $array[$key] = [];
                     foreach ($value as $item) {

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -142,6 +142,7 @@ class taoQtiTest_models_classes_QtiTestConverter
             $value = $this->getValue($component, $property);
             if ($value !== null) {
                 $key = $property->getName();
+                error_log($property->getName());
                 if ($value instanceof QtiComponentCollection) {
                     $array[$key] = [];
                     foreach ($value as $item) {
@@ -162,7 +163,11 @@ class taoQtiTest_models_classes_QtiTestConverter
                         $array[$property->getName()][] = $item;
                     }
                 } else {
-                    $array[$property->getName()] = $value;
+                    if(is_string($value)) {   
+                        $array[$property->getName()] = html_entity_decode($value);
+                    }else{
+                        $array[$property->getName()] = $value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-2073

### Description

Test entity is persisted into xml representation, so it requires to store html entities encoded. So `&` is translated into `&amp;`
When xml doc containing test is parsed back, reverse decoding doesn't happen during marshalling `vendor/qtism/qtism/qtism/data/storage/xml/marshalling/AssessmentTestMarshaller.php`, so value is being read as is and passed into json response of `getTest` endpoint.

[QTI Information model](https://www.imsglobal.org/question/qtiv2p2p2/QTIv2p2p2-ASI-InformationModelv1p0/imsqtiv2p2p2_asi_v1p0_InfoModelv1p0.html#RootCharacteristic_AssessmentTest.Attr_title) doesn't restrict that chars for title property which is of type `NormalizedString`

### How to test

Env: https://aut-2073.playground.kitchen.it.taocloud.org/ 

 - Create/edit test and set title containing some chars like `&`, `<`, `"`
 - Save the test
 - Open test to edit it, check symbols are the same you set them
