### PR TITLE
fix: add possibility to force feedback display based on feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ or manually updating DI config file `taoQtiTest/ResultTransmissionEventHandler` 
 
 return new oat\taoQtiTest\models\classes\eventHandler\ResultTransmissionEventHandler\AsynchronousResultTransmissionEventHandler();
 ```
+
+Environment variables
+=====================
+
+| Var                                           | Description                                                                         |
+|-----------------------------------------------|-------------------------------------------------------------------------------------|
+| FEATURE_FLAG_FORCE_DISPLAY_TEST_ITEM_FEEDBACK | Even if itemSessionControl `showFeedback` option is false, show item feedback modal |

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -32,6 +32,8 @@ use oat\libCat\result\ItemResult;
 use oat\libCat\result\ResultVariable;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
 use oat\tao\model\theme\ThemeService;
 use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest;
 use oat\taoDelivery\model\execution\DeliveryExecution;
@@ -976,9 +978,11 @@ class QtiRunnerService extends ConfigurableService implements PersistableRunnerS
         $session = $context->getTestSession();
 
         return $session->getCurrentSubmissionMode() !== SubmissionMode::SIMULTANEOUS
-            && $session->getCurrentAssessmentItemSession()->getItemSessionControl()->mustShowFeedback();
+            && (
+                $session->getCurrentAssessmentItemSession()->getItemSessionControl()->mustShowFeedback() ||
+                $this->getFeatureFlagChecker()->isEnabled('FEATURE_FLAG_FORCE_DISPLAY_TEST_ITEM_FEEDBACK')
+            );
     }
-
 
     /**
      * Get feedback definitions
@@ -2134,5 +2138,10 @@ class QtiRunnerService extends ConfigurableService implements PersistableRunnerS
     private function getUpdateItemContentReferencesService(): UpdateItemContentReferencesService
     {
         return $this->getServiceLocator()->getContainer()->get(UpdateItemContentReferencesService::class);
+    }
+
+    private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
+    {
+        return $this->getServiceLocator()->getContainer()->get(FeatureFlagChecker::class);
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-4126

## Problem

Previously if the item had a feedback modal, we always displayed it, even if the `show feedback` checkbox was not marked in the test authoring. This was fixed, by only showing the modal upon the checkbox was marked. 

Unfortunately it broke the behavior for customer and they would have to author and republish their tests. 

## Solution 

To avoid that, via feature flag, we can provide the option to force display feedback modal until the customers adapt their tests and deliveries.