### PR TITLE
fix: update dependency to tao-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "qtism/qtism": ">=0.27.0",
     "oat-sa/generis" : ">=15.17.1",
-    "oat-sa/tao-core" : ">=50.10.0",
+    "oat-sa/tao-core" : ">=50.18.3",
     "oat-sa/extension-tao-item" : ">=11.0.0",
     "oat-sa/extension-tao-itemqti" : ">=28.35.0",
     "oat-sa/extension-tao-test" : ">=15.0.0",


### PR DESCRIPTION
Ensure the dependency to tao-core contains the bundler fix https://github.com/oat-sa/tao-core/releases/tag/v50.18.3 