### PR TITLE
fix: display categories in sections from subsections

### DIFF
--- a/views/js/controller/creator/helpers/category.js
+++ b/views/js/controller/creator/helpers/category.js
@@ -13,16 +13,14 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2023 (original work) Open Assessment Technologies SA ;
  */
 /**
  * Helper that provides a way to browse all categories attached to a test model at the item level.
  *
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
-define([
-    'lodash'
-], function (_) {
+define(['lodash'], function (_) {
     'use strict';
 
     /**
@@ -41,14 +39,14 @@ define([
      * @param {Function} cb
      */
     function eachCategories(testModel, cb) {
-        const getCategoriesRecursively = (section) => {
+        const getCategoriesRecursively = section => {
             _.forEach(section.sectionParts, function (sectionPart) {
                 if (sectionPart['qti-type'] === 'assessmentItemRef') {
-                    _.forEach(sectionPart.categories, function(category) {
+                    _.forEach(sectionPart.categories, function (category) {
                         cb(category, sectionPart);
                     });
                 }
-                if(sectionPart['qti-type'] === 'assessmentSection') {
+                if (sectionPart['qti-type'] === 'assessmentSection') {
                     getCategoriesRecursively(sectionPart);
                 }
             });
@@ -78,7 +76,7 @@ define([
          */
         listCategories: function listCategories(testModel) {
             var categories = {};
-            eachCategories(testModel, function(category) {
+            eachCategories(testModel, function (category) {
                 if (!isCategoryOption(category)) {
                     categories[category] = true;
                 }
@@ -94,7 +92,7 @@ define([
          */
         listOptions: function listOptions(testModel) {
             var options = {};
-            eachCategories(testModel, function(category) {
+            eachCategories(testModel, function (category) {
                 if (isCategoryOption(category)) {
                     options[category] = true;
                 }

--- a/views/js/controller/creator/helpers/category.js
+++ b/views/js/controller/creator/helpers/category.js
@@ -41,13 +41,21 @@ define([
      * @param {Function} cb
      */
     function eachCategories(testModel, cb) {
+        const getCategoriesRecursively = (section) => {
+            _.forEach(section.sectionParts, function (sectionPart) {
+                if (sectionPart['qti-type'] === 'assessmentItemRef') {
+                    _.forEach(sectionPart.categories, function(category) {
+                        cb(category, sectionPart);
+                    });
+                }
+                if(sectionPart['qti-type'] === 'assessmentSection') {
+                    getCategoriesRecursively(sectionPart);
+                }
+            });
+        };
         _.forEach(testModel.testParts, function (testPart) {
             _.forEach(testPart.assessmentSections, function (assessmentSection) {
-                _.forEach(assessmentSection.sectionParts, function (itemRef) {
-                    _.forEach(itemRef.categories, function(category) {
-                        cb(category, itemRef);
-                    });
-                });
+                getCategoriesRecursively(assessmentSection);
             });
         });
     }

--- a/views/js/controller/creator/helpers/categorySelector.js
+++ b/views/js/controller/creator/helpers/categorySelector.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2023 (original work) Open Assessment Technologies SA;
  */
 /**
  * This helper manages the category selection UI:
@@ -32,53 +32,51 @@ define([
     'taoQtiTest/controller/creator/templates/index',
     'taoQtiTest/controller/creator/helpers/featureVisibility',
     'select2'
-], function($, _, __, eventifier, tooltip, templates, featureVisibility) {
+], function ($, _, __, eventifier, tooltip, templates, featureVisibility) {
     'use strict';
 
-    var allPresets = [],
+    let allPresets = [],
         allQtiCategoriesPresets = [];
 
-
     function categorySelectorFactory($container) {
-        var categorySelector,
-
-            $presetsContainer = $container.find('.category-presets'),
-            $presetsCheckboxes,
-            $customCategoriesSelect = $container.find('[name=category-custom]');
+        const $presetsContainer = $container.find('.category-presets');
+        const $customCategoriesSelect = $container.find('[name=category-custom]');
 
         /**
          * Read the form state from the DOM and trigger an event with the result, so the listeners can update the item/section model
          * @fires categorySelector#category-change
          */
         function updateCategories() {
-            var selectedCategories,
-                indeterminatedCategories,
-
-                presetSelected = $container
+            const presetSelected = $container
                     .find('.category-preset input:checked')
                     .toArray()
-                    .map(function(categoryEl) {
+                    .map(function (categoryEl) {
                         return categoryEl.value;
                     }),
                 presetIndeterminate = $container
                     .find('.category-preset input:indeterminate')
                     .toArray()
-                    .map(function(categoryEl) {
+                    .map(function (categoryEl) {
                         return categoryEl.value;
                     }),
-                customSelected = $customCategoriesSelect.siblings('.select2-container').find('.select2-search-choice').not('.partial')
+                customSelected = $customCategoriesSelect
+                    .siblings('.select2-container')
+                    .find('.select2-search-choice')
+                    .not('.partial')
                     .toArray()
-                    .map(function(categoryEl) {
+                    .map(function (categoryEl) {
                         return categoryEl.textContent && categoryEl.textContent.trim();
                     }),
-                customIndeterminate = $customCategoriesSelect.siblings('.select2-container').find('.select2-search-choice.partial')
+                customIndeterminate = $customCategoriesSelect
+                    .siblings('.select2-container')
+                    .find('.select2-search-choice.partial')
                     .toArray()
-                    .map(function(categoryEl) {
+                    .map(function (categoryEl) {
                         return categoryEl.textContent && categoryEl.textContent.trim();
                     });
 
-            selectedCategories = presetSelected.concat(customSelected);
-            indeterminatedCategories = presetIndeterminate.concat(customIndeterminate);
+            const selectedCategories = presetSelected.concat(customSelected);
+            const indeterminatedCategories = presetIndeterminate.concat(customIndeterminate);
 
             /**
              * @event categorySelector#category-change
@@ -88,7 +86,7 @@ define([
             this.trigger('category-change', selectedCategories, indeterminatedCategories);
         }
 
-        categorySelector = {
+        const categorySelector = {
             /**
              * Create the category selection form
              *
@@ -97,43 +95,41 @@ define([
              * @param {string} [level] one of the values `testPart`, `section` or `itemRef`
              */
             createForm: function createForm(currentCategories, level) {
-                var self = this,
+                const self = this,
                     presetsTpl = templates.properties.categorypresets,
                     customCategories = _.difference(currentCategories, allQtiCategoriesPresets);
 
                 const filteredPresets = featureVisibility.filterVisiblePresets(allPresets, level);
                 // add preset checkboxes
-                $presetsContainer.append(
-                    presetsTpl({presetGroups: filteredPresets})
-                );
+                $presetsContainer.append(presetsTpl({ presetGroups: filteredPresets }));
 
-                $presetsContainer.on('click', function(e) {
-                    var $preset = $(e.target).closest('.category-preset'),
-                        $checkbox;
-
+                $presetsContainer.on('click', function (e) {
+                    const $preset = $(e.target).closest('.category-preset');
                     if ($preset.length) {
-                        $checkbox = $preset.find('input');
+                        const $checkbox = $preset.find('input');
                         $checkbox.prop('indeterminate', false);
 
-                        _.defer(function() {
+                        _.defer(function () {
                             updateCategories.call(self);
                         });
                     }
                 });
 
                 // init custom categories field
-                $customCategoriesSelect.select2({
-                    width: '100%',
-                    tags : customCategories,
-                    multiple : true,
-                    tokenSeparators: [",", " ", ";"],
-                    formatNoMatches : function(){
-                        return __('Enter a custom category');
-                    },
-                    maximumInputLength : 32
-                }).on('change', function(){
-                    updateCategories.call(self);
-                });
+                $customCategoriesSelect
+                    .select2({
+                        width: '100%',
+                        tags: customCategories,
+                        multiple: true,
+                        tokenSeparators: [',', ' ', ';'],
+                        formatNoMatches: function () {
+                            return __('Enter a custom category');
+                        },
+                        maximumInputLength: 32
+                    })
+                    .on('change', function () {
+                        updateCategories.call(self);
+                    });
 
                 // enable help tooltips
                 tooltip.lookup($container);
@@ -145,17 +141,15 @@ define([
              * @param {String[]} [indeterminate] - categories in an indeterminate state at a section level
              */
             updateFormState: function updateFormState(selected, indeterminate) {
-                var customCategories;
-
                 indeterminate = indeterminate || [];
 
-                customCategories = _.difference(selected.concat(indeterminate), allQtiCategoriesPresets);
+                const customCategories = _.difference(selected.concat(indeterminate), allQtiCategoriesPresets);
 
                 // Preset categories
 
-                $presetsCheckboxes = $container.find('.category-preset input');
-                $presetsCheckboxes.each(function() {
-                    var category = this.value;
+                const $presetsCheckboxes = $container.find('.category-preset input');
+                $presetsCheckboxes.each(function () {
+                    const category = this.value;
 
                     this.indeterminate = false;
                     this.checked = false;
@@ -171,13 +165,16 @@ define([
 
                 $customCategoriesSelect.select2('val', customCategories);
 
-                $customCategoriesSelect.siblings('.select2-container').find('.select2-search-choice').each(function(){
-                    var $li = $(this);
-                    var content = $li.find('div').text();
-                    if(indeterminate.indexOf(content) !== -1){
-                        $li.addClass('partial');
-                    }
-                });
+                $customCategoriesSelect
+                    .siblings('.select2-container')
+                    .find('.select2-search-choice')
+                    .each(function () {
+                        const $li = $(this);
+                        const content = $li.find('div').text();
+                        if (indeterminate.indexOf(content) !== -1) {
+                            $li.addClass('partial');
+                        }
+                    });
             }
         };
 
@@ -198,7 +195,7 @@ define([
      *              label: 'Next Part Warning',
      *              qtiCategory : 'x-tao-option-nextPartWarning',
      *              description : 'Displays a warning before the user finishes a part'
- *              },
+     *          },
      *          ...
      *      ]
      *  },
@@ -218,7 +215,7 @@ define([
      */
     function extractCategoriesFromPresets() {
         return allPresets.reduce(function (prev, current) {
-            var groupIds = _.pluck(current.presets, 'qtiCategory');
+            const groupIds = _.pluck(current.presets, 'qtiCategory');
             return prev.concat(groupIds);
         }, []);
     }

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2023 (original work) Open Assessment Technologies SA ;
  */
 /**
  * Basic helper that is intended to manage the score processing declaration in a test model.
@@ -90,46 +90,52 @@ define([
         total: {
             key: 'total',
             signature: /^SCORE_([a-zA-Z][a-zA-Z0-9_\.-]*)$/,
-            outcomes: [{
-                writer: 'total',
-                identifier: 'SCORE_TOTAL',
-                weighted: 'SCORE_TOTAL_WEIGHTED',
-                categoryIdentifier: 'SCORE_CATEGORY_%s',
-                categoryWeighted: 'SCORE_CATEGORY_WEIGHTED_%s'
-            }, {
-                writer: 'max',
-                identifier: 'SCORE_TOTAL_MAX',
-                weighted: 'SCORE_TOTAL_MAX_WEIGHTED',
-                categoryIdentifier: 'SCORE_CATEGORY_MAX_%s',
-                categoryWeighted: 'SCORE_CATEGORY_WEIGHTED_MAX_%s'
-            }, {
-                writer: 'ratio',
-                identifier: 'SCORE_RATIO',
-                weighted: 'SCORE_RATIO_WEIGHTED',
-                scoreIdentifier: {
-                    total : 'SCORE_TOTAL',
-                    max : 'SCORE_TOTAL_MAX'
+            outcomes: [
+                {
+                    writer: 'total',
+                    identifier: 'SCORE_TOTAL',
+                    weighted: 'SCORE_TOTAL_WEIGHTED',
+                    categoryIdentifier: 'SCORE_CATEGORY_%s',
+                    categoryWeighted: 'SCORE_CATEGORY_WEIGHTED_%s'
                 },
-                scoreWeighted : {
-                    total : 'SCORE_TOTAL_WEIGHTED',
-                    max : 'SCORE_TOTAL_MAX_WEIGHTED',
+                {
+                    writer: 'max',
+                    identifier: 'SCORE_TOTAL_MAX',
+                    weighted: 'SCORE_TOTAL_MAX_WEIGHTED',
+                    categoryIdentifier: 'SCORE_CATEGORY_MAX_%s',
+                    categoryWeighted: 'SCORE_CATEGORY_WEIGHTED_MAX_%s'
                 },
-            }],
+                {
+                    writer: 'ratio',
+                    identifier: 'SCORE_RATIO',
+                    weighted: 'SCORE_RATIO_WEIGHTED',
+                    scoreIdentifier: {
+                        total: 'SCORE_TOTAL',
+                        max: 'SCORE_TOTAL_MAX'
+                    },
+                    scoreWeighted: {
+                        total: 'SCORE_TOTAL_WEIGHTED',
+                        max: 'SCORE_TOTAL_MAX_WEIGHTED'
+                    }
+                }
+            ],
             clean: true
         },
         cut: {
             key: 'cut',
             include: 'total',
             signature: /^PASS_([a-zA-Z][a-zA-Z0-9_\.-]*)$/,
-            outcomes: [{
-                writer: 'cut',
-                identifier: 'PASS_ALL',
-                feedback: 'PASS_ALL_RENDERING',
-                feedbackOk: "passed",
-                feedbackFailed: "not_passed",
-                categoryIdentifier: 'PASS_CATEGORY_%s',
-                categoryFeedback: 'PASS_CATEGORY_%s_RENDERING'
-            }],
+            outcomes: [
+                {
+                    writer: 'cut',
+                    identifier: 'PASS_ALL',
+                    feedback: 'PASS_ALL_RENDERING',
+                    feedbackOk: 'passed',
+                    feedbackFailed: 'not_passed',
+                    categoryIdentifier: 'PASS_CATEGORY_%s',
+                    categoryFeedback: 'PASS_CATEGORY_%s_RENDERING'
+                }
+            ],
             clean: true
         }
     };
@@ -145,11 +151,21 @@ define([
          * @param {Object} scoring
          * @param {Object} outcomes
          */
-        ratio : function writerRatio(descriptor, scoring, outcomes){
-            addRatioOutcomes(outcomes, descriptor.identifier, descriptor.scoreIdentifier.total, descriptor.scoreIdentifier.max);
-            if(scoring.weightIdentifier){
+        ratio: function writerRatio(descriptor, scoring, outcomes) {
+            addRatioOutcomes(
+                outcomes,
+                descriptor.identifier,
+                descriptor.scoreIdentifier.total,
+                descriptor.scoreIdentifier.max
+            );
+            if (scoring.weightIdentifier) {
                 //add weighted ratio outcome only when the scoring outcome processing rule uses a weight
-                addRatioOutcomes(outcomes, descriptor.weighted, descriptor.scoreWeighted.total, descriptor.scoreWeighted.max);
+                addRatioOutcomes(
+                    outcomes,
+                    descriptor.weighted,
+                    descriptor.scoreWeighted.total,
+                    descriptor.scoreWeighted.max
+                );
             }
         },
 
@@ -170,9 +186,21 @@ define([
             // create an outcome per categories
             if (descriptor.categoryIdentifier && categories) {
                 _.forEach(categories, function (category) {
-                    addTotalScoreOutcomes(outcomes, scoring, formatCategoryOutcome(category, descriptor.categoryIdentifier), false, category);
+                    addTotalScoreOutcomes(
+                        outcomes,
+                        scoring,
+                        formatCategoryOutcome(category, descriptor.categoryIdentifier),
+                        false,
+                        category
+                    );
                     if (descriptor.categoryWeighted && scoring.weightIdentifier) {
-                        addTotalScoreOutcomes(outcomes, scoring, formatCategoryOutcome(category, descriptor.categoryWeighted), true, category);
+                        addTotalScoreOutcomes(
+                            outcomes,
+                            scoring,
+                            formatCategoryOutcome(category, descriptor.categoryWeighted),
+                            true,
+                            category
+                        );
                     }
                 });
             }
@@ -195,9 +223,21 @@ define([
             // create an outcome per categories
             if (descriptor.categoryIdentifier && categories) {
                 _.forEach(categories, function (category) {
-                    addMaxScoreOutcomes(outcomes, scoring, formatCategoryOutcome(category, descriptor.categoryIdentifier), false, category);
+                    addMaxScoreOutcomes(
+                        outcomes,
+                        scoring,
+                        formatCategoryOutcome(category, descriptor.categoryIdentifier),
+                        false,
+                        category
+                    );
                     if (descriptor.categoryWeighted && scoring.weightIdentifier) {
-                        addMaxScoreOutcomes(outcomes, scoring, formatCategoryOutcome(category, descriptor.categoryWeighted), true, category);
+                        addMaxScoreOutcomes(
+                            outcomes,
+                            scoring,
+                            formatCategoryOutcome(category, descriptor.categoryWeighted),
+                            true,
+                            category
+                        );
                     }
                 });
             }
@@ -209,13 +249,14 @@ define([
          * @param {Object} scoring
          * @param {Object} outcomes
          * @param {Array} [categories]
+         * @returns {Object} outcomes
          */
         cut: function writerCut(descriptor, scoring, outcomes, categories) {
             var cutScore = scoring.cutScore;
             var totalModeOutcomes = outcomesRecipes.total.outcomes;
-            var total = _.find(totalModeOutcomes, {writer: 'total'});
-            var max = _.find(totalModeOutcomes, {writer: 'max'});
-            var ratio = _.find(totalModeOutcomes, {writer: 'ratio'});
+            var total = _.find(totalModeOutcomes, { writer: 'total' });
+            var max = _.find(totalModeOutcomes, { writer: 'max' });
+            var ratio = _.find(totalModeOutcomes, { writer: 'ratio' });
             var whichOutcome = scoring.weightIdentifier ? 'weighted' : 'identifier';
             var ratioIdentifier = ratio[whichOutcome];
 
@@ -241,7 +282,13 @@ define([
                     var categoryScoreIdentifier = formatCategoryOutcome(category, total[categoryOutcome]);
                     var categoryCountIdentifier = formatCategoryOutcome(category, max[categoryOutcome]);
 
-                    addCutScoreOutcomes(outcomes, categoryOutcomeIdentifier, categoryScoreIdentifier, categoryCountIdentifier, cutScore);
+                    addCutScoreOutcomes(
+                        outcomes,
+                        categoryOutcomeIdentifier,
+                        categoryScoreIdentifier,
+                        categoryCountIdentifier,
+                        cutScore
+                    );
 
                     if (descriptor.categoryFeedback) {
                         addFeedbackScoreOutcomes(
@@ -274,7 +321,7 @@ define([
             var model;
 
             if (!modelOverseer || !_.isFunction(modelOverseer.getModel)) {
-                throw new TypeError("You must provide a valid modelOverseer");
+                throw new TypeError('You must provide a valid modelOverseer');
             }
 
             model = modelOverseer.getModel();
@@ -322,7 +369,7 @@ define([
             var model, scoring, outcomes, outcomeRecipe, recipes, categories;
 
             if (!modelOverseer || !_.isFunction(modelOverseer.getModel)) {
-                throw new TypeError("You must provide a valid modelOverseer");
+                throw new TypeError('You must provide a valid modelOverseer');
             }
 
             model = modelOverseer.getModel();
@@ -333,7 +380,6 @@ define([
             if (scoring) {
                 outcomeRecipe = outcomesRecipes[scoring.outcomeProcessing];
                 if (outcomeRecipe) {
-
                     if (outcomeRecipe.clean) {
                         // erase the existing rules, they will be replaced by those that are defined here
                         removeScoring(outcomes);
@@ -348,13 +394,12 @@ define([
                     }
 
                     // will generate outcomes based of the defined recipe
-                    _.forEach(recipes, function(recipe) {
+                    _.forEach(recipes, function (recipe) {
                         var writer = outcomesWriters[recipe.writer];
                         writer(recipe, scoring, outcomes, categories);
                     });
-
                 } else {
-                    throw new Error('Unknown score processing mode: ' + scoring.outcomeProcessing);
+                    throw new Error(`Unknown score processing mode: ${scoring.outcomeProcessing}`);
                 }
             }
 
@@ -373,9 +418,15 @@ define([
      */
     function addTotalScoreOutcomes(model, scoring, identifier, weight, category) {
         var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.FLOAT);
-        var processingRule = processingRuleHelper.setOutcomeValue(identifier,
+        var processingRule = processingRuleHelper.setOutcomeValue(
+            identifier,
             processingRuleHelper.sum(
-                processingRuleHelper.testVariables(scoring.scoreIdentifier, -1, weight && scoring.weightIdentifier, category)
+                processingRuleHelper.testVariables(
+                    scoring.scoreIdentifier,
+                    -1,
+                    weight && scoring.weightIdentifier,
+                    category
+                )
             )
         );
 
@@ -393,7 +444,8 @@ define([
      */
     function addMaxScoreOutcomes(model, scoring, identifier, weight, category) {
         var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.FLOAT);
-        var processingRule = processingRuleHelper.setOutcomeValue(identifier,
+        var processingRule = processingRuleHelper.setOutcomeValue(
+            identifier,
             processingRuleHelper.sum(
                 processingRuleHelper.testVariables('MAXSCORE', -1, weight && scoring.weightIdentifier, category)
             )
@@ -404,24 +456,24 @@ define([
     /**
      * Create an outcome and the rule that process the score ratio
      *
-     * @param model
-     * @param identifier
-     * @param identifierTotal
-     * @param identifierMax
+     * @param {Object} model
+     * @param {String} identifier
+     * @param {String} identifierTotal
+     * @param {String} identifierMax
      */
     function addRatioOutcomes(model, identifier, identifierTotal, identifierMax) {
         var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.FLOAT);
         var outcomeCondition = processingRuleHelper.outcomeCondition(
             processingRuleHelper.outcomeIf(
-                processingRuleHelper.isNull(
-                    processingRuleHelper.variable(identifierMax)
-                ),
-                processingRuleHelper.setOutcomeValue(identifier,
+                processingRuleHelper.isNull(processingRuleHelper.variable(identifierMax)),
+                processingRuleHelper.setOutcomeValue(
+                    identifier,
                     processingRuleHelper.baseValue(0, baseTypeHelper.FLOAT)
                 )
             ),
             processingRuleHelper.outcomeElse(
-                processingRuleHelper.setOutcomeValue(identifier,
+                processingRuleHelper.setOutcomeValue(
+                    identifier,
                     processingRuleHelper.divide(
                         processingRuleHelper.variable(identifierTotal),
                         processingRuleHelper.variable(identifierMax)
@@ -445,7 +497,8 @@ define([
      */
     function addCutScoreOutcomes(model, identifier, scoreIdentifier, countIdentifier, cutScore) {
         var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.BOOLEAN);
-        var processingRule = processingRuleHelper.setOutcomeValue(identifier,
+        var processingRule = processingRuleHelper.setOutcomeValue(
+            identifier,
             processingRuleHelper.gte(
                 processingRuleHelper.divide(
                     processingRuleHelper.variable(scoreIdentifier),
@@ -463,13 +516,13 @@ define([
      *
      * @param {Object} model
      * @param {String} identifier
-     * @param {String} scoreIdentifier
-     * @param {String} countIdentifier
+     * @param {String} ratioIdentifier
      * @param {String|Number} cutScore
      */
     function addGlobalCutScoreOutcomes(model, identifier, ratioIdentifier, cutScore) {
         var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.BOOLEAN);
-        var processingRule = processingRuleHelper.setOutcomeValue(identifier,
+        var processingRule = processingRuleHelper.setOutcomeValue(
+            identifier,
             processingRuleHelper.gte(
                 processingRuleHelper.variable(ratioIdentifier),
                 processingRuleHelper.baseValue(cutScore, baseTypeHelper.FLOAT)
@@ -497,14 +550,10 @@ define([
                     processingRuleHelper.variable(variable),
                     processingRuleHelper.baseValue(true, baseTypeHelper.BOOLEAN)
                 ),
-                processingRuleHelper.setOutcomeValue(identifier,
-                    processingRuleHelper.baseValue(passed, type)
-                )
+                processingRuleHelper.setOutcomeValue(identifier, processingRuleHelper.baseValue(passed, type))
             ),
             processingRuleHelper.outcomeElse(
-                processingRuleHelper.setOutcomeValue(identifier,
-                    processingRuleHelper.baseValue(notPassed, type)
-                )
+                processingRuleHelper.setOutcomeValue(identifier, processingRuleHelper.baseValue(notPassed, type))
             )
         );
 
@@ -534,10 +583,12 @@ define([
         if (recipe.signature && recipe.signature.test(identifier)) {
             match = true;
             if (onlyCategories) {
-                _.forEach(recipe.outcomes, function(outcome) {
-                    if (outcome.identifier === identifier ||
+                _.forEach(recipe.outcomes, function (outcome) {
+                    if (
+                        outcome.identifier === identifier ||
                         (outcome.weighted && outcome.weighted === identifier) ||
-                        (outcome.feedback && outcome.feedback === identifier)) {
+                        (outcome.feedback && outcome.feedback === identifier)
+                    ) {
                         match = false;
                         return false;
                     }
@@ -564,23 +615,30 @@ define([
 
             // first level, the signature must match
             if (recipe.signature && recipe.signature.test(identifier)) {
-                _.forEach(recipe.outcomes, function(outcome) {
+                _.forEach(recipe.outcomes, function (outcome) {
                     // second level, the main identifier must match
-                    if (outcome.identifier !== identifier &&
+                    if (
+                        outcome.identifier !== identifier &&
                         (!outcome.weighted || (outcome.weighted && outcome.weighted !== identifier)) &&
-                        (!outcome.feedback || (outcome.feedback && outcome.feedback !== identifier))) {
-
+                        (!outcome.feedback || (outcome.feedback && outcome.feedback !== identifier))
+                    ) {
                         if (categories) {
                             // third level, a category must match
-                            _.forEach(categories, function(category) {
-                                if (outcome.categoryIdentifier &&
-                                    identifier === formatCategoryOutcome(category, outcome.categoryIdentifier)) {
+                            _.forEach(categories, function (category) {
+                                if (
+                                    outcome.categoryIdentifier &&
+                                    identifier === formatCategoryOutcome(category, outcome.categoryIdentifier)
+                                ) {
                                     outcomeMatch = true;
-                                } else if (outcome.categoryWeighted &&
-                                    identifier === formatCategoryOutcome(category, outcome.categoryWeighted)) {
+                                } else if (
+                                    outcome.categoryWeighted &&
+                                    identifier === formatCategoryOutcome(category, outcome.categoryWeighted)
+                                ) {
                                     outcomeMatch = true;
-                                } else if (outcome.categoryFeedback &&
-                                    identifier === formatCategoryOutcome(category, outcome.categoryFeedback)) {
+                                } else if (
+                                    outcome.categoryFeedback &&
+                                    identifier === formatCategoryOutcome(category, outcome.categoryFeedback)
+                                ) {
                                     outcomeMatch = true;
                                 }
                                 // found something?
@@ -608,9 +666,9 @@ define([
         }
 
         // only check the outcomes that are related to the scoring mode
-        _.forEach(outcomes, function(identifier) {
+        _.forEach(outcomes, function (identifier) {
             var signatureMatch = false;
-            _.forEach(signatures, function(signature) {
+            _.forEach(signatures, function (signature) {
                 if (signature.test(identifier)) {
                     signatureMatch = true;
                     return false;
@@ -638,7 +696,7 @@ define([
         var signatures = [];
 
         // list the signatures for each processing mode, taking care of includes
-        while(recipe) {
+        while (recipe) {
             if (recipe.signature) {
                 signatures.push(recipe.signature);
             }
@@ -657,7 +715,7 @@ define([
         var descriptors = [];
 
         // get the recipes that define the outcomes, include sub-recipes if any
-        while(recipe) {
+        while (recipe) {
             if (recipe.outcomes) {
                 descriptors = [].concat(recipe.outcomes, descriptors);
             }
@@ -736,9 +794,13 @@ define([
      * @returns {Number}
      */
     function getCutScore(model) {
-        var values = _(outcomeHelper.getOutcomeProcessingRules(model)).map(function (outcome) {
-            return outcomeHelper.getProcessingRuleProperty(outcome, 'setOutcomeValue.gte.baseValue.value');
-        }).compact().uniq().value();
+        var values = _(outcomeHelper.getOutcomeProcessingRules(model))
+            .map(function (outcome) {
+                return outcomeHelper.getProcessingRuleProperty(outcome, 'setOutcomeValue.gte.baseValue.value');
+            })
+            .compact()
+            .uniq()
+            .value();
         if (_.isEmpty(values)) {
             values = [defaultCutScore];
         }
@@ -791,7 +853,7 @@ define([
                 if (count > 1) {
                     // several modes detected, try to reduce the list by detecting includes
                     included = [];
-                    _.forEach(declarations, function(mode) {
+                    _.forEach(declarations, function (mode) {
                         if (outcomesRecipes[mode] && outcomesRecipes[mode].include) {
                             included.push(outcomesRecipes[mode].include);
                         }
@@ -805,7 +867,13 @@ define([
                     outcomeProcessing = processing[0];
 
                     // check if all outcomes are strictly related to the detected mode
-                    if (!matchRecipe(outcomesRecipes[outcomeProcessing], modelOverseer.getOutcomesNames(), modelOverseer.getCategories())) {
+                    if (
+                        !matchRecipe(
+                            outcomesRecipes[outcomeProcessing],
+                            modelOverseer.getOutcomesNames(),
+                            modelOverseer.getCategories()
+                        )
+                    ) {
                         outcomeProcessing = 'custom';
                     }
                 }
@@ -841,7 +909,7 @@ define([
             return outcome;
         });
 
-        outcomeHelper.removeOutcomes(model, function(outcome) {
+        outcomeHelper.removeOutcomes(model, function (outcome) {
             var match = false;
 
             function browseExpressions(processingRule) {

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -64,7 +64,7 @@ define(['lodash', 'i18n', 'core/errorHandler'], function (_, __, errorHandler) {
      * @returns {object}
      */
     function getCategories(model) {
-        let categories,
+        let categories= [],
             arrays,
             union,
             propagated,
@@ -75,20 +75,20 @@ define(['lodash', 'i18n', 'core/errorHandler'], function (_, __, errorHandler) {
             return errorHandler.throw(_ns, 'invalid tool config format');
         }
 
-        const getCategoriesRecursive = sectionModel => _.map(sectionModel.sectionParts, function (sectionPart) {
+        const getCategoriesRecursive = sectionModel => _.forEach(sectionModel.sectionParts, function (sectionPart) {
             if (
                 sectionPart['qti-type'] === 'assessmentItemRef' &&
                 ++itemCount &&
                 _.isArray(sectionPart.categories)
             ) {
-                return _.compact(sectionPart.categories);
+                categories.push(_.compact(sectionPart.categories));
             }
             if (sectionPart['qti-type'] === 'assessmentSection' && _.isArray(sectionPart.sectionParts)) {
-                return _.union.apply(null, _.values(getCategoriesRecursive(sectionPart)));
+                getCategoriesRecursive(sectionPart);
             }
         });
 
-        categories = getCategoriesRecursive(model);
+        getCategoriesRecursive(model);
 
         if (!itemCount) {
             return createCategories(model.categories, model.categories);

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -13,17 +13,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2023 (original work) Open Assessment Technologies SA;
  */
-define([
-    'lodash',
-    'i18n',
-    'core/errorHandler'
-], function (_, __, errorHandler){
-
+define(['lodash', 'i18n', 'core/errorHandler'], function (_, __, errorHandler) {
     'use strict';
 
-    var _ns = '.sectionCategory';
+    const _ns = '.sectionCategory';
 
     /**
      * Check if the given object is a valid assessmentSection model object
@@ -31,8 +26,8 @@ define([
      * @param {object} model
      * @returns {boolean}
      */
-    function isValidSectionModel(model){
-        return (_.isObject(model) && model['qti-type'] === 'assessmentSection' && _.isArray(model.sectionParts));
+    function isValidSectionModel(model) {
+        return _.isObject(model) && model['qti-type'] === 'assessmentSection' && _.isArray(model.sectionParts);
     }
 
     /**
@@ -43,19 +38,16 @@ define([
      * @param {array} partial - only categories in an indeterminate state
      * @returns {undefined}
      */
-    function setCategories(model, selected, partial){
-
-        var toRemove,
-            toAdd,
-            currentCategories = getCategories(model);
+    function setCategories(model, selected, partial) {
+        const currentCategories = getCategories(model);
 
         partial = partial || [];
 
         //the categories that are no longer in the new list of categories should be removed
-        toRemove = _.difference(currentCategories.all, selected.concat(partial));
+        const toRemove = _.difference(currentCategories.all, selected.concat(partial));
 
         //the categories that are not in the current categories collection should be added to the children
-        toAdd = _.difference(selected, currentCategories.propagated);
+        const toAdd = _.difference(selected, currentCategories.propagated);
 
         model.categories = _.difference(model.categories, toRemove);
         model.categories = model.categories.concat(toAdd);
@@ -72,7 +64,7 @@ define([
      * @returns {object}
      */
     function getCategories(model) {
-        var categories,
+        let categories,
             arrays,
             union,
             propagated,
@@ -83,12 +75,15 @@ define([
             return errorHandler.throw(_ns, 'invalid tool config format');
         }
 
-
-        const getCategoriesRecursive = sectionModel => _.map(sectionModel.sectionParts, function (sectionPart){
-            if(sectionPart['qti-type'] === 'assessmentItemRef' && ++itemCount && _.isArray(sectionPart.categories)){
+        const getCategoriesRecursive = sectionModel => _.map(sectionModel.sectionParts, function (sectionPart) {
+            if (
+                sectionPart['qti-type'] === 'assessmentItemRef' &&
+                ++itemCount &&
+                _.isArray(sectionPart.categories)
+            ) {
                 return _.compact(sectionPart.categories);
             }
-            if(sectionPart['qti-type'] === 'assessmentSection' && _.isArray(sectionPart.sectionParts)){
+            if (sectionPart['qti-type'] === 'assessmentSection' && _.isArray(sectionPart.sectionParts)) {
                 return _.union.apply(null, _.values(getCategoriesRecursive(sectionPart)));
             }
         });
@@ -119,17 +114,20 @@ define([
      * @param {array} categories
      * @returns {undefined}
      */
-    function addCategories(model, categories){
-        if(isValidSectionModel(model)){
-            _.each(model.sectionParts, function (itemRef){
-                if(itemRef['qti-type'] === 'assessmentItemRef'){
-                    if(!_.isArray(itemRef.categories)){
-                        itemRef.categories = [];
+    function addCategories(model, categories) {
+        if (isValidSectionModel(model)) {
+            _.each(model.sectionParts, function (sectionPart) {
+                if (sectionPart['qti-type'] === 'assessmentItemRef') {
+                    if (!_.isArray(sectionPart.categories)) {
+                        sectionPart.categories = [];
                     }
-                    itemRef.categories = _.union(itemRef.categories, categories);
+                    sectionPart.categories = _.union(sectionPart.categories, categories);
+                }
+                if (sectionPart['qti-type'] === 'assessmentSection') {
+                    addCategories(sectionPart, categories);
                 }
             });
-        }else{
+        } else {
             errorHandler.throw(_ns, 'invalid tool config format');
         }
     }
@@ -141,33 +139,39 @@ define([
      * @param {array} categories
      * @returns {undefined}
      */
-    function removeCategories(model, categories){
-        if(isValidSectionModel(model)){
-            _.each(model.sectionParts, function (itemRef){
-                if(itemRef['qti-type'] === 'assessmentItemRef' && _.isArray(itemRef.categories)){
-                    itemRef.categories = _.difference(itemRef.categories, categories);
+    function removeCategories(model, categories) {
+        if (isValidSectionModel(model)) {
+            _.each(model.sectionParts, function (sectionPart) {
+                if (sectionPart['qti-type'] === 'assessmentItemRef' && _.isArray(sectionPart.categories)) {
+                    sectionPart.categories = _.difference(sectionPart.categories, categories);
+                }
+                if (sectionPart['qti-type'] === 'assessmentSection') {
+                    removeCategories(sectionPart, categories);
                 }
             });
-        }else{
+        } else {
             errorHandler.throw(_ns, 'invalid tool config format');
         }
     }
 
     function createCategories(all = [], propagated = [], partial = []) {
-        return _.mapValues({
-            all: all,
-            propagated: propagated,
-            partial: partial
-        }, function (categories) {
-            return categories.sort();
-        });
+        return _.mapValues(
+            {
+                all: all,
+                propagated: propagated,
+                partial: partial
+            },
+            function (categories) {
+                return categories.sort();
+            }
+        );
     }
 
     return {
-        isValidSectionModel : isValidSectionModel,
-        setCategories : setCategories,
-        getCategories : getCategories,
-        addCategories : addCategories,
-        removeCategories : removeCategories
+        isValidSectionModel: isValidSectionModel,
+        setCategories: setCategories,
+        getCategories: getCategories,
+        addCategories: addCategories,
+        removeCategories: removeCategories
     };
 });

--- a/views/js/controller/creator/helpers/sectionCategory.js
+++ b/views/js/controller/creator/helpers/sectionCategory.js
@@ -83,11 +83,17 @@ define([
             return errorHandler.throw(_ns, 'invalid tool config format');
         }
 
-        categories = _.map(model.sectionParts, function (itemRef){
-            if(itemRef['qti-type'] === 'assessmentItemRef' && ++itemCount && _.isArray(itemRef.categories)){
-                return _.compact(itemRef.categories);
+
+        const getCategoriesRecursive = sectionModel => _.map(sectionModel.sectionParts, function (sectionPart){
+            if(sectionPart['qti-type'] === 'assessmentItemRef' && ++itemCount && _.isArray(sectionPart.categories)){
+                return _.compact(sectionPart.categories);
+            }
+            if(sectionPart['qti-type'] === 'assessmentSection' && _.isArray(sectionPart.sectionParts)){
+                return _.union.apply(null, _.values(getCategoriesRecursive(sectionPart)));
             }
         });
+
+        categories = getCategoriesRecursive(model);
 
         if (!itemCount) {
             return createCategories(model.categories, model.categories);

--- a/views/js/test/creator/helpers/category/test.js
+++ b/views/js/test/creator/helpers/category/test.js
@@ -77,6 +77,24 @@ define([
         }, {
             category: 'math',
             item: 'item-6'
+        }, {
+            category: 'history',
+            item: 'item-7'
+        }, {
+            category: 'subsection',
+            item: 'item-7'
+        }, {
+            category: 'history',
+            item: 'item-8'
+        }, {
+            category: 'subsection',
+            item: 'item-8'
+        }, {
+            category: 'math',
+            item: 'item-9'
+        }, {
+            category: 'subsection',
+            item: 'item-9'
         }];
         var pointer = 0;
 
@@ -92,7 +110,7 @@ define([
     });
 
     QUnit.test('helpers/category.listCategories()', function(assert) {
-        var expectedCategories = ['history', 'math'];
+        var expectedCategories = ['history', 'math', 'subsection'];
         var categories = categoryHelper.listCategories(testModelSample);
 
         categories.sort();

--- a/views/js/test/creator/helpers/testModel/test.js
+++ b/views/js/test/creator/helpers/testModel/test.js
@@ -90,7 +90,7 @@ define([
     };
 
     QUnit.test('helpers/testModel.eachItemInTest() - flat test', function(assert) {
-        const path = ['item-1', 'item-3', 'item-2', 'item-4', 'item-5', 'item-6'];
+        const path = ['item-1', 'item-3', 'item-2', 'item-4', 'item-5', 'item-6', 'item-7', 'item-8', 'item-9'];
         let pointer = 0;
 
         testModelHelper.eachItemInTest(testModelSample, function(itemRef) {

--- a/views/js/test/creator/modelOverseer/test.js
+++ b/views/js/test/creator/modelOverseer/test.js
@@ -157,7 +157,7 @@ define([
 
     QUnit.test('getCategories()', function(assert) {
         var modelOverseer = modelOverseerFactory(testModelCategoriesSample);
-        var expectedList = ['history', 'math'];
+        var expectedList = ['history', 'math', 'subsection'];
 
         assert.expect(2);
 

--- a/views/js/test/creator/samples/categories.json
+++ b/views/js/test/creator/samples/categories.json
@@ -248,6 +248,141 @@
         "allowLateSubmission": false
       },
       "index": 1
+    }, {
+      "qti-type": "assessmentSection",
+      "title": "Section 3",
+      "visible": true,
+      "keepTogether": true,
+      "rubricBlocks": [],
+      "sectionParts": [{
+        "qti-type": "assessmentSection",
+        "title": "Section 4",
+        "visible": true,
+        "keepTogether": true,
+        "rubricBlocks": [],
+        "sectionParts": [{
+          "qti-type": "assessmentItemRef",
+          "href": "http://tao.dev/tao.rdf#i148309061819894",
+          "categories": ["history", "subsection"],
+          "variableMappings": {},
+          "weights": [],
+          "templateDefaults": {},
+          "identifier": "item-7",
+          "required": false,
+          "fixed": false,
+          "preConditions": [],
+          "branchRules": [],
+          "itemSessionControl": {
+            "qti-type": "itemSessionControl",
+            "maxAttempts": 1,
+            "showFeedback": false,
+            "allowReview": true,
+            "showSolution": false,
+            "allowComment": false,
+            "validateResponses": false,
+            "allowSkipping": true
+          },
+          "timeLimits": {
+            "qti-type": "timeLimits",
+            "allowLateSubmission": false
+          },
+          "index": 0
+        }, {
+          "qti-type": "assessmentItemRef",
+          "href": "http://tao.dev/tao.rdf#i1483090620510297",
+          "categories": ["history", "subsection"],
+          "variableMappings": {},
+          "weights": [],
+          "templateDefaults": {},
+          "identifier": "item-8",
+          "required": false,
+          "fixed": false,
+          "preConditions": [],
+          "branchRules": [],
+          "itemSessionControl": {
+            "qti-type": "itemSessionControl",
+            "maxAttempts": 1,
+            "showFeedback": false,
+            "allowReview": true,
+            "showSolution": false,
+            "allowComment": false,
+            "validateResponses": false,
+            "allowSkipping": true
+          },
+          "timeLimits": {
+            "qti-type": "timeLimits",
+            "allowLateSubmission": false
+          },
+          "index": 1
+        }, {
+          "qti-type": "assessmentItemRef",
+          "href": "http://tao.dev/tao.rdf#i14830906232870100",
+          "categories": ["math", "subsection"],
+          "variableMappings": {},
+          "weights": [],
+          "templateDefaults": {},
+          "identifier": "item-9",
+          "required": false,
+          "fixed": false,
+          "preConditions": [],
+          "branchRules": [],
+          "itemSessionControl": {
+            "qti-type": "itemSessionControl",
+            "maxAttempts": 1,
+            "showFeedback": false,
+            "allowReview": true,
+            "showSolution": false,
+            "allowComment": false,
+            "validateResponses": false,
+            "allowSkipping": true
+          },
+          "timeLimits": {
+            "qti-type": "timeLimits",
+            "allowLateSubmission": false
+          },
+          "index": 2
+        }],
+        "identifier": "subsection-1",
+        "required": false,
+        "fixed": false,
+        "preConditions": [],
+        "branchRules": [],
+        "itemSessionControl": {
+          "qti-type": "itemSessionControl",
+          "maxAttempts": 1,
+          "showFeedback": false,
+          "allowReview": true,
+          "showSolution": false,
+          "allowComment": false,
+          "validateResponses": false,
+          "allowSkipping": true
+        },
+        "timeLimits": {
+          "qti-type": "timeLimits",
+          "allowLateSubmission": false
+        },
+        "index": 1
+      }],
+      "identifier": "assessmentSection-3",
+      "required": false,
+      "fixed": false,
+      "preConditions": [],
+      "branchRules": [],
+      "itemSessionControl": {
+        "qti-type": "itemSessionControl",
+        "maxAttempts": 1,
+        "showFeedback": false,
+        "allowReview": true,
+        "showSolution": false,
+        "allowComment": false,
+        "validateResponses": false,
+        "allowSkipping": true
+      },
+      "timeLimits": {
+        "qti-type": "timeLimits",
+        "allowLateSubmission": false
+      },
+      "index": 1
     }],
     "testFeedbacks": [],
     "index": 0


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2882

**Issue - in many places was old system that section contains items in sectionParts property, but now we have case that it can be subsection, so we need check type and recursively check subsections.** 

**Steps to reproduce:**

1. Create a test
2. Add a subsection to section
3. Add any item to subsection
4. Set any tag to the item in item properties

Actual result: Category tag is not applied to section level.
Expected result: Category tag is applied to section level.

**To see the effect for user, please, follow the steps:**

1. Go to test properties and set the total score/cut score Outcome processing type
2. Select the Category score checkbox enabled
3. Save the test and go back to the Tests tab
4. Select the created test and open it’s properties

Actual result: total score/cut score Outcome processing type is saved with Category score checkbox NOT enabled. 
Expected result: total score/cut score Outcome processing type is saved with Category score checkbox enabled. 