### PR TITLE
[FEATURE] [PISA25-100] Add endpoint in authoring to update metadata

### DIFF
--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -672,6 +672,75 @@
                     "application/x-www-form-urlencoded"
                 ]
             }
+        },
+        "/taoQtiTest/RestQtiTests/updateMetadata": {
+            "post": {
+                "description": "Update the metadata of a given test",
+                "tags": [
+                    "test"
+                ],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "description": "The metadata that has to be updated",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/metadataEntity"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/updateMetadataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request if you send invalid parameters.",
+                        "examples": {
+                            "application/json": {
+                                "success": false,
+                                "errorCode": 0,
+                                "errorMsg": "At least one mandatory parameter was required but found missing in your request",
+                                "version": "3.1.0"
+                            }
+                        },
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "examples": {
+                            "application/json": {
+                                "success": false,
+                                "errorCode": 0,
+                                "errorMsg": "You don't have permission to access this resource.",
+                                "version": "3.1.0"
+                            }
+                        },
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "examples": {
+                            "application/json": {
+                                "success": false,
+                                "errorCode": 0,
+                                "errorMsg": "Exception error description",
+                                "version": "3.1.0"
+                            }
+                        },
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -747,6 +816,52 @@
             "properties": {
                 "itemUri": {
                     "type": "string"
+                }
+            }
+        },
+        "metadataEntity": {
+            "type": "object",
+            "required": [
+                "resourceUri",
+                "propertyUri",
+                "value"
+            ],
+            "properties": {
+                "resourceUri": {
+                    "type": "string",
+                    "description": "The Test URI where the Metadata Belongs to",
+                    "example": "https://tao.local/ontologies/tao.rdf#my-test-uri"
+                },
+                "propertyUri": {
+                    "type": "string",
+                    "description": "The Property URI where the Metadata value is related",
+                    "example": "https://tao.local/ontologies/tao.rdf#my-property-uri"
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The value of the metadata",
+                    "example": "This is a metadata update"
+                }
+            }
+        },
+        "updateMetadataResponse": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "success",
+                    "data"
+                ],
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "data": {
+                        "$ref": "#/definitions/metadataEntity"
+                    },
+                    "version": {
+                        "type": "string"
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Introduction
This ticket relates to the issue https://oat-sa.atlassian.net/browse/PISA25-100

## How to test it:
After installing the application, you can follow the instructions on the [api documentation](https://github.com/oat-sa/extension-tao-itemqti/blob/10a06098aa270aeeae3de9887358ae4ad90ee926/doc/rest.json) to access the new endpoint. Here you can find a request examples with **basic authorization** where username is `admin` and password is `Admin.12345`.

### For Item
```
curl --location --request POST 'https://testtaophp74.docker.localhost/taoQtiItem/RestQtiItem/updateMetadata' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'Authorization: Basic YWRtaW46QWRtaW4uMTIzNDU=' \
--header 'Cookie: XDEBUG_SESSION=PHPSTORM' \
--data-raw '{
    "resourceUri": "https://testtaophp74.docker.localhost/ontologies/tao.rdf#i6357c62f633821062f79daa47f73e9c",
    "propertyUri": "https://testtaophp74.docker.localhost/ontologies/tao.rdf#i6357ef2f938df38a135c0d605652e65",
    "value": "http://www.tao.lu/Ontologies/TAO.rdf#Langen-US"
}'
```
### For test
```
curl --location --request POST 'https://testtaophp74.docker.localhost/taoQtiTest/RestQtiTests/updateMetadata' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'Authorization: Basic YWRtaW46QWRtaW4uMTIzNDU='  \
--header 'Cookie: XDEBUG_SESSION=PHPSTORM' \
--data-raw '{
    "resourceUri": "https://testtaophp74.docker.localhost/ontologies/tao.rdf#i6357c62516c9e10252f631b3d0311bb",
    "propertyUri": "https://testtaophp74.docker.localhost/ontologies/tao.rdf#i6358ee17065a055678f93c0b31e2e55",
    "value": "this is a test"
}'
```
