### PR TITLE
Feature/aut 2337/marshall lang dir attributes 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.27.0",
+    "qtism/qtism": ">=0.27.0",
     "oat-sa/generis" : ">=15.17.1",
     "oat-sa/tao-core" : ">=50.10.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "^0.26.0",
+    "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as ^0.27.0",
     "oat-sa/generis" : ">=15.17.1",
     "oat-sa/tao-core" : ">=50.10.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as ^0.27.0",
+    "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.27.0",
     "oat-sa/generis" : ">=15.17.1",
     "oat-sa/tao-core" : ">=50.10.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2337

## Problem to solve

Import/export shared stimulus and keep the "lang" and "dir" attributes is not working.

Example where the problem happens: https://github.com/oat-sa/extension-tao-mediamanager/blob/master/model/sharedStimulus/encoder/SharedStimulusMediaEncoder.php#L51 When we call XmlDocument::load() it does not keep the attributes we need. 

## Solutions

- Add possibilities for custom attributes in the BodyElement

## PRs

- https://github.com/oat-sa/qti-sdk/pull/318