### PR TITLE
chore: update required qtism-qtism to ^0.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "^0.25.0",
+    "qtism/qtism": "^0.26.0",
     "oat-sa/generis" : ">=15.17.1",
     "oat-sa/tao-core" : ">=50.10.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",


### PR DESCRIPTION
Related PR: https://github.com/oat-sa/extension-tao-itemqti/pull/2138