### PR TITLE
fix: Improve opening another tab with new session with the same user

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ Environment variables
 |-----------------------------------------------|-------------------------------------------------------------------------------------|
 | FEATURE_FLAG_FORCE_DISPLAY_TEST_ITEM_FEEDBACK | Even if itemSessionControl `showFeedback` option is false, show item feedback modal |
 | FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS        | When set, forces restoring the timers state from the browser storage on test init   |
+| FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE | Typed environment variable, controlling whether a delivery execution state should be kept as is or reset each time it starts. If `"false"` the state will be reset on each restart. Default behavior. If `"true"` the state will be maintained upon a restart |

--- a/model/Container/TestQtiServiceProvider.php
+++ b/model/Container/TestQtiServiceProvider.php
@@ -171,6 +171,7 @@ class TestQtiServiceProvider implements ContainerServiceProviderInterface
                     service(RuntimeService::SERVICE_ID),
                     service(DeliveryExecutionService::SERVICE_ID),
                     service(FeatureFlagChecker::class),
+                    service(StateServiceInterface::class),
                 ]
             );
     }

--- a/model/Container/TestQtiServiceProvider.php
+++ b/model/Container/TestQtiServiceProvider.php
@@ -171,7 +171,7 @@ class TestQtiServiceProvider implements ContainerServiceProviderInterface
                     service(RuntimeService::SERVICE_ID),
                     service(DeliveryExecutionService::SERVICE_ID),
                     service(FeatureFlagChecker::class),
-                    service(StateServiceInterface::class),
+                    service(StateServiceInterface::SERVICE_ID),
                 ]
             );
     }

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -87,9 +87,8 @@ class ConcurringSessionService
             }
 
             $this->getConcurringSessionService()->clearConcurringSession($activeExecution);
+            $this->resetDeliveryExecutionState($activeExecution);
         }
-
-        $this->resetDeliveryExecutionState($activeExecution);
     }
 
     public function pauseConcurrentSessions(DeliveryExecution $activeExecution): void

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -77,7 +77,7 @@ class ConcurringSessionService
         $this->currentSession = $currentSession ?? PHPSession::singleton();
     }
 
