### PR TITLE
fix: Removing furigana from test authoring

### DIFF
--- a/views/js/controller/creator/qtiContentCreator.js
+++ b/views/js/controller/creator/qtiContentCreator.js
@@ -43,7 +43,8 @@ define([
                     'taoqtimaths',
                     'taoqtiinclude',
                     'taoqtitable',
-                    'sharedspace' // That Ck instance still use floatingspace to position the toolbar, whereas the sharedspace plugin is used by the Item creator
+                    'sharedspace', // That Ck instance still use floatingspace to position the toolbar, whereas the sharedspace plugin is used by the Item creator
+                    'taofurigana' // furiganaPlugin currently unsupported on test authoring
                 ].join(','),
 
                 toolbar = [


### PR DESCRIPTION
Ticket: [AUT-3327](https://oat-sa.atlassian.net/browse/AUT-3327)

## What's Changed

- Ruby tag removed from Rubric Block's CK Editor on Test Authoring

## Demo
![image](https://i.imgur.com/Eo6DBzD.gif)

## Test Env
[test-kiril.playground.kitchen](http://test-kiril.playground.kitchen.it.taocloud.org:40351/tao/Main/login)
Creds: admin/admin

## How to test
- Navigate to 'Tests' tab
- Open the test from preconditions in 'Authoring' mode
- Click ‘+ New section’ button
- Click ‘Manage Rubric Blocks' on the right from the section’s name
- Click '+ New Rubric Block' button
- Observe CK Editor
- Enter some text
- Select entered text and click 'Insert Furigana (Ruby)' button
- Enter some text
- Click 'Save' button

[AUT-3327]: https://oat-sa.atlassian.net/browse/AUT-3327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