### PR TITLE
chore: experiment

### DIFF
--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -239,6 +239,12 @@ class ConcurringSessionService
 
         $context = $this->getContextByDeliveryExecution($execution);
 
+        //@FIXME @TODO Testing
+        $testSession = $context->getTestSession();
+        $testSession->initItemTimer(microtime(true));
+        $testSession->getTimer()->end($testSession->getItemTags($testSession->getRoute()->current()), microtime(true))->save();
+        //@FIXME @TODO Testing
+
         $this->qtiRunnerService->endTimer($context);
         $this->qtiRunnerService->pause($context);
     }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-5911

# Goal: 

- Timers should be paused on server side

# How to test:

- Launch delivery A with user U1 via LTI 1.3
- Launch delivery B with user U1 via LTI 1.3
- Delivery A should be paused 
- Delivery A timers should be paused
- Delivery B should continue
- If relaunching delivery A, timers should resume from where they were paused