### PR TITLE
feat: show required property for subsection

### DIFF
--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -34,7 +34,7 @@
         </div>
     </div>
 
-{{!-- Property not yet available in delivery
+{{#if isSubsection}}
 <!-- assessmentTest/testPart/assessmentSection/required -->
     <div class="grid-row pseudo-label-box">
         <div class="col-5">
@@ -53,7 +53,7 @@
             </div>
         </div>
     </div>
---}}
+{{/if}}
 
 {{!-- Property not yet available in delivery
 <!-- assessmentTest/testPart/assessmentSection/fixed -->

--- a/views/js/controller/creator/templates/section-props.tpl
+++ b/views/js/controller/creator/templates/section-props.tpl
@@ -49,7 +49,7 @@
         <div class="col-1 help">
             <span class="icon-help" data-tooltip="~ .tooltip-content" data-tooltip-theme="info"></span>
             <div class="tooltip-content">
-            {{__ 'If required, it must appears at least once in the selection.'}}
+            {{__ 'If required it must appear (at least once) in the selection.'}}
             </div>
         </div>
     </div>

--- a/views/js/controller/creator/views/section.js
+++ b/views/js/controller/creator/views/section.js
@@ -96,7 +96,7 @@ define([
         if (!_.isEmpty(config.routes.blueprintsById)) {
             sectionModel.hasBlueprint = true;
         }
-
+        sectionModel.isSubsection = false;
         sectionModel.hasSelectionWithReplacement = servicesFeatures.isVisible(
             'taoQtiTest/creator/properties/selectionWithReplacement',
             false

--- a/views/js/controller/creator/views/subsection.js
+++ b/views/js/controller/creator/views/subsection.js
@@ -84,7 +84,7 @@ define([
         if (!_.isEmpty(config.routes.blueprintsById)) {
             subsectionModel.hasBlueprint = true;
         }
-
+        subsectionModel.isSubsection = true;
         sectionModel.hasSelectionWithReplacement = servicesFeatures.isVisible(
             'taoQtiTest/creator/properties/selectionWithReplacement',
             false


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-3084

## ACs:
The author can set the value of the Required field in sub-sections’ Properties panel in the Test Authoring tool.

A new field is created in the Properties panel of sub-sections:
Type of field: checkbox
Default: unchecked
Label: Required
Tooltip: If required it must appear (at least once) in the selection.

It is acceptable to have the Required field also in first-level sections although it has no effect, because the section selection doesn’t exist at the level of test part, so the first-level sections are always presented. Although, if the Required field is only displayed in the Properties panel of sub-sections, it would be less ambiguous.

When the test is saved, the value of the required attribute of the <assessmentSection> XML element is set according (required attribute is already generated, but with value always set to false).

## implemented
![image](https://github.com/oat-sa/extension-tao-testqti/assets/25976342/0c115a32-7ede-4d69-80f1-e87478d41fc3)

![image](https://github.com/oat-sa/extension-tao-testqti/assets/25976342/dd01ce62-bc9a-470b-b224-cdf3db056ea7)

