### PR TITLE
feat: Custom config for testing PHP-MD codesize rules in the pipelines

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: CI
-        uses: oat-sa/tao-extension-ci-action@v1
+        uses: oat-sa/tao-extension-ci-action@experimental/phpmd-ci-checks
         with:
           php: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage }}

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -378,7 +378,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         }
 
         // @todo Changing this file should trigger an error in the pipelines due to high CC
-        
+
         // Validate the manifest (well formed XML, valid against the schema).
         if ($validPackage === true) {
             $folder = $qtiPackageParser->extract();

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -377,6 +377,8 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
             $report->add(common_report_Report::createFailure($invalidArchiveMsg));
         }
 
+        // @todo Changing this file should trigger an error in the pipelines due to high CC
+        
         // Validate the manifest (well formed XML, valid against the schema).
         if ($validPackage === true) {
             $folder = $qtiPackageParser->extract();


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1444](https://oat-sa.atlassian.net/browse/ADF-1444)

**DO NOT MERGE (yet).**

For testing/debugging purposes.

This is testing changes from https://github.com/oat-sa/tao-extension-ci-action/pull/11

Errors are shown here: https://github.com/oat-sa/extension-tao-testqti/security/code-scanning?query=pr%3A2451+tool%3APHPMD+is%3Aopen (can be accessed from the "Checks" tab from the PR page)

[ADF-1444]: https://oat-sa.atlassian.net/browse/ADF-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