### PR TITLE
feat: Adjust server-side timers when resuming an execution

### DIFF
--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -138,7 +138,7 @@ class ConcurringSessionService
 
     public function adjustTimers(DeliveryExecution $execution): void
     {
-        $this->logger->info(
+        $this->logger->debug(
             sprintf('Adjusting timers on test restart, current ts is %f', microtime(true))
         );
 
@@ -163,7 +163,7 @@ class ConcurringSessionService
                 $last = $this->currentSession->getAttribute("pausedAt-{$executionId}");
                 $this->currentSession->removeAttribute("pausedAt-{$executionId}");
 
-                $this->logger->info(
+                $this->logger->debug(
                     sprintf('Adjusting timers based on timestamp stored in session: %f', $last)
                 );
             }
@@ -172,14 +172,14 @@ class ConcurringSessionService
         if (!isset($last) && $testSession instanceof TestSession) {
             $last = $this->getHighestItemTimestamp($testSession, $timer);
 
-            $this->logger->info(
+            $this->logger->debug(
                 sprintf('Adjusting timers based on highest item timestamp: %f', $last)
             );
         }
 
         if (isset($last) && $last > 0) {
             $delta = (new DateTime('now'))->format('U') - $last;
-            $this->logger->info(sprintf('Adjusting timers by %.2f s', $delta));
+            $this->logger->debug(sprintf('Adjusting timers by %.2f s', $delta));
 
             $this->getTimerAdjustmentService()->increase(
                 $testSession,

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -178,13 +178,10 @@ class ConcurringSessionService
         }
 
         if (isset($last) && $last > 0) {
-            $delta = (new DateTime('now'))->format('U') - $last;
-            $this->logger->debug(sprintf('Adjusting timers by %.2f s', $delta));
+            $delta = (int) round((new DateTime('now'))->format('U') - $last);
+            $this->logger->debug(sprintf('Adjusting timers by %d s', $delta));
 
-            $this->getTimerAdjustmentService()->increase(
-                $testSession,
-                (int) $delta
-            );
+            $this->getTimerAdjustmentService()->increase($testSession, $delta);
 
             $testSession->suspend();
             $this->getTestSessionService()->persist($testSession);
@@ -227,7 +224,8 @@ class ConcurringSessionService
             );
         }
 
-        $testDefinition = $container->getSourceTest($execution);
+        $sessionId = $execution->getIdentifier();
+        $testDefinitionUri = $container->getSourceTest($execution);
         $testCompilation = sprintf(
             '%s|%s',
             $container->getPrivateDirId($execution),
@@ -235,9 +233,10 @@ class ConcurringSessionService
         );
 
         return $this->qtiRunnerService->getServiceContext(
-            $testDefinition,
+            $testDefinitionUri,
             $testCompilation,
-            $execution->getOriginalIdentifier()
+            $sessionId,
+            $execution->getUserIdentifier()
         );
     }
 

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace oat\taoQtiTest\model\Service;
 
 use common_Exception;
-use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -96,9 +96,10 @@ class ConcurringSessionService
 
         foreach ($userExecutions as $execution) {
             $executionId = $execution->getOriginalIdentifier();
+
             if ($executionId !== $activeExecution->getOriginalIdentifier()) {
                 try {
-                    $this->setConcurringSession($execution->getOriginalIdentifier());
+                    $this->setConcurringSession($executionId);
 
                     $context = $this->getContextByDeliveryExecution($execution);
                     $this->qtiRunnerService->endTimer($context);
@@ -110,7 +111,7 @@ class ConcurringSessionService
                         sprintf(
                             '%s: Unable to pause delivery execution %s: %s',
                             self::class,
-                            $execution->getOriginalIdentifier(),
+                            $executionId,
                             $e->getMessage()
                         )
                     );

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -139,7 +139,7 @@ class ConcurringSessionService
     public function adjustTimers(DeliveryExecution $execution): void
     {
         $this->logger->info(
-            sprintf("Adjusting timers on test restart, current ts is %f", microtime(true))
+            sprintf('Adjusting timers on test restart, current ts is %f', microtime(true))
         );
 
         $testSession = $this->getTestSessionService()->getTestSession($execution);
@@ -164,7 +164,7 @@ class ConcurringSessionService
                 $this->currentSession->removeAttribute("pausedAt-{$executionId}");
 
                 $this->logger->info(
-                    sprintf("Adjusting timers based on timestamp stored in session: %f", $last)
+                    sprintf('Adjusting timers based on timestamp stored in session: %f', $last)
                 );
             }
         }
@@ -173,13 +173,13 @@ class ConcurringSessionService
             $last = $this->getHighestItemTimestamp($testSession, $timer);
 
             $this->logger->info(
-                sprintf("Adjusting timers based on highest item timestamp: %f", $last)
+                sprintf('Adjusting timers based on highest item timestamp: %f', $last)
             );
         }
 
         if (isset($last) && $last > 0) {
             $delta = (new DateTime('now'))->format('U') - $last;
-            $this->logger->info(sprintf("Adjusting timers by %.2f s", $delta));
+            $this->logger->info(sprintf('Adjusting timers by %.2f s', $delta));
 
             $this->getTimerAdjustmentService()->increase(
                 $testSession,
@@ -201,7 +201,7 @@ class ConcurringSessionService
                 $testSession->getItemTags($item)
             );
 
-            if($timestamp > 0) {
+            if ($timestamp > 0) {
                 $timestamps[] = $timestamp;
             }
         }

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace oat\taoQtiTest\model\Service;
 
 use common_Exception;
-use oat\generis\model\data\Ontology;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
 use oat\taoDelivery\model\execution\DeliveryExecution;
@@ -51,7 +50,6 @@ class ConcurringSessionService
     private LoggerInterface $logger;
     private QtiRunnerService $qtiRunnerService;
     private RuntimeService $runtimeService;
-    private Ontology $ontology;
     private DeliveryExecutionService $deliveryExecutionService;
     private FeatureFlagCheckerInterface $featureFlagChecker;
     private ?PHPSession $currentSession;
@@ -60,7 +58,6 @@ class ConcurringSessionService
         LoggerInterface $logger,
         QtiRunnerService $qtiRunnerService,
         RuntimeService $runtimeService,
-        Ontology $ontology,
         DeliveryExecutionService $deliveryExecutionService,
         FeatureFlagCheckerInterface $featureFlagChecker,
         PHPSession $currentSession = null
@@ -68,7 +65,6 @@ class ConcurringSessionService
         $this->logger = $logger;
         $this->qtiRunnerService = $qtiRunnerService;
         $this->runtimeService = $runtimeService;
-        $this->ontology = $ontology;
         $this->deliveryExecutionService = $deliveryExecutionService;
         $this->featureFlagChecker = $featureFlagChecker;
         $this->currentSession = $currentSession ?? PHPSession::singleton();

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -24,7 +24,6 @@ namespace oat\taoQtiTest\model\Service;
 
 use common_Exception;
 use core_kernel_classes_Resource;
-use DateTime;
 use oat\generis\model\data\Ontology;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
@@ -43,6 +42,7 @@ use oat\taoQtiTest\models\TestSessionService;
 use PHPSession;
 use Psr\Log\LoggerInterface;
 use qtism\runtime\tests\RouteItem;
+use DateTime;
 use Throwable;
 
 class ConcurringSessionService

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -193,50 +193,12 @@ class ConcurringSessionService
 
             $this->getTimerAdjustmentService()->increase(
                 $testSession,
-                (int) $delta,
-                TimerAdjustmentServiceInterface::TYPE_TIME_ADJUSTMENT,
-                $this->getAdjustmentPlace($testSession)
+                (int) $delta
             );
 
             $testSession->suspend();
             $this->getTestSessionService()->persist($testSession);
         }
-    }
-
-    private function getAdjustmentPlace(TestSession $testSession): ?QtiIdentifiable
-    {
-        $test = $testSession->getAssessmentTest();
-        $testPart = $testSession->getCurrentTestPart();
-        $section = $testSession->getCurrentAssessmentSection();
-        $itemRef = $testSession->getCurrentAssessmentItemRef();
-
-        if ($itemRef && $itemRef->hasTimeLimits()) {
-            $this->logger->info('Adjusting at the item level');
-
-            return $itemRef;
-        }
-
-        if ($testPart && $testPart->hasTimeLimits()) {
-            $this->logger->info('Adjusting at the test part level');
-
-            return $testPart;
-        }
-
-        if ($section && $section->hasTimeLimits()) {
-            $this->logger->info('Adjusting at the section level');
-
-            return $section;
-        }
-
-        if ($test && $test->hasTimeLimits()) {
-            $this->logger->info('Adjusting at the test level');
-
-            return $section;
-        }
-
-        $this->logger->info('Adjusting at the test session level');
-
-        return null;
     }
 
     private function getHighestItemTimestamp(TestSession $testSession, QtiTimer $timer): ?float

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -189,7 +189,7 @@ class ConcurringSessionService
 
         if (isset($last) && $last > 0) {
             $delta = (new DateTime('now'))->format('U') - $last;
-            $this->logger->info(sprintf("Adjusting by %.2f s", $delta));
+            $this->logger->info(sprintf("Adjusting timers by %.2f s", $delta));
 
             $this->getTimerAdjustmentService()->increase(
                 $testSession,

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -39,7 +39,6 @@ use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\time\QtiTimer;
 use oat\taoQtiTest\models\runner\time\QtiTimerFactory;
 use oat\taoQtiTest\models\runner\time\TimerAdjustmentService;
-use oat\taoQtiTest\models\SessionStateService;
 use oat\taoQtiTest\models\TestSessionService;
 use PHPSession;
 use Psr\Log\LoggerInterface;

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -336,12 +336,16 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
     {
         $target = $this->getTimerTarget();
         $routeItem = $this->getCurrentRouteItem();
+
         $sources = [
-            $routeItem->getAssessmentTest(),
+            $this->getAssessmentTest(),
             $this->getCurrentTestPart(),
             $this->getCurrentAssessmentSection(),
-            $routeItem->getAssessmentItemRef(),
         ];
+
+        if ($routeItem instanceof RouteItem) {
+            array_unshift($sources, $routeItem->getAssessmentItemRef());
+        }
 
         foreach ($sources as $source) {
             $this->updateDurationCache($source->getIdentifier(), $target);

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -347,7 +347,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
             $sources[] = $routeItem->getAssessmentItemRef();
         }
 
-        foreach ($sources as $source) {
+        foreach (array_filter($sources) as $source) {
             $this->updateDurationCache($source->getIdentifier(), $target);
         }
     }

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2016-2024 (original work) Open Assessment Technologies SA
  *
  */
 

--- a/models/classes/runner/session/TestSession.php
+++ b/models/classes/runner/session/TestSession.php
@@ -344,7 +344,7 @@ class TestSession extends taoQtiTest_helpers_TestSession implements UserUriAware
         ];
 
         if ($routeItem instanceof RouteItem) {
-            array_unshift($sources, $routeItem->getAssessmentItemRef());
+            $sources[] = $routeItem->getAssessmentItemRef();
         }
 
         foreach ($sources as $source) {


### PR DESCRIPTION
**Associated Jira issue:** [TR-5911](https://oat-sa.atlassian.net/browse/TR-5911)

**Changelog:**

- Makes the `ConcurringSessionService` to store the timestamp when a test is suspended because another one has been launched.
- Introduces a method to adjust the timers for a test based on the current timestamp and the timestamp when the test was paused
  - This method is called by the LTI Delivery Provider when a paused test is resumed ([here](https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/377))
  - It tried to use the suspension timestamp if available; otherwise, it uses the highest timestamp associated with an item
  - The suspension timestamp is stored as part of the test session in the same way as the suspension reason was stored
- Fixes a bug when handling the item duration cache, as the old code assumed item durations would only be updated for the currently-running test.
  - If the test is not running, `getCurrentRouteItem()` may be `null`

[TR-5911]: https://oat-sa.atlassian.net/browse/TR-5911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