### PR TITLE
[NCC-399] Backport TR-4008 session state restoration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,10 +65,8 @@
   },
   "autoload": {
     "psr-4": {
+      "oat\\taoQtiTest\\" : "",
       "oat\\taoQtiTest\\models\\": "models/classes/",
-      "oat\\taoQtiTest\\helpers\\": "helpers",
-      "oat\\taoQtiTest\\test\\": "test",
-      "oat\\taoQtiTest\\scripts\\": "scripts"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
   "autoload": {
     "psr-4": {
       "oat\\taoQtiTest\\" : "",
-      "oat\\taoQtiTest\\models\\": "models/classes/",
+      "oat\\taoQtiTest\\models\\": "models/classes/"
     }
   }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -20,8 +20,10 @@
  */
 
 use oat\tao\model\user\TaoRoles;
-use oat\taoQtiTest\scripts\update\Updater;
-use oat\taoQtiTest\scripts\install\SetupProvider;
+use oat\taoQtiTest\model\Container\TestQtiServiceProvider;
+use oat\taoQtiTest\models\classes\render\CustomInteraction\ServiceProvider\CustomInteractionPostProcessingServiceProvider;
+use oat\taoQtiTest\models\render\ItemsReferencesServiceProvider;
+use oat\taoQtiTest\models\TestSessionState\Container\TestSessionStateServiceProvider;
 use oat\taoQtiTest\models\xmlEditor\XmlEditorInterface;
 use oat\taoQtiTest\scripts\install\CreateTestSessionFilesystem;
 use oat\taoQtiTest\scripts\install\RegisterCreatorServices;
@@ -29,6 +31,7 @@ use oat\taoQtiTest\scripts\install\RegisterFrontendPaths;
 use oat\taoQtiTest\scripts\install\RegisterQtiCategoryPresetProviders;
 use oat\taoQtiTest\scripts\install\RegisterQtiFlysystemManager;
 use oat\taoQtiTest\scripts\install\RegisterQtiPackageExporter;
+use oat\taoQtiTest\scripts\install\RegisterResultTransmissionEventHandlers;
 use oat\taoQtiTest\scripts\install\RegisterSectionPauseService;
 use oat\taoQtiTest\scripts\install\RegisterTestCategoryPresetProviderService;
 use oat\taoQtiTest\scripts\install\RegisterTestContainer;
@@ -42,8 +45,10 @@ use oat\taoQtiTest\scripts\install\SetLinearNextItemWarningConfig;
 use oat\taoQtiTest\scripts\install\SetSynchronisationService;
 use oat\taoQtiTest\scripts\install\SetupDefaultTemplateConfiguration;
 use oat\taoQtiTest\scripts\install\SetupEventListeners;
+use oat\taoQtiTest\scripts\install\SetupProvider;
 use oat\taoQtiTest\scripts\install\SetUpQueueTasks;
 use oat\taoQtiTest\scripts\install\SyncChannelInstaller;
+use oat\taoQtiTest\scripts\update\Updater;
 
 $extpath = __DIR__ . DIRECTORY_SEPARATOR;
 $taopath = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'tao' . DIRECTORY_SEPARATOR;
@@ -141,5 +146,11 @@ return [
     ],
     'extra' => [
         'structures' => __DIR__ . DIRECTORY_SEPARATOR . 'actions' . DIRECTORY_SEPARATOR . 'structures.xml',
+    ],
+    'containerServiceProviders' => [
+        CustomInteractionPostProcessingServiceProvider::class,
+        ItemsReferencesServiceProvider::class,
+        TestQtiServiceProvider::class,
+        TestSessionStateServiceProvider::class
     ],
 ];

--- a/manifest.php
+++ b/manifest.php
@@ -58,7 +58,7 @@ return [
     'label' => 'QTI test model',
     'description' => 'TAO QTI test implementation',
     'license' => 'GPL-2.0',
-    'version' => '40.3.12.2',
+    'version' => '40.3.12.3',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'taoQtiItem' => '>=24.0.0',

--- a/models/classes/QtiTestListenerService.php
+++ b/models/classes/QtiTestListenerService.php
@@ -24,6 +24,7 @@ use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoQtiTest\models\classes\tasks\QtiStateOffload\AbstractQtiStateManipulationTask;
 use oat\taoQtiTest\models\classes\tasks\QtiStateOffload\StateOffloadTask;
 use oat\taoQtiTest\models\event\AfterAssessmentTestSessionClosedEvent;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
@@ -158,9 +159,9 @@ class QtiTestListenerService extends ConfigurableService
     private function dispatchOffload(string $userId, string $callId, string $stateLabel): void
     {
         $this->getQueueDispatcher()->createTask(new StateOffloadTask(), [
-            StateOffloadTask::PARAM_USER_ID_KEY => $userId,
-            StateOffloadTask::PARAM_CALL_ID_KEY => $callId,
-            StateOffloadTask::PARAM_STATE_LABEL_KEY => $stateLabel
+            AbstractQtiStateManipulationTask::PARAM_USER_ID_KEY => $userId,
+            AbstractQtiStateManipulationTask::PARAM_CALL_ID_KEY => $callId,
+            AbstractQtiStateManipulationTask::PARAM_STATE_LABEL_KEY => $stateLabel
         ]);
     }
 

--- a/models/classes/QtiTestListenerService.php
+++ b/models/classes/QtiTestListenerService.php
@@ -41,19 +41,19 @@ use qtism\runtime\tests\AssessmentTestSession;
 class QtiTestListenerService extends ConfigurableService
 {
     const SERVICE_ID = 'taoQtiTest/QtiTestListenerService';
-    
+
     const OPTION_ARCHIVE_EXCLUDE = 'archive-exclude';
-    
+
     /**
      * @var string Constant to turn off test state archiving.
      */
     const ARCHIVE_EXCLUDE_TEST = 'archive-exclude-test';
-    
+
     /**
      * @var string Constant to turn off item state archiving.
      */
     const ARCHIVE_EXCLUDE_ITEMS = 'archive-exclude-items';
-    
+
     /**
      * @var string Constant to turn off extended test state archiving.
      */
@@ -62,9 +62,9 @@ class QtiTestListenerService extends ConfigurableService
     public function __construct($options = [])
     {
         parent::__construct($options);
-        
+
         $archiveExcludeOption = $this->getOption(self::OPTION_ARCHIVE_EXCLUDE);
-        
+
         if (is_null($archiveExcludeOption) || !is_array($archiveExcludeOption)) {
             $this->setOption(self::OPTION_ARCHIVE_EXCLUDE, []);
         }
@@ -114,7 +114,7 @@ class QtiTestListenerService extends ConfigurableService
             $stateService->addEvent($session->getSessionId(), TestStateChannel::CHANNEL_NAME, $data);
         }
     }
-    
+
     /**
      * Archive Test States
      *
@@ -167,6 +167,6 @@ class QtiTestListenerService extends ConfigurableService
 
     private function getQueueDispatcher(): QueueDispatcherInterface
     {
-        return $this->getServiceManager()->getContainer()->get(QueueDispatcherInterface::SERVICE_ID);
+        return $this->getServiceManager()->get(QueueDispatcherInterface::SERVICE_ID);
     }
 }

--- a/models/classes/TestSessionState/Api/TestSessionStateRestorationInterface.php
+++ b/models/classes/TestSessionState/Api/TestSessionStateRestorationInterface.php
@@ -29,7 +29,7 @@ use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoQtiTest\models\QtiTestExtractionFailedException;
 use oat\taoQtiTest\models\TestSessionState\Exception\RestorationImpossibleException;
 
-interface TestSessionStateRestorationServiceInterface
+interface TestSessionStateRestorationInterface
 {
     /**
      * @throws common_exception_NoContent

--- a/models/classes/TestSessionState/Api/TestSessionStateRestorationServiceInterface.php
+++ b/models/classes/TestSessionState/Api/TestSessionStateRestorationServiceInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\TestSessionState\Api;
+
+use common_exception_NoContent;
+use common_exception_NotFound;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoQtiTest\models\QtiTestExtractionFailedException;
+use oat\taoQtiTest\models\TestSessionState\Exception\RestorationImpossibleException;
+
+interface TestSessionStateRestorationServiceInterface
+{
+    /**
+     * @throws common_exception_NoContent
+     * @throws common_exception_NotFound
+     * @throws QtiTestExtractionFailedException
+     * @throws RestorationImpossibleException
+     */
+    public function restore(DeliveryExecution $deliveryExecution):void;
+}

--- a/models/classes/TestSessionState/Container/TestSessionStateServiceProvider.php
+++ b/models/classes/TestSessionState/Container/TestSessionStateServiceProvider.php
@@ -26,6 +26,7 @@ namespace oat\taoQtiTest\models\TestSessionState\Container;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\log\LoggerService;
 use oat\tao\model\state\StateMigration;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoQtiTest\models\QtiTestUtils;
 use oat\taoQtiTest\models\TestSessionService;
 use oat\taoQtiTest\models\TestSessionState\Api\TestSessionStateRestorationInterface;
@@ -47,6 +48,7 @@ class TestSessionStateServiceProvider implements ContainerServiceProviderInterfa
                     service(QtiTestUtils::SERVICE_ID),
                     service(StateMigration::SERVICE_ID),
                     service(LoggerService::SERVICE_ID),
+                    service(QueueDispatcherInterface::SERVICE_ID),
                 ]
             );
     }

