### PR TITLE
bugfix: move event to proper delivery finish

### DIFF
--- a/helpers/class.TestSession.php
+++ b/helpers/class.TestSession.php
@@ -819,12 +819,11 @@ class taoQtiTest_helpers_TestSession extends AssessmentTestSession
             $this->getSessionId(),
             $variables,
             $this->getSessionId(),
-            $testUri,
-            $this->isManualScored()
+            $testUri
         ));
     }
 
-    private function isManualScored(): bool
+    public function isManualScored(): bool
     {
         /** @var AssessmentItemRef $itemRef */
         foreach ($this->getRoute()->getAssessmentItemRefs() as $itemRef) {

--- a/models/classes/event/DeliveryExecutionFinish.php
+++ b/models/classes/event/DeliveryExecutionFinish.php
@@ -27,7 +27,7 @@ use oat\taoDelivery\model\execution\DeliveryExecution;
 
 class DeliveryExecutionFinish implements Event
 {
-    private DeliveryExecution $deliveryExecutionId;
+    private DeliveryExecution $deliveryExecution;
     private array $variables;
     private bool $isManualScored;
 
@@ -36,7 +36,7 @@ class DeliveryExecutionFinish implements Event
         array $variables,
         bool $isManualScored
     ) {
-        $this->deliveryExecutionId = $deliveryExecution;
+        $this->deliveryExecution = $deliveryExecution;
         $this->variables = $variables;
         $this->isManualScored = $isManualScored;
     }
@@ -48,7 +48,7 @@ class DeliveryExecutionFinish implements Event
 
     public function getDeliveryExecution(): DeliveryExecution
     {
-        return $this->deliveryExecutionId;
+        return $this->deliveryExecution;
     }
 
     public function getVariables(): array

--- a/models/classes/event/DeliveryExecutionFinish.php
+++ b/models/classes/event/DeliveryExecutionFinish.php
@@ -23,19 +23,20 @@ declare(strict_types=1);
 namespace oat\taoQtiTest\models\event;
 
 use oat\oatbox\event\Event;
+use oat\taoDelivery\model\execution\DeliveryExecution;
 
-class TestVariablesRecorded implements Event
+class DeliveryExecutionFinish implements Event
 {
-    private string $deliveryExecutionId;
+    private DeliveryExecution $deliveryExecutionId;
     private array $variables;
     private bool $isManualScored;
 
     public function __construct(
-        string $deliveryExecutionId,
+        DeliveryExecution $deliveryExecution,
         array $variables,
         bool $isManualScored
     ) {
-        $this->deliveryExecutionId = $deliveryExecutionId;
+        $this->deliveryExecutionId = $deliveryExecution;
         $this->variables = $variables;
         $this->isManualScored = $isManualScored;
     }
@@ -45,7 +46,7 @@ class TestVariablesRecorded implements Event
         return self::class;
     }
 
-    public function getDeliveryExecutionId(): string
+    public function getDeliveryExecution(): DeliveryExecution
     {
         return $this->deliveryExecutionId;
     }

--- a/models/classes/event/ResultTestVariablesTransmissionEvent.php
+++ b/models/classes/event/ResultTestVariablesTransmissionEvent.php
@@ -34,21 +34,17 @@ class ResultTestVariablesTransmissionEvent implements Event
     private $transmissionId;
     /** @var string */
     private $testUri;
-    /** @var bool  */
-    private bool $isManualScored;
 
     public function __construct(
         string $deliveryExecutionId,
         array $variables,
         string $transmissionId,
-        string $testUri = '',
-        bool $isManualScored = null,
+        string $testUri = ''
     ) {
         $this->deliveryExecutionId = $deliveryExecutionId;
         $this->variables = $variables;
         $this->transmissionId = $transmissionId;
         $this->testUri = $testUri;
-        $this->isManualScored = $isManualScored;
     }
 
     public function getName(): string
@@ -74,10 +70,5 @@ class ResultTestVariablesTransmissionEvent implements Event
     public function getTestUri(): string
     {
         return $this->testUri;
-    }
-
-    public function isManualScored(): bool
-    {
-        return $this->isManualScored;
     }
 }

--- a/models/classes/eventHandler/ResultTransmissionEventHandler/ResultTransmissionEventHandler.php
+++ b/models/classes/eventHandler/ResultTransmissionEventHandler/ResultTransmissionEventHandler.php
@@ -22,19 +22,13 @@ declare(strict_types=1);
 
 namespace oat\taoQtiTest\models\classes\eventHandler\ResultTransmissionEventHandler;
 
-use common_exception_Error;
-use oat\oatbox\event\EventManager;
-use oat\oatbox\service\ServiceManager;
 use oat\oatbox\service\ServiceNotFoundException;
 use oat\tao\model\service\InjectionAwareService;
 use oat\taoDelivery\model\execution\DeliveryServerService;
 use oat\taoQtiTest\models\classes\event\ResultTestVariablesTransmissionEvent;
 use oat\taoQtiTest\models\event\ResultItemVariablesTransmissionEvent;
-use oat\taoQtiTest\models\event\TestVariablesRecorded;
 use taoQtiCommon_helpers_ResultTransmitter;
 use oat\oatbox\service\exception\InvalidServiceManagerException;
-use oat\taoResultServer\models\classes\implementation\ResultServerService;
-use taoResultServer_models_classes_ReadableResultStorage as ReadableResultStorage;
 
 class ResultTransmissionEventHandler extends InjectionAwareService implements
     Api\ResultTransmissionEventHandlerInterface
@@ -55,6 +49,7 @@ class ResultTransmissionEventHandler extends InjectionAwareService implements
     /**
      * @param ResultTestVariablesTransmissionEvent $event
      * @throws InvalidServiceManagerException
+     * @throws ServiceNotFoundException
      * @throws \taoQtiCommon_helpers_ResultTransmissionException
      */
     public function transmitResultTestVariable(ResultTestVariablesTransmissionEvent $event): void
@@ -64,14 +59,14 @@ class ResultTransmissionEventHandler extends InjectionAwareService implements
             $event->getTransmissionId(),
             $event->getTestUri()
         );
