### PR TITLE
bugfix: add section for QtiPair

### DIFF
--- a/models/classes/class.QtiTestConverter.php
+++ b/models/classes/class.QtiTestConverter.php
@@ -18,6 +18,7 @@
 * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
 */
 
+use qtism\common\datatypes\QtiPair;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\data\QtiComponent;
 use qtism\data\QtiComponentCollection;
@@ -146,7 +147,10 @@ class taoQtiTest_models_classes_QtiTestConverter
             $value = $this->getValue($component, $property);
             if ($value !== null) {
                 $key = $property->getName();
-                if ($value instanceof QtiComponentCollection) {
+                if ($value instanceof QtiPair) {
+                    $array[$property->getName()] = (string) $value;
+                }
+                elseif ($value instanceof QtiComponentCollection) {
                     $array[$key] = [];
                     foreach ($value as $item) {
                         $array[$key][] = $this->componentToArray($item);


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3506

## What's Changed

- Add ability to convert test with QtiPair to array, without it the XMLEditor saving fails.

## How to test
- Enable XmlEditor in your Authoring. Follow the [documentation](https://oat-sa.atlassian.net/wiki/spaces/NEX/pages/1862860825/How+to+enable+Test+XML+Editor)
- Create test and open it using XmlEdit button.
- add code for `branchRule` with `baseRule` `directedPair` for example
` <branchRule target="testPart-3">
      <contains>
        <variable identifier="item-1.RESPONSE"/>
        <multiple>
          <baseValue baseType="directedPair">ST410_01 ST410Q01B</baseValue>
        </multiple>
      </contains>
    </branchRule>`
- Click save. 
- Without change it will fail.