--- a/models/classes/TestSessionState/Container/TestSessionStateServiceProvider.php
+++ b/models/classes/TestSessionState/Container/TestSessionStateServiceProvider.php
@@ -28,7 +28,7 @@ use oat\oatbox\log\LoggerService;
 use oat\tao\model\state\StateMigration;
 use oat\taoQtiTest\models\QtiTestUtils;
 use oat\taoQtiTest\models\TestSessionService;
-use oat\taoQtiTest\models\TestSessionState\Api\TestSessionStateRestorationServiceInterface;
+use oat\taoQtiTest\models\TestSessionState\Api\TestSessionStateRestorationInterface;
 use oat\taoQtiTest\models\TestSessionState\TestSessionStateRestorationService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -39,7 +39,7 @@ class TestSessionStateServiceProvider implements ContainerServiceProviderInterfa
     {
         $services = $configurator->services();
         $services
-            ->set(TestSessionStateRestorationServiceInterface::class, TestSessionStateRestorationService::class)
+            ->set(TestSessionStateRestorationInterface::class, TestSessionStateRestorationService::class)
             ->public()
             ->args(
                 [

--- a/models/classes/TestSessionState/Container/TestSessionStateServiceProvider.php
+++ b/models/classes/TestSessionState/Container/TestSessionStateServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\TestSessionState\Container;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\state\StateMigration;
+use oat\taoQtiTest\models\QtiTestUtils;
+use oat\taoQtiTest\models\TestSessionService;
+use oat\taoQtiTest\models\TestSessionState\Api\TestSessionStateRestorationServiceInterface;
+use oat\taoQtiTest\models\TestSessionState\TestSessionStateRestorationService;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class TestSessionStateServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+        $services
+            ->set(TestSessionStateRestorationServiceInterface::class, TestSessionStateRestorationService::class)
+            ->public()
+            ->args(
+                [
+                    service(TestSessionService::SERVICE_ID),
+                    service(QtiTestUtils::SERVICE_ID),
+                    service(StateMigration::SERVICE_ID),
+                    service(LoggerService::SERVICE_ID),
+                ]
+            );
+    }
+}

--- a/models/classes/TestSessionState/Exception/RestorationImpossibleException.php
+++ b/models/classes/TestSessionState/Exception/RestorationImpossibleException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace oat\taoQtiTest\models\TestSessionState\Exception;
+
+class RestorationImpossibleException extends \Exception
+{
+
+}

--- a/models/classes/TestSessionState/Exception/RestorationImpossibleException.php
+++ b/models/classes/TestSessionState/Exception/RestorationImpossibleException.php
@@ -1,8 +1,31 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types=1);
+
 namespace oat\taoQtiTest\models\TestSessionState\Exception;
 
