### PR TITLE
fix: add missing const in metadata exporter implementation

### DIFF
--- a/models/classes/export/Formats/Metadata/TestPackageExport.php
+++ b/models/classes/export/Formats/Metadata/TestPackageExport.php
@@ -32,6 +32,8 @@ class TestPackageExport extends AbstractTestExport
 {
     use EventManagerAwareTrait;
 
+    protected const VERSION = 'metadata';
+
     public function getLabel(): string
     {
         return __('QTI Test Metadata');


### PR DESCRIPTION
https://github.com/oat-sa/extension-tao-testqti/pull/2444

Backport 