### PR TITLE
fix: add missing const in metadata exporter implementation

### DIFF
--- a/models/classes/export/Formats/Metadata/TestPackageExport.php
+++ b/models/classes/export/Formats/Metadata/TestPackageExport.php
@@ -32,6 +32,8 @@ class TestPackageExport extends AbstractTestExport
 {
     use EventManagerAwareTrait;
 
+    protected const VERSION = 'metadata';
+
     public function getLabel(): string
     {
         return __('QTI Test Metadata');


### PR DESCRIPTION
MIssing const in `\oat\taoQtiTest\models\export\Formats\Metadata\TestPackageExport` was causing critical error when creating empty manifest file: in `\oat\taoQtiTest\models\QtiTestUtils::emptyImsManifest`. 

Defined const to `metadata`
This change does not impact exporter functionality. 