### PR TITLE
Backport for AGS fixes

### DIFF
--- a/helpers/class.TestSession.php
+++ b/helpers/class.TestSession.php
@@ -44,6 +44,7 @@ use qtism\data\ExtendedAssessmentItemRef;
 use qtism\data\processing\OutcomeProcessing;
 use qtism\data\rules\OutcomeRuleCollection;
 use qtism\data\rules\SetOutcomeValue;
+use qtism\data\state\OutcomeDeclaration;
 use qtism\runtime\common\OutcomeVariable;
 use qtism\runtime\common\ProcessingException;
 use qtism\runtime\processing\OutcomeProcessingEngine;
@@ -772,8 +773,26 @@ class taoQtiTest_helpers_TestSession extends AssessmentTestSession
             $this->getSessionId(),
             $variables,
             $this->getSessionId(),
-            $testUri
+            $testUri,
+            $this->isManualScored()
         ));
+    }
+
+    private function isManualScored(): bool
+    {
+        /** @var AssessmentItemRef $itemRef */
+        foreach ($this->getRoute()->getAssessmentItemRefs() as $itemRef) {
+            foreach ($itemRef->getComponents() as $component) {
+                if (
+                    $component instanceof OutcomeDeclaration
+                    && $component->isExternallyScored()
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/models/classes/event/TestVariablesRecorded.php
+++ b/models/classes/event/TestVariablesRecorded.php
@@ -15,39 +15,28 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
 
-namespace oat\taoQtiTest\models\classes\event;
+namespace oat\taoQtiTest\models\event;
 
 use oat\oatbox\event\Event;
 
-class ResultTestVariablesTransmissionEvent implements Event
+class TestVariablesRecorded implements Event
 {
-    /** @var string */
-    private $deliveryExecutionId;
-    /** @var array */
-    private $variables;
-    /** @var string */
-    private $transmissionId;
-    /** @var string */
-    private $testUri;
-    /** @var bool  */
+    private string $deliveryExecutionId;
+    private array $variables;
     private bool $isManualScored;
 
     public function __construct(
         string $deliveryExecutionId,
         array $variables,
-        string $transmissionId,
-        string $testUri = '',
-        bool $isManualScored = null,
+        bool $isManualScored
     ) {
         $this->deliveryExecutionId = $deliveryExecutionId;
         $this->variables = $variables;
-        $this->transmissionId = $transmissionId;
-        $this->testUri = $testUri;
         $this->isManualScored = $isManualScored;
     }
 
@@ -66,17 +55,7 @@ class ResultTestVariablesTransmissionEvent implements Event
         return $this->variables;
     }
 
-    public function getTransmissionId(): string
-    {
-        return $this->transmissionId;
-    }
-
-    public function getTestUri(): string
-    {
-        return $this->testUri;
-    }
-
-    public function isManualScored(): bool
+    public function getIsManualScored(): bool
     {
         return $this->isManualScored;
     }

--- a/models/classes/eventHandler/ResultTransmissionEventHandler/ResultTransmissionEventHandler.php
+++ b/models/classes/eventHandler/ResultTransmissionEventHandler/ResultTransmissionEventHandler.php
@@ -22,11 +22,19 @@ declare(strict_types=1);
 
 namespace oat\taoQtiTest\models\classes\eventHandler\ResultTransmissionEventHandler;
 
+use common_exception_Error;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\service\ServiceManager;
+use oat\oatbox\service\ServiceNotFoundException;
 use oat\tao\model\service\InjectionAwareService;
 use oat\taoDelivery\model\execution\DeliveryServerService;
 use oat\taoQtiTest\models\classes\event\ResultTestVariablesTransmissionEvent;
 use oat\taoQtiTest\models\event\ResultItemVariablesTransmissionEvent;
+use oat\taoQtiTest\models\event\TestVariablesRecorded;
 use taoQtiCommon_helpers_ResultTransmitter;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\taoResultServer\models\classes\implementation\ResultServerService;
+use taoResultServer_models_classes_ReadableResultStorage as ReadableResultStorage;
 
 class ResultTransmissionEventHandler extends InjectionAwareService implements Api\ResultTransmissionEventHandlerInterface
 {
@@ -45,6 +53,8 @@ class ResultTransmissionEventHandler extends InjectionAwareService implements Ap
     }
 
     /**
+     * @param ResultTestVariablesTransmissionEvent $event
+     * @throws InvalidServiceManagerException
      * @throws \taoQtiCommon_helpers_ResultTransmissionException
      */
     public function transmitResultTestVariable(ResultTestVariablesTransmissionEvent $event): void
@@ -54,6 +64,12 @@ class ResultTransmissionEventHandler extends InjectionAwareService implements Ap
             $event->getTransmissionId(),
             $event->getTestUri()
         );
+
+        if (!$this->containsScoreTotal($event)) {
+            return;
+        }
+
+        $this->triggerTestVariablesRecorded($event);
     }
 
     private function buildTransmitter($deliveryExecutionId): taoQtiCommon_helpers_ResultTransmitter
@@ -63,5 +79,59 @@ class ResultTransmissionEventHandler extends InjectionAwareService implements Ap
         $resultStore = $deliveryServerService->getResultStoreWrapper($deliveryExecutionId);
 
         return new taoQtiCommon_helpers_ResultTransmitter($resultStore);
+    }
+
+    public function getEventManager()
+    {
+        return $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+    }
+
+    public function getServiceLocator()
+    {
+        return ServiceManager::getServiceManager();
+    }
+
+    /**
+     * @return ReadableResultStorage
+     * @throws ServiceNotFoundException
+     * @throws common_exception_Error
+     */
+    private function getResultsStorage(): ReadableResultStorage
+    {
+        $resultServerService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
+        $storage = $resultServerService->getResultStorage();
+
+        if (!$storage instanceof ReadableResultStorage) {
+            throw new common_exception_Error('Configured result storage is not writable.');
+        }
+
+        return $storage;
+    }
+
+    private function containsScoreTotal(ResultTestVariablesTransmissionEvent $event): bool
+    {
+        $scoreTotal = array_filter(
+            $event->getVariables(),
+            function ($item) {
+                return $item->getIdentifier() === 'SCORE_TOTAL';
+            }
+        );
+
+        return !empty($scoreTotal);
+    }
+
+    /**
+     * @param ResultTestVariablesTransmissionEvent $event
+     * @return void
+     * @throws InvalidServiceManagerException
+     */
+    private function triggerTestVariablesRecorded(ResultTestVariablesTransmissionEvent $event): void
+    {
+        $outcomeVariables = $this->getResultsStorage()->getDeliveryVariables($event->getDeliveryExecutionId());
+        $this->getEventManager()->trigger(new TestVariablesRecorded(
+            $event->getDeliveryExecutionId(),
+            $outcomeVariables,
+            $event->isManualScored()
+        ));
     }
 }


### PR DESCRIPTION
Backport of : feature: add new event ResultTestVariablesAfterTransmissionEvent (#2425)

https://github.com/oat-sa/extension-tao-testqti/pull/2429

* feature: add new event ResultTestVariablesAfterTransmissionEvent

* feature: rewrite LtiAgsListener

* fix: codestyle

* fix: codestyle

* fix: code review

* feature: change to TestVariablesRecorded, and use it in ResultTransmissionEventHandler

* fix: code review fixes

(cherry picked from commit e67ac3469f0fd71712171441516b595e3bc3f7b3)