### PR TITLE
Feature/TR-5858/Detect delivery concurrency

### DIFF
--- a/migrations/Version202311241512382260_taoQtiTest.php
+++ b/migrations/Version202311241512382260_taoQtiTest.php
@@ -10,8 +10,6 @@ use oat\taoQtiTest\scripts\install\RegisterTestRunnerPlugins;
 use oat\taoTests\models\runner\plugins\PluginRegistry;
 
 /**
- * Auto-generated Migration: Please modify to your needs!
- *
  * phpcs:disable Squiz.Classes.ValidClassName
  */
 final class Version202311241512382260_taoQtiTest extends AbstractMigration

--- a/migrations/Version202311241512382260_taoQtiTest.php
+++ b/migrations/Version202311241512382260_taoQtiTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoTests\models\runner\plugins\PluginRegistry;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202311241512382260_taoQtiTest extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register plugin to prevent session concurrency';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        if (!$registry->isRegistered('taoQtiTest/runner/plugins/controls/session/preventConcurrency')) {
+            $registry->register(TestPlugin::fromArray([
+                'id' => 'preventConcurrency',
+                'name' => 'Prevent session concurrency',
+                'module' => 'taoQtiTest/runner/plugins/controls/session/preventConcurrency',
+                'bundle' => 'taoQtiTest/loader/testPlugins.min',
+                'description' => 'Detect concurrent deliveries launched from the same user session',
+                'category' => 'controls',
+                'active' => true,
+                'tags' => [ 'core', 'technical' ]
+            ]));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $registry = PluginRegistry::getRegistry();
+        if ($registry->isRegistered('taoQtiTest/runner/plugins/controls/session/preventConcurrency')) {
+            $registry->remove('taoQtiTest/runner/plugins/controls/session/preventConcurrency');
+        }
+    }
+}

--- a/migrations/Version202311241512382260_taoQtiTest.php
+++ b/migrations/Version202311241512382260_taoQtiTest.php
@@ -6,8 +6,8 @@ namespace oat\taoQtiTest\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiTest\scripts\install\RegisterTestRunnerPlugins;
 use oat\taoTests\models\runner\plugins\PluginRegistry;
