### PR TITLE
feat: adds visibility option

### DIFF
--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -187,6 +187,7 @@
             </div>
         </div>
 
+        {{#if hasSelectionWithReplacement}}
 <!-- assessmentTest/testPart/assessmentSection/selection/withReplacement -->
         <div class="grid-row pseudo-label-box">
             <div class="col-5">
@@ -206,6 +207,7 @@
                 </div>
             </div>
         </div>
+        {{/if}}
     </div>
 
     <h4 class="toggler closed" data-toggle="~ .section-ordering">{{__ 'Ordering'}}</h4>

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -96,9 +96,10 @@ define([
             sectionModel.hasBlueprint = true;
         }
 
-        if (servicesFeatures.isVisible('taoQtiTest/creator/properties/selectionWithReplacement', false)) {
-            sectionModel.hasSelectionWithReplacement = true;
-        }
+        sectionModel.hasSelectionWithReplacement = servicesFeatures.isVisible(
+            'taoQtiTest/creator/properties/selectionWithReplacement',
+            false
+        );
 
         //add feature visibility properties to sectionModel
         featureVisibility.addSectionVisibilityProps(sectionModel);

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -38,7 +38,8 @@ define([
     'ui/dialog/confirm',
     'taoQtiTest/controller/creator/helpers/subsection',
     'taoQtiTest/controller/creator/helpers/validators',
-    'taoQtiTest/controller/creator/helpers/featureVisibility'
+    'taoQtiTest/controller/creator/helpers/featureVisibility',
+    'services/features'
 ], function (
     $,
     _,
@@ -58,7 +59,8 @@ define([
     confirmDialog,
     subsectionsHelper,
     validators,
-    featureVisibility
+    featureVisibility,
+    servicesFeatures
 ) {
     ('use strict');
 
@@ -92,6 +94,10 @@ define([
 
         if (!_.isEmpty(config.routes.blueprintsById)) {
             sectionModel.hasBlueprint = true;
+        }
+
+        if (servicesFeatures.isVisible('taoQtiTest/creator/properties/selectionWithReplacement', false)) {
+            sectionModel.hasSelectionWithReplacement = true;
         }
 
         //add feature visibility properties to sectionModel

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -84,9 +84,10 @@ define([
             subsectionModel.hasBlueprint = true;
         }
 
-        if (servicesFeatures.isVisible('taoQtiTest/creator/properties/selectionWithReplacement', false)) {
-            sectionModel.hasSelectionWithReplacement = true;
-        }
+        sectionModel.hasSelectionWithReplacement = servicesFeatures.isVisible(
+            'taoQtiTest/creator/properties/selectionWithReplacement',
+            false
+        );
 
         actions.properties($titleWithActions, 'section', subsectionModel, propHandler);
         actions.move($titleWithActions, 'subsections', 'subsection');

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -32,7 +32,8 @@ define([
     'taoQtiTest/controller/creator/helpers/sectionBlueprints',
     'ui/dialog/confirm',
     'taoQtiTest/controller/creator/helpers/subsection',
-    'taoQtiTest/controller/creator/helpers/validators'
+    'taoQtiTest/controller/creator/helpers/validators',
+    'services/features'
 ], function (
     $,
     _,
@@ -49,7 +50,8 @@ define([
     sectionBlueprint,
     confirmDialog,
     subsectionsHelper,
-    validators
+    validators,
+    servicesFeatures
 ) {
     'use strict';
     /**
@@ -81,6 +83,11 @@ define([
         if (!_.isEmpty(config.routes.blueprintsById)) {
             subsectionModel.hasBlueprint = true;
         }
+
+        if (servicesFeatures.isVisible('taoQtiTest/creator/properties/selectionWithReplacement', false)) {
+            sectionModel.hasSelectionWithReplacement = true;
+        }
+
         actions.properties($titleWithActions, 'section', subsectionModel, propHandler);
         actions.move($titleWithActions, 'subsections', 'subsection');
         actions.displayItemWrapper($subsection);


### PR DESCRIPTION
[TR-1328](https://oat-sa.atlassian.net/browse/TR-1328)

changelog:
* disable visibility of selection property in section and sub section
* creates a new section property to allow visibility via migration

Steps to check:

* login with admin credentials
* go to tests section
* create a test
* add some items
* check the selection tool
* To enable the “with replacement“ (out of the scope, but for the sake of tests), editing the config/tao/client_lib_config_registry and adding 'services/features' => [    'visibility' => [        'taoQtiTest/creator/properties/selectionWithReplacement' => 'show',    ]] just at the end, and hard reloading your browser should show the “with replacement“ option back

[TR-1328]: https://oat-sa.atlassian.net/browse/TR-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