### PR TITLE
feat: place imported assets to correct class

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -559,7 +559,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         $report = new common_report_Report(common_report_Report::TYPE_INFO);
 
         // The class where the items that belong to the test will be imported.
-        $itemRootClass = $this->getClass($itemClassUri ?: TaoOntology::CLASS_URI_ITEM);
+        $itemParentClass = $this->getClass($itemClassUri ?: TaoOntology::CLASS_URI_ITEM);
 
         // Load and validate the manifest
         $qtiManifestParser = new taoQtiTest_models_classes_ManifestParser($folder . 'imsmanifest.xml');
@@ -621,10 +621,10 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
                         }
                     }
 
-                    $this->deleteTestsFromClassByLabel($testLabel, $itemsClassLabel, $testClass, $itemRootClass);
+                    $this->deleteTestsFromClassByLabel($testLabel, $itemsClassLabel, $testClass, $itemParentClass);
                 }
 
-                $targetItemClass = $itemRootClass->createSubClass(self::IN_PROGRESS_LABEL);
+                $targetItemClass = $itemParentClass->createSubClass(self::IN_PROGRESS_LABEL);
 
                 // add real label without saving (to not pass it separately to item importer)
                 $targetItemClass->label = $testLabel;


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/PISA25-561
## What's Changed

Related PR: https://github.com/oat-sa/extension-tao-itemqti/pull/2407
- Adding label property to target item class, it is needed because ItemImporter should know that label, but in DB we keep it be 'in progress' by the end of the import process.  

## How to test
check: https://github.com/oat-sa/extension-tao-itemqti/pull/2407