-
-        if (!$this->containsScoreTotal($event)) {
-            return;
-        }
-
-        $this->triggerTestVariablesRecorded($event);
     }
 
+    /**
+     * @param $deliveryExecutionIdigcicd
+     * @return taoQtiCommon_helpers_ResultTransmitter
+     * @throws InvalidServiceManagerException
+     * @throws \oat\oatbox\service\ServiceNotFoundException
+     */
     private function buildTransmitter($deliveryExecutionId): taoQtiCommon_helpers_ResultTransmitter
     {
         /** @var DeliveryServerService $deliveryServerService */
@@ -79,59 +74,5 @@ class ResultTransmissionEventHandler extends InjectionAwareService implements
         $resultStore = $deliveryServerService->getResultStoreWrapper($deliveryExecutionId);
 
         return new taoQtiCommon_helpers_ResultTransmitter($resultStore);
-    }
-
-    public function getEventManager()
-    {
-        return $this->getServiceLocator()->get(EventManager::SERVICE_ID);
-    }
-
-    public function getServiceLocator()
-    {
-        return ServiceManager::getServiceManager();
-    }
-
-    /**
-     * @return ReadableResultStorage
-     * @throws ServiceNotFoundException
-     * @throws common_exception_Error
-     */
-    private function getResultsStorage(): ReadableResultStorage
-    {
-        $resultServerService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
-        $storage = $resultServerService->getResultStorage();
-
-        if (!$storage instanceof ReadableResultStorage) {
-            throw new common_exception_Error('Configured result storage is not writable.');
-        }
-
-        return $storage;
-    }
-
-    private function containsScoreTotal(ResultTestVariablesTransmissionEvent $event): bool
-    {
-        $scoreTotal = array_filter(
-            $event->getVariables(),
-            function ($item) {
-                return $item->getIdentifier() === 'SCORE_TOTAL';
-            }
-        );
-
-        return !empty($scoreTotal);
-    }
-
-    /**
-     * @param ResultTestVariablesTransmissionEvent $event
-     * @return void
-     * @throws InvalidServiceManagerException
-     */
-    private function triggerTestVariablesRecorded(ResultTestVariablesTransmissionEvent $event): void
-    {
-        $outcomeVariables = $this->getResultsStorage()->getDeliveryVariables($event->getDeliveryExecutionId());
-        $this->getEventManager()->trigger(new TestVariablesRecorded(
-            $event->getDeliveryExecutionId(),
-            $outcomeVariables,
-            $event->isManualScored()
-        ));
     }
 }

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -46,6 +46,7 @@ use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\DeliveryServerService;
 use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
 use oat\taoDelivery\model\RuntimeService;
