### PR TITLE
Fix/TR-4212/Revert unneeded decoding of HTML entities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "ext-dom": "*",
     "oat-sa/lib-test-cat": "2.3.7",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": ">=0.27.0",
+    "qtism/qtism": ">=0.28.1",
     "oat-sa/generis" : ">=15.17.1",
     "oat-sa/tao-core" : ">=50.18.3",
     "oat-sa/extension-tao-item" : ">=11.0.0",

--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -162,7 +162,7 @@ class taoQtiTest_models_classes_QtiTestConverter
                         $array[$property->getName()][] = $item;
                     }
                 } else {
-                    $array[$property->getName()] = is_string($value) ? html_entity_decode($value) : $value;
+                    $array[$property->getName()] = $value;
                 }
             }
         }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4212

Revert the fix added by #2268 for [AUT-2073](https://oat-sa.atlassian.net/browse/AUT-2073).
It is not needed anymore to decode the HTML entities from the XML attributes since it is fixed inside QTI-SDK (see: https://github.com/oat-sa/qti-sdk/pull/325).

How to test:
 - Create/edit a test and set a title containing some chars like `&`, `<`, `"`
 - Save the test (look at the XML file generated  at `data/taoQtiTest`)
 - Open the test for editing again, and check the symbols added to the title are properly displayed


TODO:
- [x] update the reference to `qtism/qtism` in `composer.json`.