-    public function pauseActiveDeliveryExecution($activeExecution): void
+    public function pauseActiveDeliveryExecutionsForUser($activeExecution): void
     {
         if ($activeExecution instanceof DeliveryExecution) {
             $this->getConcurringSessionService()->pauseConcurrentSessions($activeExecution);

--- a/test/unit/model/Service/ConcurringSessionServiceTest.php
+++ b/test/unit/model/Service/ConcurringSessionServiceTest.php
@@ -26,6 +26,7 @@ use core_kernel_classes_Resource;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
+use oat\taoDelivery\model\execution\StateServiceInterface;
 use oat\taoDelivery\model\RuntimeService;
 use oat\taoQtiTest\model\Service\ConcurringSessionService;
 use oat\taoQtiTest\models\container\QtiTestDeliveryContainer;
@@ -47,6 +48,7 @@ class ConcurringSessionServiceTest extends TestCase
     private FeatureFlagCheckerInterface $featureFlagChecker;
     private PHPSession $currentSession;
     private ConcurringSessionService $subject;
+    private StateServiceInterface $stateService;
 
     protected function setUp(): void
     {
@@ -55,6 +57,7 @@ class ConcurringSessionServiceTest extends TestCase
         $this->deliveryExecutionService = $this->createMock(DeliveryExecutionService::class);
         $this->featureFlagChecker = $this->createMock(FeatureFlagCheckerInterface::class);
         $this->currentSession = $this->createMock(PHPSession::class);
+        $this->stateService = $this->createMock(StateServiceInterface::class);
 
         $this->subject = new ConcurringSessionService(
             $this->createMock(LoggerInterface::class),
@@ -62,6 +65,7 @@ class ConcurringSessionServiceTest extends TestCase
             $this->runtimeService,
             $this->deliveryExecutionService,
             $this->featureFlagChecker,
+            $this->stateService,
             $this->currentSession
         );
     }
@@ -265,5 +269,154 @@ class ConcurringSessionServiceTest extends TestCase
             ->with($context);
 
         $this->subject->pauseConcurrentSessions($execution);
+    }
+
+    public function testPauseActiveDeliveryExecutionsForUser()
+    {
+        $this->featureFlagChecker
+            ->method('isEnabled')
+            ->withConsecutive(['FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS'], ['FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE'])
+            ->willReturn(true);
+
+        $otherDeliveryResource = $this->createMock(core_kernel_classes_Resource::class);
+        $executionDomainObject = $this->createMock(DeliveryExecution::class);
+        $otherExecutionDomainObject = $this->createMock(DeliveryExecution::class);
+
+        $executionDomainObject
+            ->expects($this->atLeastOnce())
+            ->method('getOriginalIdentifier')
+            ->willReturn('https://example.com/execution/1');
+
+        $otherExecutionDomainObject
+            ->expects($this->atLeastOnce())
+            ->method('getDelivery')
+            ->willReturn($otherDeliveryResource);
+        $otherExecutionDomainObject
+            ->expects($this->atLeastOnce())
+            ->method('getOriginalIdentifier')
+            ->willReturn('https://example.com/execution/2');
+        $otherExecutionDomainObject
+            ->expects($this->atLeastOnce())
+            ->method('getIdentifier')
+            ->willReturn('https://example.com/execution/2');
+
+        $this->deliveryExecutionService
+            ->expects($this->atLeastOnce())
+            ->method('getDeliveryExecutionsByStatus')
+            ->willReturn([$executionDomainObject, $otherExecutionDomainObject]);
+
+        $otherDeliveryResource
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn('https://example.com/delivery/2');
+
+        $executionState = $this->createMock(core_kernel_classes_Resource::class);
+        $executionState
+            ->method('getUri')
+            ->willReturn(DeliveryExecution::STATE_ACTIVE);
+
+        $execution = $this->createMock(DeliveryExecution::class);
+        $execution
+            ->expects($this->atLeastOnce())
+            ->method('getOriginalIdentifier')
+            ->willReturn('https://example.com/execution/1');
+        $execution
+            ->expects($this->atLeastOnce())
+            ->method('getUserIdentifier')
+            ->willReturn('https://example.com/user/1');
+        $execution
+            ->method('getState')
+            ->willReturn($executionState);
+
+        $qtiTestDeliveryContainer = $this->createMock(QtiTestDeliveryContainer::class);
+        $qtiTestDeliveryContainer
+            ->expects($this->once())
+            ->method('getPrivateDirId')
+            ->with($execution)
+            ->willReturn('privateDirId');
+        $qtiTestDeliveryContainer
+            ->expects($this->once())
+            ->method('getPublicDirId')
+            ->with($execution)
+            ->willReturn('publicDirId');
+        $qtiTestDeliveryContainer
+            ->expects($this->once())
+            ->method('getSourceTest')
+            ->with($execution)
+            ->willReturn('http://example.com/sourceTest/1');
+
+        $this->runtimeService
+            ->expects($this->once())
+            ->method('getDeliveryContainer')
+            ->with('https://example.com/delivery/2')
+            ->willReturn($qtiTestDeliveryContainer);
+
+        $itemRef = $this->createMock(AssessmentItemRef::class);
+        $itemRef
+            ->expects($this->once())
+            ->method('getIdentifier')
+            ->willReturn('itemRef');
+
+        $duration = $this->createMock(QtiDuration::class);
+        $duration
+            ->expects($this->exactly(2))
+            ->method('getSeconds')
+            ->with(true)
+            ->willReturn(123);
+
+        $testSession = $this->createMock(TestSession::class);
+        $testSession
+            ->expects($this->once())
+            ->method('getCurrentAssessmentItemRef')
+            ->willReturn($itemRef);
+        $testSession
+            ->expects($this->once())
+            ->method('getTimerTarget')
+            ->willReturn(TimePoint::TARGET_SERVER);
+        $testSession
+            ->expects($this->once())
+            ->method('getTimerDuration')
+            ->with('itemRef', TimePoint::TARGET_SERVER)
+            ->willReturn($duration);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context
+            ->expects($this->exactly(2))
+            ->method('getTestSession')
+            ->willReturn($testSession);
+
+        $this->qtiRunnerService
+            ->expects($this->once())
+            ->method('getServiceContext')
+            ->with(
+                'http://example.com/sourceTest/1',
+                'privateDirId|publicDirId',
+                'https://example.com/execution/2'
+            )->willReturn($context);
+
+        $this->currentSession
+            ->expects($this->exactly(2))
+            ->method('setAttribute')
+            ->withConsecutive(
+                [
+                    'pauseReason-https://example.com/execution/2',
+                    'PAUSE_REASON_CONCURRENT_TEST'
+                ],
+                [
+                    'itemDuration-https://example.com/execution/2',
+                    123
+                ]
+            )->willReturn(null);
+
+        $this->qtiRunnerService
+            ->expects($this->once())
+            ->method('endTimer')
+            ->with($context);
+        $this->qtiRunnerService
+            ->expects($this->once())
+            ->method('pause')
+            ->with($context);
+
+        $this->subject->pauseActiveDeliveryExecutionsForUser($execution);
     }
 }

--- a/test/unit/model/Service/ConcurringSessionServiceTest.php
+++ b/test/unit/model/Service/ConcurringSessionServiceTest.php
@@ -275,7 +275,10 @@ class ConcurringSessionServiceTest extends TestCase
     {
         $this->featureFlagChecker
             ->method('isEnabled')
-            ->withConsecutive(['FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS'], ['FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE'])
+            ->withConsecutive(
+                ['FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS'],
+                ['FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE']
+            )
             ->willReturn(true);
 
         $otherDeliveryResource = $this->createMock(core_kernel_classes_Resource::class);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-266

For cases when one of sessions was finished and then reopened, the pausing for another tabs worked not like expected.

How to test:

1. Start new test A (new LTI link)
2. Start new test B (new LTI link)
3. A gets the “concurrent test” popup. Do not click on it
4. Finish test B
5. Check that you have “Thank you” page
6. Go back to test A & Accept the popup
7. Check that you have “Test suspended” page
8. Start the previous test A again (reusing the previous LTI link). This unpauses A
9. Start the previous test B again (reusing the previous LTI link). This pauses A
10. Go back to test A & Accept the popup
11. You should receive the “Test suspended” page

https://github.com/oat-sa/extension-tao-testqti/assets/1053022/de422b1d-26e6-40a0-b680-42acfddf6863

