### PR TITLE
fix: preload Match operator class on php8

### DIFF
--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -53,6 +53,7 @@ class taoQtiTest_models_classes_QtiTestConverter
         'custom',
         'math',
         'or',
+        'match',
         'stats'
     ];
 


### PR DESCRIPTION
# [AUT-2578](https://oat-sa.atlassian.net/browse/AUT-2578)

## Description
When User set Cut score Outcome processing and tries to save the test, the server responds with 500:error without saving the changes. And in this case, user is not able to use the Cut score option - there is no workaround. For example - if the user clicks “Manage Tests“ and try to save the test this way, the server also responds with 500.

## Steps to test:
1. Go to the "Tests" page, create a new Test and go to its "Authoring" tab
2. Click on the gear symbol that is located to the right of the name of the Test (not to be confused with the test Part title below that)
3. Select the "Cut score" option in the "Outcome processing" drop-down list
4. Click the “Save“ button

## Development impact 
1. The bug happens on `class_exists` function because of second params (autoload). 
Since PHP 8 match is registered under a callable type entity so it is not possible to use it as a class name event it covered with version validation, and usage `match` without `()` is a mistake. 
2. I Apply it to work around which used before for other such elements. Now instead of class `Match` we validate and preload class `MatchOperator` which seems to be okay 

## Demo 

https://user-images.githubusercontent.com/2750628/191057859-22aa31ef-b05c-41de-b10e-012d1399a4cc.mov


