### PR TITLE
fix: add Resource Created to trigger taoAdvanceSearch index update

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -19,6 +19,7 @@
  */
 
 use League\Flysystem\FileExistsException;
+use oat\generis\model\data\event\ResourceCreated;
 use oat\oatbox\filesystem\Directory;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\filesystem\FileSystemService;
@@ -853,6 +854,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
             $msg = __("IMS QTI Test referenced as \"%s\" in the IMS Manifest file successfully imported.", $qtiTestResource->getIdentifier());
             // phpcs:enable Generic.Files.LineLength
             $report->setMessage($msg);
+            $this->getEventManager()->trigger(new ResourceCreated($testResource));
         } else {
             $report->setType(common_report_Report::TYPE_ERROR);
             // phpcs:disable Generic.Files.LineLength


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/PISA25-480
## What's Changed

- Add triggering ResourceCreated event at end of importing QtiTest so taoAdvancedSearch can index new data

## How to test
- Setup taoAdvacedSearch
- Use import API importDeferred to import test
- Check ES instance to have imported test data in it.

Video showing how it works

https://github.com/oat-sa/extension-tao-testqti/assets/118974926/bec79c08-93ba-41ec-8d6d-2e599cef2029