+use oat\taoOutcomeRds\model\RdsResultStorage;
 use oat\taoQtiItem\model\portableElement\exception\PortableElementNotFoundException;
 use oat\taoQtiItem\model\portableElement\exception\PortableModelMissing;
 use oat\taoQtiItem\model\portableElement\PortableElementService;
@@ -57,6 +58,7 @@ use oat\taoQtiTest\models\event\QtiContinueInteractionEvent;
 use oat\taoQtiTest\models\event\TestExitEvent;
 use oat\taoQtiTest\models\event\TestInitEvent;
 use oat\taoQtiTest\models\event\TestTimeoutEvent;
+use oat\taoQtiTest\models\event\DeliveryExecutionFinish;
 use oat\taoQtiTest\models\ExtendedStateService;
 use oat\taoQtiTest\models\files\QtiFlysystemFileManager;
 use oat\taoQtiTest\models\render\UpdateItemContentReferencesService;
@@ -68,6 +70,7 @@ use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\toolsStates\ToolsStateStorage;
 use oat\taoQtiTest\models\TestSessionService;
+use oat\taoResultServer\models\classes\implementation\ResultServerService;
 use qtism\common\datatypes\QtiInteger;
 use qtism\common\datatypes\QtiString as QtismString;
 use qtism\common\enums\BaseType;
@@ -1185,8 +1188,27 @@ class QtiRunnerService extends ConfigurableService implements PersistableRunnerS
         }
 
         $this->getServiceManager()->get(ExtendedStateService::SERVICE_ID)->clearEvents($executionUri);
+        /** @var TestSession $session */
+        $session = $context->getTestSession();
+        $this->triggerDeliveryExecutionFinish($deliveryExecution, $session->isManualScored());
 
         return $result;
+    }
+
+    private function getResultsStorage(): RdsResultStorage
+    {
+        return $this->getServiceLocator()->get(ResultServerService::SERVICE_ID)->getResultStorage();
+    }
+
+    private function triggerDeliveryExecutionFinish(DeliveryExecution $deliveryExecution, bool $isManualScored): void
+    {
+        $outcomeVariables = $this->getResultsStorage()->getDeliveryVariables($deliveryExecution->getIdentifier());
+        $this->getServiceManager()->get(EventManager::SERVICE_ID)->trigger(
+            new DeliveryExecutionFinish(
+                $deliveryExecution,
+                $outcomeVariables,
+                $isManualScored
+            ));
     }
 
     /**


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-248

## What's Changed

Moving the event to the end of Delivery Execution gives us access to Outcomes and DE Finish time at the same time. We need both of these values to cover the case when a query is sent via the AGS API without changing the result and when the test is set with Outcomes is set to none

## Dependencies PRs

- https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/371
- https://github.com/oat-sa/extension-tao-outcome/pull/273