### PR TITLE
Add `getItems` endpoint for access to imported test items id

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here is a list of known category options:
 REST API
 ========
 
-[QTI Test REST API](https://openapi.taotesting.com/viewer/?url=https://raw.githubusercontent.com/oat-sa/extension-tao-testqti/master/doc/swagger.json)
+[QTI Test REST API](https://raw.githubusercontent.com/oat-sa/extension-tao-testqti/master/doc/swagger.json)
 
 Results variables transmission
 ==============================

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here is a list of known category options:
 REST API
 ========
 
-[QTI Test REST API](https://raw.githubusercontent.com/oat-sa/extension-tao-testqti/master/doc/swagger.json)
+[QTI Test REST API](https://editor.swagger.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Foat-sa%2Fextension-tao-testqti%2Fmaster%2Fdoc%2Fswagger.json)
 
 Results variables transmission
 ==============================

--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -179,7 +179,7 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
 
             $this->returnSuccess(
                 array_map(static function (Resource $item) {
-                    return $item->getUri();
+                    return ['itemUri' => $item->getUri()];
                 }, array_values($this->getQtiTestService()->getItems($testResource)))
             );
         } catch (MissingTestmodelException $e) {

--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -25,6 +25,7 @@ use oat\taoQtiTest\models\tasks\ImportQtiTest;
 use oat\taoQtiItem\controller\AbstractRestQti;
 use core_kernel_classes_Resource as Resource;
 use oat\taoTests\models\MissingTestmodelException;
+use Slim\Http\StatusCode;
 
 /**
  *
@@ -184,7 +185,7 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
         } catch (MissingTestmodelException $e) {
             $this->returnFailure(new common_exception_NotFound(
                 sprintf('Test %s not found', $testUri),
-                404,
+                StatusCode::HTTP_NOT_FOUND,
                 $e
             ));
         } catch (Exception $e) {

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
     "oat-sa/extension-tao-test" : ">=15.0.0",
     "oat-sa/extension-tao-delivery" : ">=15.0.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0",
-    "league/flysystem": "~1.0"
+    "league/flysystem": "~1.0",
+    "slim/slim": "^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -566,6 +566,109 @@
                     }
                 }
             }
+        },
+        "/taoQtiTest/RestQtiTests/getItems": {
+            "get": {
+                "description": "Get list of test items id. Available since Tao 3.1.",
+                "tags": [
+                    "test", "items"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request was correctly handled, test waw found, test items were found",
+                        "schema": {
+                            "title": "response",
+                            "format": "json",
+                            "type": "object",
+                            "required": [
+                                "success",
+                                "version",
+                                "data"
+                            ],
+                            "properties": {
+                                "success": {
+                                    "type": "boolean",
+                                    "description": "True on success"
+                                },
+                                "version": {
+                                    "type": "string",
+                                    "description": "Tao version"
+                                },
+                                "data": {
+                                    "description": "List of items identifiers",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "examples": {
+                            "application/json": {
+                                "success": true,
+                                "data": [
+                                    "http://tao.local/mytao.rdf#xxxxxxxxxxxxx"
+                                ],
+                                "version": "3.1.0"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Required data was not provided",
+                        "examples": {
+                            "application/json": {
+                                "success": false,
+                                "errorCode": 0,
+                                "errorMsg": "Exception error description",
+                                "version": "3.1.0"
+                            }
+                        },
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    },
+                    "404": {
+                        "description": "Test with given id was not found",
+                        "examples": {
+                            "application/json": {
+                                "success": false,
+                                "errorCode": 0,
+                                "errorMsg": "Exception error description",
+                                "version": "3.1.0"
+                            }
+                        },
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error (should not occur)",
+                        "examples": {
+                            "application/json": {
+                                "success": false,
+                                "errorCode": 0,
+                                "errorMsg": "Exception error description",
+                                "version": "3.1.0"
+                            }
+                        },
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "testUri",
+                        "in": "query",
+                        "description": "Test identifier",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ]
+            }
         }
     },
     "definitions": {

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -598,7 +598,8 @@
                                     "description": "List of items identifiers",
                                     "type": "array",
                                     "items": {
-                                        "type": "string"
+                                        "type": "object",
+                                        "$ref": "#/definitions/item"
                                     }
                                 }
                             }
@@ -607,7 +608,9 @@
                             "application/json": {
                                 "success": true,
                                 "data": [
-                                    "http://tao.local/mytao.rdf#xxxxxxxxxxxxx"
+                                    {
+                                        "itemUri": "http://tao.local/mytao.rdf#xxxxxxxxxxxxx"
+                                    }
                                 ],
                                 "version": "3.1.0"
                             }
@@ -733,6 +736,17 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "item": {
+            "type": "object",
+            "required": [
+                "itemUri"
+            ],
+            "properties": {
+                "itemUri": {
+                    "type": "string"
                 }
             }
         }


### PR DESCRIPTION
# [ADF-1052](https://oat-sa.atlassian.net/browse/ADF-1052)

## Summary
New endpoint provided for possibility to fetch items id for asynchronously imported tests

## How to test
- install branch
- use REST api endpoint to import test `/taoQtiTest/RestQtiTests/importDeferred`
- request test id by `/taoQtiTest/RestQtiTests/getStatus?id={taskId}`
- make request on new endpoint `/taoQtiTest/RestQtiTests/getItems?testUri={testId}`
- next payload should be provided
```json
{
    "success": true,
    "data": [
        "http://tao.local/mytao.rdf#xxxxxxxxxxxxx"
    ],
    "version": "{version}"
}
```

## TAE
https://oat-sa.atlassian.net/browse/ADF-1052?focusedCommentId=198991