### PR TITLE
Backport/adf 1327/cherry pick

### DIFF
--- a/models/classes/export/AbstractQtiTestExporter.php
+++ b/models/classes/export/AbstractQtiTestExporter.php
@@ -159,6 +159,10 @@ abstract class AbstractQtiTestExporter extends ItemExporter implements QtiTestEx
     /** Export the test definition and all its dependencies (media, items, ...) into the related ZIP archive. */
     public function export(array $options = []): Report
     {
+        if ($options['manifest']) {
+            $this->setManifest($options['manifest']);
+        }
+
         $this->preProcessing();
 
         // 1. Export the items bound to the test.

--- a/models/classes/export/AbstractTestExport.php
+++ b/models/classes/export/AbstractTestExport.php
@@ -111,8 +111,10 @@ abstract class AbstractTestExport implements ExportHandler, PhpSerializable
             throw new common_Exception(sprintf('Unable to create ZIP archive for QTI Test at location "%s".', $path));
         }
 
+        $manifest = $this->getServiceManager()->get(QtiTestUtils::SERVICE_ID)->emptyImsManifest(static::VERSION);
+
         foreach ($instances as $instance) {
-            $subReport = $this->getTestExporter($this->getResource($instance))->export();
+            $subReport = $this->getTestExporter($this->getResource($instance))->export(['manifest' => $manifest]);
             if (
                 $report->getType() !== ReportInterface::TYPE_ERROR &&
                 ($subReport->containsError() || $subReport->getType() === ReportInterface::TYPE_ERROR)
@@ -151,7 +153,7 @@ abstract class AbstractTestExport implements ExportHandler, PhpSerializable
         return sprintf('%s_%d.zip', $userDefinedName, time());
     }
 
-    protected function getManifest()
+    protected function getEmptyManifest()
     {
         return $this->getServiceManager()->get(QtiTestUtils::SERVICE_ID)->emptyImsManifest(static::VERSION);
     }

--- a/models/classes/export/Formats/Package2p1/TestPackageExport.php
+++ b/models/classes/export/Formats/Package2p1/TestPackageExport.php
@@ -46,7 +46,7 @@ class TestPackageExport extends AbstractTestExport
      */
     protected function getTestExporter(Resource $test): QtiTestExporterInterface
     {
-        return new QtiTestExporter($test, $this->getZip(), $this->getManifest());
+        return new QtiTestExporter($test, $this->getZip(), $this->getEmptyManifest());
     }
 }
 

--- a/models/classes/export/Formats/Package2p2/TestPackageExport.php
+++ b/models/classes/export/Formats/Package2p2/TestPackageExport.php
@@ -26,6 +26,7 @@ use core_kernel_classes_Resource as Resource;
 use oat\taoQtiTest\models\export\AbstractTestExport;
 use oat\taoQtiTest\models\export\QtiTestExporterInterface;
 use taoQtiTest_models_classes_QtiTestServiceException as QtiTestServiceException;
+use ZipArchive;
 
 class TestPackageExport extends AbstractTestExport
 {
@@ -46,7 +47,7 @@ class TestPackageExport extends AbstractTestExport
      */
     protected function getTestExporter(Resource $test): QtiTestExporterInterface
     {
-        return new QtiTestExporter($test, $this->getZip(), $this->getManifest());
+        return new QtiTestExporter($test, $this->getZip(), $this->getEmptyManifest());
     }
 }
 

--- a/models/classes/export/Formats/Package2p2/TestPackageExport.php
+++ b/models/classes/export/Formats/Package2p2/TestPackageExport.php
@@ -26,7 +26,6 @@ use core_kernel_classes_Resource as Resource;
 use oat\taoQtiTest\models\export\AbstractTestExport;
 use oat\taoQtiTest\models\export\QtiTestExporterInterface;
 use taoQtiTest_models_classes_QtiTestServiceException as QtiTestServiceException;
-use ZipArchive;
 
 class TestPackageExport extends AbstractTestExport
 {


### PR DESCRIPTION
Fix [ADF-1327](https://oat-sa.atlassian.net/browse/ADF-1327) : : add manifest in export test options https://github.com/oat-sa/extension-tao-testqti/pull/2415

[ADF-1327]: https://oat-sa.atlassian.net/browse/ADF-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