### PR TITLE
fix: Don't use class_alias if the alias already exists

### DIFF
--- a/migrations/Version202211031203542260_taoQtiTest.php
+++ b/migrations/Version202211031203542260_taoQtiTest.php
@@ -20,9 +20,17 @@ final class Version202211031203542260_taoQtiTest extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        class_alias(TestPackageMetadataExport::class, 'oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler');
-        class_alias(TestPackage2p1Export::class, 'taoQtiTest_models_classes_export_TestExport');
-        class_alias(TestPackage2p2Export::class, 'taoQtiTest_models_classes_export_TestExport22');
+        //class_alias(TestPackageMetadataExport::class, 'oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler');
+        //class_alias(TestPackage2p1Export::class, 'taoQtiTest_models_classes_export_TestExport');
+        //class_alias(TestPackage2p2Export::class, 'taoQtiTest_models_classes_export_TestExport22');
+        if(!class_exists('oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler'))
+            class_alias(TestPackageMetadataExport::class, 'oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler');
+
+        if(!class_exists('taoQtiTest_models_classes_export_TestExport'))
+            class_alias(TestPackage2p1Export::class, 'taoQtiTest_models_classes_export_TestExport');
+
+        if(!class_exists('taoQtiTest_models_classes_export_TestExport22'))
+            class_alias(TestPackage2p2Export::class, 'taoQtiTest_models_classes_export_TestExport22');
 
         $testModelService = $this->getServiceLocator()->get(TestModelService::SERVICE_ID);
 

--- a/migrations/Version202211031203542260_taoQtiTest.php
+++ b/migrations/Version202211031203542260_taoQtiTest.php
@@ -20,17 +20,17 @@ final class Version202211031203542260_taoQtiTest extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        //class_alias(TestPackageMetadataExport::class, 'oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler');
-        //class_alias(TestPackage2p1Export::class, 'taoQtiTest_models_classes_export_TestExport');
-        //class_alias(TestPackage2p2Export::class, 'taoQtiTest_models_classes_export_TestExport22');
-        if(!class_exists('oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler'))
+        if(!class_exists('oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler')) {
             class_alias(TestPackageMetadataExport::class, 'oat\\taoQtiTest\\models\\export\\metadata\\TestMetadataByClassExportHandler');
+        }
 
-        if(!class_exists('taoQtiTest_models_classes_export_TestExport'))
+        if(!class_exists('taoQtiTest_models_classes_export_TestExport')) {
             class_alias(TestPackage2p1Export::class, 'taoQtiTest_models_classes_export_TestExport');
+        }
 
-        if(!class_exists('taoQtiTest_models_classes_export_TestExport22'))
+        if(!class_exists('taoQtiTest_models_classes_export_TestExport22')) {
             class_alias(TestPackage2p2Export::class, 'taoQtiTest_models_classes_export_TestExport22');
+        }
 
         $testModelService = $this->getServiceLocator()->get(TestModelService::SERVICE_ID);
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1320

It crashes taoUpdate on deployments

```
I have no name!@3391afb25b60:/tao/code$ php tao/scripts/taoUpdate.php
PHP Warning:  Cannot declare class oat\taoQtiTest\models\export\metadata\TestMetadataByClassExportHandler, because the name is already in use in /tao/code/taoQtiTest/migrations/Version202211031203542260_taoQtiTest.php on line 23

Warning: Cannot declare class oat\taoQtiTest\models\export\metadata\TestMetadataByClassExportHandler, because the name is already in use in /tao/code/taoQtiTest/migrations/Version202211031203542260_taoQtiTest.php on line 23
PHP Warning:  Cannot declare class taoQtiTest_models_classes_export_TestExport, because the name is already in use in /tao/code/taoQtiTest/migrations/Version202211031203542260_taoQtiTest.php on line 24

Warning: Cannot declare class taoQtiTest_models_classes_export_TestExport, because the name is already in use in /tao/code/taoQtiTest/migrations/Version202211031203542260_taoQtiTest.php on line 24
PHP Warning:  Cannot declare class taoQtiTest_models_classes_export_TestExport22, because the name is already in use in /tao/code/taoQtiTest/migrations/Version202211031203542260_taoQtiTest.php on line 25

Warning: Cannot declare class taoQtiTest_models_classes_export_TestExport22, because the name is already in use in /tao/code/taoQtiTest/migrations/Version202211031203542260_taoQtiTest.php on line 25
PHP Fatal error:  Uncaught Symfony\Component\DependencyInjection\Exception\BadMethodCallException: Adding definition to a compiled container is not allowed. in /tao/code/vendor/symfony/dependency-injection/ContainerBuilder.php:947
Stack trace:
#0 /tao/code/vendor/symfony/dependency-injection/ContainerBuilder.php(912): Symfony\Component\DependencyInjection\ContainerBuilder->setDefinition('service_contain...', Object(Symfony\Component\DependencyInjection\Definition))
#1 /tao/code/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(102): Symfony\Component\DependencyInjection\ContainerBuilder->addDefinitions(Array)
#2 /tao/code/vendor/symfony/dependency-injection/Compiler/Compiler.php(91): Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process(Object(oat\generis\model\DependencyInjection\ContainerBuilder))
#3 /tao/code/vendor/symfony/dependency-injection/ContainerBuilder.php(744): Symfony\Component\DependencyInjection\Compiler\Compiler->compile(Object(oat\generis\model\ in /tao/code/vendor/symfony/dependency-injection/ContainerBuilder.php on line 947
```

Previous aliases here: https://github.com/oat-sa/extension-tao-testqti/commit/6bda76dbcd1fa65b4f081dde1c1b685cf2e919c3