-use oat\taoTests\models\runner\plugins\TestPlugin;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
@@ -16,6 +16,8 @@ use oat\taoTests\models\runner\plugins\TestPlugin;
  */
 final class Version202311241512382260_taoQtiTest extends AbstractMigration
 {
+    public const PLUGIN_URI = 'taoQtiTest/runner/plugins/controls/session/preventConcurrency';
+
     public function getDescription(): string
     {
         return 'Register plugin to prevent session concurrency';
@@ -24,25 +26,18 @@ final class Version202311241512382260_taoQtiTest extends AbstractMigration
     public function up(Schema $schema): void
     {
         $registry = PluginRegistry::getRegistry();
-        if (!$registry->isRegistered('taoQtiTest/runner/plugins/controls/session/preventConcurrency')) {
-            $registry->register(TestPlugin::fromArray([
-                'id' => 'preventConcurrency',
-                'name' => 'Prevent session concurrency',
-                'module' => 'taoQtiTest/runner/plugins/controls/session/preventConcurrency',
-                'bundle' => 'taoQtiTest/loader/testPlugins.min',
-                'description' => 'Detect concurrent deliveries launched from the same user session',
-                'category' => 'controls',
-                'active' => true,
-                'tags' => [ 'core', 'technical' ]
-            ]));
+
+        if (!$registry->isRegistered(self::PLUGIN_URI)) {
+            $registry->register(RegisterTestRunnerPlugins::getPlugin('preventConcurrency'));
         }
     }
 
     public function down(Schema $schema): void
     {
         $registry = PluginRegistry::getRegistry();
-        if ($registry->isRegistered('taoQtiTest/runner/plugins/controls/session/preventConcurrency')) {
-            $registry->remove('taoQtiTest/runner/plugins/controls/session/preventConcurrency');
+
+        if ($registry->isRegistered(self::PLUGIN_URI)) {
+            $registry->remove(self::PLUGIN_URI);
         }
     }
 }

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -448,7 +448,7 @@ class RegisterTestRunnerPlugins extends InstallAction
         ]
     ];
 
-    public static function getPlugin(string $pluginIdentifier): TestPlugin
+    public static function getPlugin(string $pluginIdentifier): ?TestPlugin
     {
         foreach (self::$plugins as $categoryPlugins) {
             foreach ($categoryPlugins as $pluginData) {

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -448,6 +448,18 @@ class RegisterTestRunnerPlugins extends InstallAction
         ]
     ];
 
+    public static function getPlugin(string $pluginIdentifier): TestPlugin
+    {
+        foreach (self::$plugins as $categoryPlugins) {
+            foreach ($categoryPlugins as $pluginData) {
+                if ($pluginData['id'] == $pluginIdentifier || $pluginData['module'] == $pluginIdentifier) {
+                    return TestPlugin::fromArray($pluginData);
+                }
+            }
+        }
+        return null;
+    }
+
     public function __invoke($params)
     {
         $registry = PluginRegistry::getRegistry();

--- a/scripts/install/RegisterTestRunnerPlugins.php
+++ b/scripts/install/RegisterTestRunnerPlugins.php
@@ -192,6 +192,15 @@ class RegisterTestRunnerPlugins extends InstallAction
                 'active' => true,
                 'tags' => [ 'core', 'technical', 'required' ]
             ], [
+                'id' => 'preventConcurrency',
+                'name' => 'Prevent session concurrency',
+                'module' => 'taoQtiTest/runner/plugins/controls/session/preventConcurrency',
+                'bundle' => 'taoQtiTest/loader/testPlugins.min',
+                'description' => 'Detect concurrent deliveries launched from the same user session',
+                'category' => 'controls',
+                'active' => true,
+                'tags' => [ 'core', 'technical' ]
+            ], [
                 'id' => 'connectivity',
                 'name' => 'Connectivity check',
                 'module' => 'taoQtiTest/runner/plugins/controls/connectivity/connectivity',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@oat-sa/tao-test-runner": "^1.0.0",
-                "@oat-sa/tao-test-runner-qti": "^4.0.0"
+                "@oat-sa/tao-test-runner-qti": "https://github.com/oat-sa/tao-test-runner-qti-fe#feature/TR-5858/detect-delivery-concurrency"
             }
         },
         "node_modules/@oat-sa/tao-test-runner": {
@@ -23,8 +23,8 @@
         },
         "node_modules/@oat-sa/tao-test-runner-qti": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-4.0.0.tgz",
-            "integrity": "sha512-cpl5AImr9Ozd0allMAQO+ZVFHeD7bzmaIYhLJPHBO4OrAE/njKtrvxV+mYCqSxOZwXKbUiyAHr1/ZGlKR/I+Bg==",
+            "resolved": "git+ssh://git@github.com/oat-sa/tao-test-runner-qti-fe.git#e387ea098f62ee0c69cffd05f41ab043513e6df1",
+            "license": "GPL-2.0",
             "engines": {
                 "node": ">=14.0.0"
             }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     "license": "GPL-2.0",
     "dependencies": {
         "@oat-sa/tao-test-runner": "^1.0.0",
-        "@oat-sa/tao-test-runner-qti": "^4.0.0"
+        "@oat-sa/tao-test-runner-qti": "https://github.com/oat-sa/tao-test-runner-qti-fe#feature/TR-5858/detect-delivery-concurrency"
     }
 }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5854

Requires: 
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/522

### Summary

Add a mechanism for detecting concurrent delivery sessions.

### Details

Install the `preventConcurrency` plugin.

When the test runner initializes, a sequence number is stored in the browser's storage. Each time the duration is updated, the sequence number is read from the storage and compared with the value created at the beginning. If a discrepancy is discovered this means another test runner started meanwhile and updated the storage. A dialog message is presented to the user and the test runner is stopped.

### How to test

The feature flag `FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS` needs to be set.
```
php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS -v true
```
- checkout the branch `feature/TR-5858/detect-delivery-concurrency`
- make sure the frontend is up to date: `cd taoQtiTest/views && npm ci`
- run taoUpdate
- launch a delivery
- duplicate the tab or launch another delivery
- the first tab should show a message and stop the test