### PR TITLE
Feature ADF-1102 CI pipeline

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '7.2'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.4', '8.0', '8.1' ]
         include:
-          - php-version: '7.2'
+          - php-version: '7.4'
             coverage: true
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 extension-tao-testqti
 =====================
 
+[![codecov](https://codecov.io/gh/oat-sa/extension-tao-testqti/branch/master/graph/badge.svg?token=L2pTXu17kz)](https://codecov.io/gh/oat-sa/extension-tao-testqti)
+
 Extension to create QTI tests into TAO
 
 

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
     "oat-sa/extension-tao-itemqti" : ">=28.35.0",
     "oat-sa/extension-tao-test" : ">=15.0.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
+    "oat-sa/extension-tao-delivery-rdf": ">=3.12.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0",
     "league/flysystem": "~1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,6 @@
     "oat-sa/extension-tao-itemqti" : ">=28.35.0",
     "oat-sa/extension-tao-test" : ">=15.0.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
-    "oat-sa/extension-tao-delivery-rdf": ">=3.12.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0",
     "league/flysystem": "~1.0"
   },

--- a/model/Infrastructure/QtiTestRepository.php
+++ b/model/Infrastructure/QtiTestRepository.php
@@ -24,7 +24,6 @@ namespace oat\taoQtiTest\model\Infrastructure;
 
 use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
-use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoQtiItem\model\qti\Service;
 use oat\taoQtiTest\model\Domain\Model\QtiTest;
 use oat\taoQtiTest\model\Domain\Model\QtiTestRepositoryInterface;
@@ -51,7 +50,7 @@ class QtiTestRepository implements QtiTestRepositoryInterface
     public function findByDelivery(string $deliveryUri): ?QtiTest
     {
         $delivery = $this->ontology->getResource($deliveryUri);
-        $deliveryTest = $delivery->getProperty(DeliveryAssemblyService::PROPERTY_ORIGIN);
+        $deliveryTest = $delivery->getProperty('http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDeliveryOrigin');
         $testId = $delivery->getOnePropertyValue($deliveryTest)->getUri();
 
         return new QtiTest($testId, $this->getFirstTestItemLanguage($testId));

--- a/test/unit/QtiTestCompilerUtilsTest.php
+++ b/test/unit/QtiTestCompilerUtilsTest.php
@@ -34,12 +34,11 @@ use \qtism\data\storage\xml\XmlDocument;
  */
 class QtiTestCompilerUtilsTest extends TestCase
 {
-    
     public static function samplesDir()
     {
         return dirname(__FILE__) . '/../samples/xml/compiler/meta/';
     }
-    
+
     /**
      *
      * @dataProvider metaProvider
@@ -50,21 +49,77 @@ class QtiTestCompilerUtilsTest extends TestCase
     {
         $xml = new XmlDocument();
         $xml->load($testFile);
-        
+
         $this->assertEquals($expectedMeta, taoQtiTest_helpers_TestCompilerUtils::testMeta($xml->getDocumentComponent()));
     }
-    
+
     public function metaProvider()
     {
         return [
-            [self::samplesDir() . 'linear_nopreconditions_nobranchrules.xml', ['branchRules' => false, 'preConditions' => false]],
-            [self::samplesDir() . 'linear_preconditions_nobranchrules.xml', ['branchRules' => false, 'preConditions' => true]],
-            [self::samplesDir() . 'linear_nopreconditions_branchrules.xml', ['branchRules' => true, 'preConditions' => false]],
-            [self::samplesDir() . 'linear_preconditions_branchrules.xml', ['branchRules' => true, 'preConditions' => true]],
-            [self::samplesDir() . 'nonlinear_nopreconditions_nobranchrules.xml', ['branchRules' => false, 'preConditions' => false]],
-            [self::samplesDir() . 'nonlinear_nopreconditions_branchrules.xml', ['branchRules' => false, 'preConditions' => false]],
-            [self::samplesDir() . 'nonlinear_preconditions_branchrules.xml', ['branchRules' => false, 'preConditions' => false]],
-            [self::samplesDir() . 'nonlinear_preconditions_nobranchrules.xml', ['branchRules' => false, 'preConditions' => false]],
+            [
+                self::samplesDir() . 'linear_nopreconditions_nobranchrules.xml',
+                [
+                    'branchRules' => false,
+                    'preConditions' => false,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
+            [
+                self::samplesDir() . 'linear_preconditions_nobranchrules.xml',
+                [
+                    'branchRules' => false,
+                    'preConditions' => true,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
+            [
+                self::samplesDir() . 'linear_nopreconditions_branchrules.xml',
+                [
+                    'branchRules' => true,
+                    'preConditions' => false,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
+            [
+                self::samplesDir() . 'linear_preconditions_branchrules.xml',
+                [
+                    'branchRules' => true,
+                    'preConditions' => true,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
+            [
+                self::samplesDir() . 'nonlinear_nopreconditions_nobranchrules.xml',
+                [
+                    'branchRules' => false,
+                    'preConditions' => false,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
+            [
+                self::samplesDir() . 'nonlinear_nopreconditions_branchrules.xml',
+                [
+                    'branchRules' => false,
+                    'preConditions' => false,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
+            [
+                self::samplesDir() . 'nonlinear_preconditions_branchrules.xml',
+                [
+                    'branchRules' => false,
+                    'preConditions' => false,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
+            [
+                self::samplesDir() . 'nonlinear_preconditions_nobranchrules.xml',
+                [
+                    'branchRules' => false,
+                    'preConditions' => false,
+                    taoQtiTest_helpers_TestCompilerUtils::COMPILATION_VERSION => 1,
+                ],
+            ],
         ];
     }
 }

--- a/test/unit/model/Infrastructure/QtiTestRepositoryTest.php
+++ b/test/unit/model/Infrastructure/QtiTestRepositoryTest.php
@@ -26,7 +26,6 @@ use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
-use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoQtiItem\model\qti\Item;
 use oat\taoQtiItem\model\qti\Service;
 use oat\taoQtiTest\model\Domain\Model\QtiTest;
@@ -141,7 +140,7 @@ class QtiTestRepositoryTest extends TestCase
         $deliveryTestProperty = $this->createMock(core_kernel_classes_Property::class);
 
         $delivery->method('getProperty')
-            ->with(DeliveryAssemblyService::PROPERTY_ORIGIN)
+            ->with('http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDeliveryOrigin')
             ->willReturn($deliveryTestProperty);
 
         $delivery->method('getOnePropertyValue')

--- a/test/unit/models/classes/runner/synchronisation/synchronisationService/ResponseGeneratorTest.php
+++ b/test/unit/models/classes/runner/synchronisation/synchronisationService/ResponseGeneratorTest.php
@@ -167,7 +167,7 @@ class ResponseGeneratorTest extends TestCase
             $testRunnerAction2,
             []
         ], $serviceContext, $now);
-        $this->assertSame($now - (10 + 5 + 0.002), $last);
+        $this->assertEquals($now - (10 + 5 + 0.002), $last);
     }
 
     public function testGetActionResponseEmptyAction(): void


### PR DESCRIPTION
# [ADF-1102](https://oat-sa.atlassian.net/browse/ADF-1102)

This PR aims to integrate the extension with a new CI pipeline defined by https://github.com/oat-sa/tao-extension-ci-action

⚠️ It is expected that PHP > 7.4 pipeline fail ⚠️

## Changelog
- ci: add a CI action
- docs: add a codecov badge to README.md
- [fix: QtiTestCompilerUtilsTest test cases](https://github.com/oat-sa/extension-tao-testqti/pull/2288/commits/e142346cd275d8b66649f10a169eb358dd5ea802)
- [fix: ResponseGeneratorTest float comparison](https://github.com/oat-sa/extension-tao-testqti/pull/2288/commits/46cb63ba0b478cf26e8f7c595be101be7a50d1b7)
- [fix: remove a cercular depepdency on oat-sa/extension-tao-delivery-rdf](https://github.com/oat-sa/extension-tao-testqti/pull/2288/commits/a0239c6dafc9db10c1c44d78ffe828067512f258)