### PR TITLE
fix: fix deleting of test classes if any errors during imports

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -538,7 +538,6 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         $reportCtx = new stdClass();
         $reportCtx->manifestResource = $qtiTestResource;
         $reportCtx->rdfsResource = $testResource;
-        $reportCtx->itemClass = $targetClass;
         $reportCtx->items = [];
         $reportCtx->newItems = [];
         $reportCtx->overwrittenItems = [];
@@ -548,8 +547,6 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
         // 'uriResource' key is needed by javascript in tao/views/templates/form/import.tpl
         $reportCtx->uriResource = $testResource->getUri();
-
-        $report->setData($reportCtx);
 
         // Expected test.xml file location.
         $expectedTestFile = $folder . str_replace('/', DIRECTORY_SEPARATOR, $qtiTestResource->getFile());
@@ -584,7 +581,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
                 }
 
                 $targetClass = $itemClass->createSubClass($testResource->getLabel());
-
+                $reportCtx->itemClass = $targetClass;
                 // -- Load all items related to test.
                 $itemError = false;
 
@@ -769,6 +766,8 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
                 );
             }
         }
+
+        $report->setData($reportCtx);
 
         if ($report->containsError() === false) {
             $report->setType(common_report_Report::TYPE_SUCCESS);


### PR DESCRIPTION
Fix the issue when after failed import the whole test class was deleted.

**How to test**

1. Create with some content on the Tests page
2. Test exported and some items are removed from the test package
3. Open Test tab and select the class from preconditions
4. Click "Import" button below the Tests tree
5. Select "QTI/APIP Test Content Package" radio button
6. Select the test from preconditions  and click "Open"
7. Click "Import" button in appeared "Import" form 
8. Wait for import process is finished and report is displayed in task queue
9. Re-load the page and observe the test tree

After reloading the class that was used for importing should be still exists