### PR TITLE
fix: update tao-test-runner-qti version to fix bug test navigation disabled with min duration

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,8 +10,9 @@
             "integrity": "sha512-PB1dozCUv+loYijTV4us6xH1cr5iFUj66u0HswBBXwN0o/aI1qNouT5rj6Q6F9jKxUpTj441hE7Qbbz6vjd4TQ=="
         },
         "@oat-sa/tao-test-runner-qti": {
-            "version": "github:oat-sa/tao-test-runner-qti-fe#41864b707d0ebefe84cd48edca7986cf46462211",
-            "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-3481/test-navigation-disabled-with-min-duration-tr"
+            "version": "2.32.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.32.0.tgz",
+            "integrity": "sha512-kZ6TsX3gS6HOKEdz8eeVc/Klz0R2+J2Je86gANuerxYOaDLvjIrHJ9+hptJwdBNp8OM5Sp6d5Vd025Ml3FD+iw=="
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,9 +10,8 @@
             "integrity": "sha512-PB1dozCUv+loYijTV4us6xH1cr5iFUj66u0HswBBXwN0o/aI1qNouT5rj6Q6F9jKxUpTj441hE7Qbbz6vjd4TQ=="
         },
         "@oat-sa/tao-test-runner-qti": {
-            "version": "2.31.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-2.31.2.tgz",
-            "integrity": "sha512-REXFQphsh3uA53URjAcEdwf+qF6D7QODf/PNrysUkHAzkX9RYF+eZ+2GjrCEFr85tS3beJBhHR66xRlRQ1MX5Q=="
+            "version": "github:oat-sa/tao-test-runner-qti-fe#41864b707d0ebefe84cd48edca7986cf46462211",
+            "from": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-3481/test-navigation-disabled-with-min-duration-tr"
         }
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     "license": "GPL-2.0",
     "dependencies": {
         "@oat-sa/tao-test-runner": "0.9.0",
-        "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-3481/test-navigation-disabled-with-min-duration-tr"
+        "@oat-sa/tao-test-runner-qti": "2.32.0"
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     "license": "GPL-2.0",
     "dependencies": {
         "@oat-sa/tao-test-runner": "0.9.0",
-        "@oat-sa/tao-test-runner-qti": "2.31.2"
+        "@oat-sa/tao-test-runner-qti": "github:oat-sa/tao-test-runner-qti-fe#fix/TR-3481/test-navigation-disabled-with-min-duration-tr"
     }
 }


### PR DESCRIPTION
**Related to:** [TR-3481](https://oat-sa.atlassian.net/browse/TR-3481)

**Update** `@oat-sa/tao-test-runner-qti`  with  version @2.32.0