-class RestorationImpossibleException extends \Exception
+use Exception;
+
+class RestorationImpossibleException extends Exception
 {
 
 }

--- a/models/classes/TestSessionState/TestSessionStateRestorationService.php
+++ b/models/classes/TestSessionState/TestSessionStateRestorationService.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\TestSessionState;
+
+use League\Flysystem\FileNotFoundException;
+use oat\tao\model\state\StateMigration;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoQtiTest\models\QtiTestUtils;
+use oat\taoQtiTest\models\runner\ExtendedState;
+use oat\taoQtiTest\models\runner\time\QtiTimeStorage;
+use oat\taoQtiTest\models\TestSessionService;
+use oat\taoQtiTest\models\TestSessionState\Api\TestSessionStateRestorationServiceInterface;
+use oat\taoQtiTest\models\TestSessionState\Exception\RestorationImpossibleException;
+use Psr\Log\LoggerInterface;
+use qtism\data\AssessmentSection;
+use qtism\data\SectionPartCollection;
+use qtism\data\TestPart;
+use qtism\data\TestPartCollection;
+
+class TestSessionStateRestorationService implements TestSessionStateRestorationServiceInterface
+{
+    /** @var TestSessionService */
+    private $testSessionService;
+    /** @var QtiTestUtils */
+    private $qtiTestUtils;
+    /** @var StateMigration */
+    private $stateMigration;
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(
+        TestSessionService $testSessionService,
+        QtiTestUtils $qtiTestUtils,
+        StateMigration $stateMigration,
+        LoggerInterface $logger
+    ) {
+        $this->testSessionService = $testSessionService;
+        $this->qtiTestUtils = $qtiTestUtils;
+        $this->stateMigration = $stateMigration;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function restore(DeliveryExecution $deliveryExecution): void
+    {
+        $deliveryExecutionId = $deliveryExecution->getIdentifier();
+        $userId = $deliveryExecution->getUserIdentifier();
+
+        try {
+            $this->stateMigration->restore($userId, $deliveryExecutionId);
+        } catch (FileNotFoundException $e) {
+            throw new RestorationImpossibleException();
+        }
+
+        $this->restoreExtendedState($userId, $deliveryExecutionId);
+        $this->restoreTimeLineState($userId, $deliveryExecutionId);
+        $this->restoreItemsState($deliveryExecution);
+    }
+
+    private function restoreExtendedState(string $userId, string $sessionId): void
+    {
+        $extendedStorageId = ExtendedState::getStorageKeyFromTestSessionId($sessionId);
+        try {
+            $this->stateMigration->restore($userId, $extendedStorageId);
+        } catch (FileNotFoundException $e) {
+            $this->logger->debug(
+                sprintf(
+                    '[%s] Extended state restoration impossible for user %s',
+                    $extendedStorageId,
+                    $userId
+                )
+            );
+        }
+    }
+
+    private function restoreTimeLineState(string $userId, string $sessionId): void
+    {
+        $extendedStorageId = QtiTimeStorage::getStorageKeyFromTestSessionId($sessionId);
+        try {
+            $this->stateMigration->restore($userId, $extendedStorageId);
+        } catch (FileNotFoundException $e) {
+            $this->logger->debug(
+                sprintf(
+                    '[%s] TimeLine state restoration impossible for user %s',
+                    $extendedStorageId,
+                    $userId
+                )
+            );
+        }
+    }
+
+    private function restoreItemsState(DeliveryExecution $deliveryExecution): void
+    {
+        $runtimeInputParameters = $this->testSessionService->getRuntimeInputParameters($deliveryExecution);
+        $testDefinition = $this->qtiTestUtils->getTestDefinition($runtimeInputParameters['QtiTestCompilation']);
+        $this->walkTestParts($testDefinition->getTestParts(), $deliveryExecution);
+    }
+
+
+    private function walkTestParts(TestPartCollection $testParts, DeliveryExecution $deliveryExecution)
+    {
+        foreach ($testParts as $testPart) {
+            $this->walkAssessmentSections($testPart->getAssessmentSections(), $deliveryExecution);
+        }
+    }
+
+    private function walkAssessmentSections(
+        SectionPartCollection $assessmentSections,
+        DeliveryExecution $deliveryExecution
+    ) {
+        foreach ($assessmentSections as $assessmentSection) {
+            $this->walkAssessmentSection($assessmentSection, $deliveryExecution);
+        }
+    }
+
+
+    private function walkAssessmentSection(AssessmentSection $assessmentSection, DeliveryExecution $deliveryExecution)
+    {
+        foreach ($assessmentSection->getSectionParts() as $sectionPart) {
+            $this->restoreItemState(
+                $deliveryExecution->getUserIdentifier(),
+                $deliveryExecution->getIdentifier() . $sectionPart->getIdentifier()
+            );
+        }
+    }
+
+    private function restoreItemState(string $userId, string $callId)
+    {
+        try {
+            $this->stateMigration->restore($userId, $callId);
+        } catch (FileNotFoundException $e) {
+            $this->logger->debug(
+                sprintf(
+                    '[%s] Item state restoration impossible for user %s',
+                    $callId,
+                    $userId
+                )
+            );
+        }
+    }
+}

--- a/models/classes/TestSessionState/TestSessionStateRestorationService.php
+++ b/models/classes/TestSessionState/TestSessionStateRestorationService.php
@@ -162,11 +162,10 @@ class TestSessionStateRestorationService implements TestSessionStateRestorationI
      */
     private function walkAssessmentSection(AssessmentSection $assessmentSection, DeliveryExecution $deliveryExecution)
     {
+        $userId = $deliveryExecution->getUserIdentifier();
+        $deliveryExecutionId = $deliveryExecution->getIdentifier();
         foreach ($assessmentSection->getSectionParts() as $sectionPart) {
-            $this->restoreItemState(
-                $deliveryExecution->getUserIdentifier(),
-                $deliveryExecution->getIdentifier() . $sectionPart->getIdentifier()
-            );
+            $this->restoreItemState($userId, $deliveryExecutionId . $sectionPart->getIdentifier());
         }
     }
 

--- a/models/classes/tasks/QtiStateOffload/AbstractQtiStateManipulationTask.php
+++ b/models/classes/tasks/QtiStateOffload/AbstractQtiStateManipulationTask.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\tasks\QtiStateOffload;
+
+use InvalidArgumentException;
+use oat\oatbox\extension\AbstractAction;
+use oat\oatbox\reporting\Report;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\tao\model\state\StateMigration;
+use oat\tao\model\taskQueue\Task\TaskAwareInterface;
+use oat\tao\model\taskQueue\Task\TaskAwareTrait;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+abstract class AbstractQtiStateManipulationTask extends AbstractAction implements TaskAwareInterface
+{
+    use TaskAwareTrait;
+
+    public const PARAM_USER_ID_KEY = 'userId';
+    public const PARAM_CALL_ID_KEY = 'callId';
+    public const PARAM_STATE_LABEL_KEY = 'stateLabel';
+
+    public function __invoke($params): Report
+    {
+        [$userId, $callId, $stateLabel] = $this->validateParameters($params);
+
+        return $this->manipulateState($userId, $callId, $stateLabel);
+    }
+
+    abstract protected function manipulateState(string $userId, string $callId, string $stateLabel): Report;
+
+    /**
+     * @param $params
+     * @return array [$userId, $callId, $stateLabel]
+     */
+    private function validateParameters($params): array
+    {
+        if (!isset(
+            $params[self::PARAM_USER_ID_KEY],
+            $params[self::PARAM_CALL_ID_KEY],
+            $params[self::PARAM_STATE_LABEL_KEY]
+        )) {
+            throw new InvalidArgumentException('[%s] Invalid parameter set was provided', self::class);
+        }
+
+        return [
+            $params[self::PARAM_USER_ID_KEY],
+            $params[self::PARAM_CALL_ID_KEY],
+            $params[self::PARAM_STATE_LABEL_KEY]
+        ];
+    }
+
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws InvalidServiceManagerException
+     */
+    protected function getStateMigrationService(): StateMigration
+    {
+        return $this->getServiceLocator()->get(StateMigration::SERVICE_ID);
+    }
+}

--- a/models/classes/tasks/QtiStateOffload/AbstractQtiStateManipulationTask.php
+++ b/models/classes/tasks/QtiStateOffload/AbstractQtiStateManipulationTask.php
@@ -24,7 +24,7 @@ namespace oat\taoQtiTest\models\classes\tasks\QtiStateOffload;
 
 use InvalidArgumentException;
 use oat\oatbox\extension\AbstractAction;
-use oat\oatbox\reporting\Report;
+use common_report_Report as Report;
 use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\tao\model\state\StateMigration;
 use oat\tao\model\taskQueue\Task\TaskAwareInterface;

--- a/models/classes/tasks/QtiStateOffload/StateBackupRemovalTask.php
+++ b/models/classes/tasks/QtiStateOffload/StateBackupRemovalTask.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\tasks\QtiStateOffload;
+
+use Exception;
+use oat\oatbox\reporting\Report;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+class StateBackupRemovalTask extends AbstractQtiStateManipulationTask
+{
+    /**
+     * @param string $userId
+     * @param string $callId
+     * @param string $stateLabel
+     * @return Report
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function manipulateState(string $userId, string $callId, string $stateLabel): Report
+    {
+        try {
+            $this->getStateMigrationService()->removeBackup($userId, $callId);
+
+            $this->getLogger()->info(
+                sprintf('%s state backup has been deleted', $stateLabel),
+                [
+                    'userId' => $userId,
+                    'callId' => $callId,
+                    'stateType' => $stateLabel
+                ]
+            );
+            return Report::createSuccess(
+                sprintf(
+                    '[%s] - %s state backup was successfully removed for user %s',
+                    $callId,
+                    $stateLabel,
+                    $userId
+                )
+            );
+        } catch (Exception $exception) {
+            $this->getLogger()->warning(
+                sprintf('Failed to delete backup %s state', $stateLabel),
+                [
+                    'userId' => $userId,
+                    'callId' => $callId,
+                    'stateType' => $stateLabel
+                ]
+            );
+            return Report::createError(
+                sprintf(
+                    '[%s] - %s state backup removing failed for user %s',
+                    $callId,
+                    $stateLabel,
+                    $userId
+                )
+            );
+        }
+    }
+}

--- a/models/classes/tasks/QtiStateOffload/StateBackupRemovalTask.php
+++ b/models/classes/tasks/QtiStateOffload/StateBackupRemovalTask.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace oat\taoQtiTest\models\classes\tasks\QtiStateOffload;
 
 use Exception;
-use oat\oatbox\reporting\Report;
+use common_report_Report as Report;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -67,7 +67,7 @@ class StateBackupRemovalTask extends AbstractQtiStateManipulationTask
                     'stateType' => $stateLabel
                 ]
             );
-            return Report::createError(
+            return Report::createFailure(
                 sprintf(
                     '[%s] - %s state backup removing failed for user %s',
                     $callId,

--- a/models/classes/tasks/QtiStateOffload/StateOffloadTask.php
+++ b/models/classes/tasks/QtiStateOffload/StateOffloadTask.php
@@ -24,7 +24,7 @@ namespace oat\taoQtiTest\models\classes\tasks\QtiStateOffload;
 
 use InvalidArgumentException;
 use oat\oatbox\extension\AbstractAction;
-use oat\oatbox\reporting\Report;
+use common_report_Report as Report;
 use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\tao\model\state\StateMigration;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
@@ -48,7 +48,7 @@ class StateOffloadTask extends AbstractQtiStateManipulationTask
                 sprintf('Failed to archive %s state', $stateLabel),
                 $logContext
             );
-            return Report::createError(
+            return Report::createFailure(
                 sprintf(
                     '[%s] - %s state archiving failed for user %s',
                     $callId,

--- a/models/classes/tasks/QtiStateOffload/StateOffloadTask.php
+++ b/models/classes/tasks/QtiStateOffload/StateOffloadTask.php
@@ -62,7 +62,7 @@ class StateOffloadTask extends AbstractAction implements TaskAwareInterface
 
         if ($this->getStateMigrationService()->archive($userId, $callId)) {
             $this->getStateMigrationService()->removeState($userId, $callId);
-            $this->getLoggerInterface()->debug(
+            $this->getLoggerInterface()->info(
                 sprintf('%s State archived for user: %s and callId: %s', $stateType, $userId, $callId)
             );
         }

--- a/models/classes/tasks/QtiStateOffload/StateOffloadTask.php
+++ b/models/classes/tasks/QtiStateOffload/StateOffloadTask.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\tasks\QtiStateOffload;
+
+use InvalidArgumentException;
+use oat\oatbox\extension\AbstractAction;
+use oat\oatbox\log\LoggerService;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\tao\model\state\StateMigration;
+use oat\tao\model\taskQueue\Task\TaskAwareInterface;
+use oat\tao\model\taskQueue\Task\TaskAwareTrait;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+
+class StateOffloadTask extends AbstractAction implements TaskAwareInterface
+{
+    use TaskAwareTrait;
+
+    public const PARAM_USER_ID_KEY = 'userId';
+    public const PARAM_CALL_ID_KEY = 'callId';
+    public const PARAM_STATE_LABEL_KEY = 'stateLabel';
+
+    /**
+     * @throws NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     * @throws InvalidServiceManagerException
+     */
+    public function __invoke($params)
+    {
+        if (!isset(
+            $params[self::PARAM_USER_ID_KEY],
+            $params[self::PARAM_CALL_ID_KEY],
+            $params[self::PARAM_STATE_LABEL_KEY]
+        )) {
+            throw new InvalidArgumentException('Invalid parameter set was provided');
+        }
+
+        $userId = $params[self::PARAM_USER_ID_KEY];
+        $callId = $params[self::PARAM_CALL_ID_KEY];
+        $stateType = $params[self::PARAM_STATE_LABEL_KEY];
+
+        if ($this->getStateMigrationService()->archive($userId, $callId)) {
+            $this->getStateMigrationService()->removeState($userId, $callId);
+            $this->getLoggerInterface()->debug(
+                sprintf('%s State archived for user: %s and callId: %s', $stateType, $userId, $callId)
+            );
+        }
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws InvalidServiceManagerException
+     */
+    private function getStateMigrationService(): StateMigration
+    {
+        return $this->getServiceLocator()->get(StateMigration::SERVICE_ID);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws InvalidServiceManagerException
+     */
+    private function getLoggerInterface(): LoggerInterface
+    {
+        return $this->getServiceLocator()->get(LoggerService::SERVICE_ID);
+    }
+}

--- a/models/classes/tasks/QtiStateOffload/StateRemovalTask.php
+++ b/models/classes/tasks/QtiStateOffload/StateRemovalTask.php
@@ -25,7 +25,7 @@ namespace oat\taoQtiTest\models\classes\tasks\QtiStateOffload;
 use Exception;
 use InvalidArgumentException;
 use oat\oatbox\extension\AbstractAction;
-use oat\oatbox\reporting\Report;
+use common_report_Report as Report;
 use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\tao\model\state\StateMigration;
 use oat\tao\model\taskQueue\Task\TaskAwareInterface;
@@ -63,7 +63,7 @@ class StateRemovalTask extends AbstractQtiStateManipulationTask
                 sprintf('Failed to delete %s state', $stateLabel),
                 $loggerContext
             );
-            return Report::createError(
+            return Report::createFailure(
                 sprintf(
                     '[%s] - %s state removing failed for user %s',
                     $callId,

--- a/test/unit/models/classes/TestSessionState/TestSessionStateRestorationServiceTest.php
+++ b/test/unit/models/classes/TestSessionState/TestSessionStateRestorationServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+
+use League\Flysystem\FileNotFoundException;
+use oat\tao\model\state\StateMigration;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoQtiTest\models\QtiTestUtils;
+use oat\taoQtiTest\models\TestSessionService;
+use oat\taoQtiTest\models\TestSessionState\Exception\RestorationImpossibleException;
+use oat\taoQtiTest\models\TestSessionState\TestSessionStateRestorationService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use qtism\data\AssessmentSection;
+use qtism\data\AssessmentSectionCollection;
+use qtism\data\AssessmentTest;
+use qtism\data\SectionPart;
+use qtism\data\SectionPartCollection;
+use qtism\data\TestPart;
+use qtism\data\TestPartCollection;
+use Ramsey\Uuid\Uuid;
+
+class TestSessionStateRestorationServiceTest extends TestCase
+{
+    /** @var TestSessionService|MockObject */
+    private $testSessionServiceMock;
+    /** @var QtiTestUtils|MockObject */
+    private $qtiTestUtilsMock;
+    /** @var StateMigration|MockObject */
+    private $stateMigrationMock;
+    /** @var MockObject|LoggerInterface */
+    private $loggerMock;
+    /** @var TestSessionStateRestorationService */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testSessionServiceMock = $this->createMock(TestSessionService::class);
+        $this->qtiTestUtilsMock = $this->createMock(QtiTestUtils::class);
+        $this->stateMigrationMock = $this->createMock(StateMigration::class);
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+        $this->subject = new TestSessionStateRestorationService(
+            $this->testSessionServiceMock,
+            $this->qtiTestUtilsMock,
+            $this->stateMigrationMock,
+            $this->loggerMock
+        );
+    }
+
+    public function testImpossibleTestSessionStateRestoration(): void
+    {
+        $deliveryExecution = $this->createMock(DeliveryExecution::class);
+        $deliveryExecution->expects(self::once())->method('getIdentifier')
+            ->willReturn(Uuid::uuid4()->toString());
+        $deliveryExecution->expects(self::once())->method('getUserIdentifier')
+            ->willReturn(Uuid::uuid4()->toString());
+        $this->stateMigrationMock->expects(self::once())->method('restore')
+            ->willThrowException(new FileNotFoundException(''));
+
+        $this->expectException(RestorationImpossibleException::class);
+        $this->subject->restore($deliveryExecution);
+    }
+
+    /**
+     * @dataProvider getAssessmentTests
+     */
+    public function testSuccessRestoration($questionCount, $testPartCount, $assessmentTest): void
+    {
+        $deliveryExecution = $this->createMock(DeliveryExecution::class);
+        $deliveryExecution->expects(self::exactly(1 + $testPartCount))->method('getIdentifier')
+            ->willReturn(Uuid::uuid4()->toString());
+        $deliveryExecution->expects(self::exactly(1 + $testPartCount))->method('getUserIdentifier')
+            ->willReturn(Uuid::uuid4()->toString());
+
+        $this->testSessionServiceMock->expects(self::once())->method('getRuntimeInputParameters');
+        $this->qtiTestUtilsMock->expects(self::once())->method('getTestDefinition')
+            ->willReturn($assessmentTest);
+
+
+        $this->stateMigrationMock->expects(self::exactly(3 + $questionCount))->method('restore');
+        $this->subject->restore($deliveryExecution);
+    }
+
+    public function getAssessmentTests()
+    {
+        $sectionPart = new SectionPartCollection(
+            [
+                new SectionPart('q1.'),
+                new SectionPart('q2.'),
+            ]
+        );
+
+        $assessmentSection1 = new AssessmentSection('a1.', '', false);
+        $assessmentSection2 = new AssessmentSection('a2.', '', false);
+        $assessmentSection1->setSectionParts($sectionPart);
+        $assessmentSection2->setSectionParts($sectionPart);
+
+        return [
+            [2, 1, new AssessmentTest('a1.', '', new TestPartCollection([new TestPart('a1.', new AssessmentSectionCollection([$assessmentSection1]))]))],
+            [4, 2, new AssessmentTest('a1.', '', new TestPartCollection([new TestPart('a1.', new AssessmentSectionCollection([$assessmentSection1, $assessmentSection2]))]))],
+            [4, 2, new AssessmentTest('a1.', '', new TestPartCollection([new TestPart('a1.', new AssessmentSectionCollection([$assessmentSection1])), new TestPart('a2.', new AssessmentSectionCollection([$assessmentSection2]))]))],
+            [6, 3, new AssessmentTest('a1.', '', new TestPartCollection([new TestPart('a1.', new AssessmentSectionCollection([$assessmentSection1, $assessmentSection2])), new TestPart('a2.', new AssessmentSectionCollection([$assessmentSection1]))]))],
+        ];
+    }
+}


### PR DESCRIPTION
# Introduction

This Backport is intended to solve the issue [NCC-399](https://oat-sa.atlassian.net/browse/NCC-399).

Current Implementation:
The states are being archived in a synchronous manner and can not be configured to be saved on s3
With the backport:
The states will be archived in an asynchronous manner using the tao task queue and saved on s3

# How to test

1. Setup the `/path/to/tao/nccer/config/generis/event.conf.php`:
```
        'oat\\taoQtiTest\\models\\event\\AfterAssessmentTestSessionClosedEvent' => array(
            array(
                'oat\\taoQtiTest\\models\\QtiTestListenerService',
                'archiveState'
            )
        ),
```
2. Take a test
3. check your `stateBackup` file system. You should have the states saved there:
<img width="1369" alt="Screenshot 2022-08-10 at 14 43 22" src="https://user-images.githubusercontent.com/11900046/183904245-d4b2bf40-c9f6-4698-a45c-a4fbd9f68634.png">

