### PR TITLE
Feature/AUT-3414/Align categories that activate the TextToSpeech tool

### DIFF
--- a/models/classes/TestCategoryPreset.php
+++ b/models/classes/TestCategoryPreset.php
@@ -49,7 +49,7 @@ class TestCategoryPreset implements JsonSerializable
     /**
      * @var string[] $altCategories - the other possible qti categories that would activate the preset
      */
-    private $altCategories;
+    private $altCategories = [];
 
     /**
      * @var string $description - what is the category purpose
@@ -97,8 +97,6 @@ class TestCategoryPreset implements JsonSerializable
         $this->label        = (string) $label;
         $this->qtiCategory  = (string) $qtiCategory;
 
-        $this->altCategories = [];
-
         if (isset($data['description'])) {
             $this->description = (string) $data['description'];
         }
@@ -136,7 +134,7 @@ class TestCategoryPreset implements JsonSerializable
         return $this->altCategories;
     }
 
-    public function getDescription(): ?string
+    public function getDescription(): string
     {
         return $this->description;
     }

--- a/models/classes/TestCategoryPreset.php
+++ b/models/classes/TestCategoryPreset.php
@@ -31,57 +31,45 @@ use common_exception_InconsistentData;
  */
 class TestCategoryPreset implements JsonSerializable
 {
-    /**
-     * @var string $id
-     */
-    private $id;
+    private string $id;
 
     /**
-     * @var string $label - short preset name
+     * Short preset name
      */
-    private $label;
+    private string $label;
 
     /**
-     * @var string $qtiCategory - the actual qti category that will end up in the QTI markup
+     * The actual qti category that will end up in the QTI markup
      */
-    private $qtiCategory;
+    private string $qtiCategory;
 
     /**
-     * @var string[] $altCategories - the other possible qti categories that would activate the preset
+     * The other possible qti categories that would activate the preset
      */
-    private $altCategories = [];
+    private array $altCategories = [];
 
     /**
-     * @var string $description - what is the category purpose
+     * What is the category purpose
      */
-    private $description = '';
+    private string $description = '';
 
     /**
-     * @var string $order - to sort the categories
+     * To sort the categories
      */
-    private $order = 0;
+    private int $order = 0;
 
     /**
-     * @var string $pluginId - related plugin that the preset depends on
+     * Related plugin that the preset depends on
      */
-    private $pluginId = '';
+    private string $pluginId = '';
 
     /**
-     * @var string $featureFlag - the name of a config flag,
-     * the preset will be deactivated based on this optional value.
+     * The name of a config flag, the preset will be deactivated based on this optional value.
      */
-    private $featureFlag;
+    private string $featureFlag = '';
 
 
-    /**
-     * Create a test category preset
-     * @param string $id
-     * @param string $label
-     * @param string $qtiCategory
-     * @param array $data - optional parameters
-     * @throws common_exception_InconsistentData
-     */
-    public function __construct($id, $label, $qtiCategory, $data)
+    public function __construct(string $id, string $label, string $qtiCategory, array $data = [])
     {
         if (! is_string($id) || empty($id)) {
             throw new common_exception_InconsistentData('The category preset needs an id');
@@ -151,21 +139,14 @@ class TestCategoryPreset implements JsonSerializable
 
     public function getFeatureFlag(): string
     {
-        return (string) $this->featureFlag;
+        return $this->featureFlag;
     }
 
-    /**
-     * @see JsonSerializable::jsonSerialize
-     */
     public function jsonSerialize(): array
     {
         return $this->toArray();
     }
 
-    /**
-     * Convenient method to convert the members to an assoc array
-     * @return array the data
-     */
     public function toArray(): array
     {
         return [
@@ -180,12 +161,6 @@ class TestCategoryPreset implements JsonSerializable
         ];
     }
 
-    /**
-     * Create a test category preset from an assoc array
-     * @param array $data
-     * @return TestCategoryPreset the new instance
-     * @throws common_exception_InconsistentData
-     */
     public static function fromArray(array $data): TestCategoryPreset
     {
         if (!isset($data['id']) || !isset($data['label']) || !isset($data['qtiCategory'])) {

--- a/models/classes/TestCategoryPreset.php
+++ b/models/classes/TestCategoryPreset.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2024 (original work) Open Assessment Technologies SA;
  *
  */
 
@@ -106,37 +106,37 @@ class TestCategoryPreset implements JsonSerializable
         }
     }
 
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
 
-    public function getQtiCategory()
+    public function getQtiCategory(): string
     {
         return $this->qtiCategory;
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return $this->order;
     }
 
-    public function getPluginId()
+    public function getPluginId(): string
     {
         return $this->pluginId;
     }
 
-    public function getFeatureFlag()
+    public function getFeatureFlag(): string
     {
         return (string) $this->featureFlag;
     }
@@ -144,7 +144,7 @@ class TestCategoryPreset implements JsonSerializable
     /**
      * @see JsonSerializable::jsonSerialize
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -153,7 +153,7 @@ class TestCategoryPreset implements JsonSerializable
      * Convenient method to convert the members to an assoc array
      * @return array the data
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'id'          => $this->id,
@@ -172,7 +172,7 @@ class TestCategoryPreset implements JsonSerializable
      * @return TestCategoryPreset the new instance
      * @throws common_exception_InconsistentData
      */
-    public static function fromArray(array $data)
+    public static function fromArray(array $data): TestCategoryPreset
     {
         if (!isset($data['id']) || !isset($data['label']) || !isset($data['qtiCategory'])) {
             throw new common_exception_InconsistentData(

--- a/models/classes/TestCategoryPreset.php
+++ b/models/classes/TestCategoryPreset.php
@@ -47,6 +47,11 @@ class TestCategoryPreset implements JsonSerializable
     private $qtiCategory;
 
     /**
+     * @var string[] $altCategories - the other possible qti categories that would activate the preset
+     */
+    private $altCategories;
+
+    /**
      * @var string $description - what is the category purpose
      */
     private $description = '';
@@ -92,6 +97,8 @@ class TestCategoryPreset implements JsonSerializable
         $this->label        = (string) $label;
         $this->qtiCategory  = (string) $qtiCategory;
 
+        $this->altCategories = [];
+
         if (isset($data['description'])) {
             $this->description = (string) $data['description'];
         }
@@ -103,6 +110,9 @@ class TestCategoryPreset implements JsonSerializable
         }
         if (isset($data['featureFlag'])) {
             $this->featureFlag = (string) $data['featureFlag'];
+        }
+        if (isset($data['altCategories'])) {
+            $this->altCategories = array_map('strval', $data['altCategories']);
         }
     }
 
@@ -121,7 +131,12 @@ class TestCategoryPreset implements JsonSerializable
         return $this->qtiCategory;
     }
 
-    public function getDescription(): string
+    public function getAltCategory(): array
+    {
+        return $this->altCategories;
+    }
+
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -156,13 +171,14 @@ class TestCategoryPreset implements JsonSerializable
     public function toArray(): array
     {
         return [
-            'id'          => $this->id,
-            'label'       => $this->label,
-            'qtiCategory' => $this->qtiCategory,
-            'description' => $this->description,
-            'order'       => $this->order,
-            'pluginId'    => $this->pluginId,
-            'featureFlag' => $this->featureFlag
+            'id'            => $this->id,
+            'label'         => $this->label,
+            'qtiCategory'   => $this->qtiCategory,
+            'altCategories' => $this->altCategories,
+            'description'   => $this->description,
+            'order'         => $this->order,
+            'pluginId'      => $this->pluginId,
+            'featureFlag'   => $this->featureFlag
         ];
     }
 

--- a/views/js/controller/creator/helpers/categorySelector.js
+++ b/views/js/controller/creator/helpers/categorySelector.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2023 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2024 (original work) Open Assessment Technologies SA;
  */
 /**
  * This helper manages the category selection UI:
@@ -35,58 +35,50 @@ define([
 ], function ($, _, __, eventifier, tooltip, templates, featureVisibility) {
     'use strict';
 
-    let allPresets = [],
-        allQtiCategoriesPresets = [];
+    let allPresets = [];
+    let allQtiCategoriesPresets = [];
 
     function categorySelectorFactory($container) {
         const $presetsContainer = $container.find('.category-presets');
         const $customCategoriesSelect = $container.find('[name=category-custom]');
 
-        /**
-         * Read the form state from the DOM and trigger an event with the result, so the listeners can update the item/section model
-         * @fires categorySelector#category-change
-         */
-        function updateCategories() {
-            const presetSelected = $container
-                    .find('.category-preset input:checked')
-                    .toArray()
-                    .map(function (categoryEl) {
-                        return categoryEl.value;
-                    }),
-                presetIndeterminate = $container
-                    .find('.category-preset input:indeterminate')
-                    .toArray()
-                    .map(function (categoryEl) {
-                        return categoryEl.value;
-                    }),
-                customSelected = $customCategoriesSelect
-                    .siblings('.select2-container')
-                    .find('.select2-search-choice')
-                    .not('.partial')
-                    .toArray()
-                    .map(function (categoryEl) {
-                        return categoryEl.textContent && categoryEl.textContent.trim();
-                    }),
-                customIndeterminate = $customCategoriesSelect
-                    .siblings('.select2-container')
-                    .find('.select2-search-choice.partial')
-                    .toArray()
-                    .map(function (categoryEl) {
-                        return categoryEl.textContent && categoryEl.textContent.trim();
-                    });
-
-            const selectedCategories = presetSelected.concat(customSelected);
-            const indeterminatedCategories = presetIndeterminate.concat(customIndeterminate);
-
-            /**
-             * @event categorySelector#category-change
-             * @param {String[]} allCategories
-             * @param {String[]} indeterminate
-             */
-            this.trigger('category-change', selectedCategories, indeterminatedCategories);
-        }
-
         const categorySelector = {
+            /**
+             * Read the form state from the DOM and trigger an event with the result, so the listeners can update the item/section model
+             * @fires categorySelector#category-change
+             */
+            updateCategories() {
+                const presetSelected = $container
+                        .find('.category-preset input:checked')
+                        .toArray()
+                        .map(categoryEl => categoryEl.value),
+                    presetIndeterminate = $container
+                        .find('.category-preset input:indeterminate')
+                        .toArray()
+                        .map(categoryEl => categoryEl.value),
+                    customSelected = $customCategoriesSelect
+                        .siblings('.select2-container')
+                        .find('.select2-search-choice')
+                        .not('.partial')
+                        .toArray()
+                        .map(categoryEl => categoryEl.textContent && categoryEl.textContent.trim()),
+                    customIndeterminate = $customCategoriesSelect
+                        .siblings('.select2-container')
+                        .find('.select2-search-choice.partial')
+                        .toArray()
+                        .map(categoryEl => categoryEl.textContent && categoryEl.textContent.trim());
+
+                const selectedCategories = presetSelected.concat(customSelected);
+                const indeterminatedCategories = presetIndeterminate.concat(customIndeterminate);
+
+                /**
+                 * @event categorySelector#category-change
+                 * @param {String[]} allCategories
+                 * @param {String[]} indeterminate
+                 */
+                this.trigger('category-change', selectedCategories, indeterminatedCategories);
+            },
+
             /**
              * Create the category selection form
              *
@@ -94,24 +86,21 @@ define([
              * contains all the categories applied to at least one item of the section.
              * @param {string} [level] one of the values `testPart`, `section` or `itemRef`
              */
-            createForm: function createForm(currentCategories, level) {
-                const self = this,
-                    presetsTpl = templates.properties.categorypresets,
-                    customCategories = _.difference(currentCategories, allQtiCategoriesPresets);
+            createForm(currentCategories, level) {
+                const presetsTpl = templates.properties.categorypresets;
+                const customCategories = _.difference(currentCategories, allQtiCategoriesPresets);
 
                 const filteredPresets = featureVisibility.filterVisiblePresets(allPresets, level);
                 // add preset checkboxes
                 $presetsContainer.append(presetsTpl({ presetGroups: filteredPresets }));
 
-                $presetsContainer.on('click', function (e) {
+                $presetsContainer.on('click', e => {
                     const $preset = $(e.target).closest('.category-preset');
                     if ($preset.length) {
                         const $checkbox = $preset.find('input');
                         $checkbox.prop('indeterminate', false);
 
-                        _.defer(function () {
-                            updateCategories.call(self);
-                        });
+                        _.defer(() => this.updateCategories());
                     }
                 });
 
@@ -127,9 +116,7 @@ define([
                         },
                         maximumInputLength: 32
                     })
-                    .on('change', function () {
-                        updateCategories.call(self);
-                    });
+                    .on('change', () => this.updateCategories());
 
                 // enable help tooltips
                 tooltip.lookup($container);
@@ -140,7 +127,7 @@ define([
              * @param {String[]} selected - categories associated with an item, or with all the items of the same section
              * @param {String[]} [indeterminate] - categories in an indeterminate state at a section level
              */
-            updateFormState: function updateFormState(selected, indeterminate) {
+            updateFormState(selected, indeterminate) {
                 indeterminate = indeterminate || [];
 
                 const customCategories = _.difference(selected.concat(indeterminate), allQtiCategoriesPresets);
@@ -148,16 +135,16 @@ define([
                 // Preset categories
 
                 const $presetsCheckboxes = $container.find('.category-preset input');
-                $presetsCheckboxes.each(function () {
-                    const category = this.value;
+                $presetsCheckboxes.each((idx, input) => {
+                    const category = input.value;
 
-                    this.indeterminate = false;
-                    this.checked = false;
+                    input.indeterminate = false;
+                    input.checked = false;
 
                     if (indeterminate.indexOf(category) !== -1) {
-                        this.indeterminate = true;
+                        input.indeterminate = true;
                     } else if (selected.indexOf(category) !== -1) {
-                        this.checked = true;
+                        input.checked = true;
                     }
                 });
 
@@ -168,8 +155,8 @@ define([
                 $customCategoriesSelect
                     .siblings('.select2-container')
                     .find('.select2-search-choice')
-                    .each(function () {
-                        const $li = $(this);
+                    .each((idx, li) => {
+                        const $li = $(li);
                         const content = $li.find('div').text();
                         if (indeterminate.indexOf(content) !== -1) {
                             $li.addClass('partial');
@@ -193,8 +180,9 @@ define([
      *          {
      *              id: 'nextPartWarning',
      *              label: 'Next Part Warning',
-     *              qtiCategory : 'x-tao-option-nextPartWarning',
-     *              description : 'Displays a warning before the user finishes a part'
+     *              qtiCategory: 'x-tao-option-nextPartWarning',
+     *              description: 'Displays a warning before the user finishes a part'
+     *              ...
      *          },
      *          ...
      *      ]
@@ -214,7 +202,7 @@ define([
      * @returns {String[]}
      */
     function extractCategoriesFromPresets() {
-        return allPresets.reduce(function (prev, current) {
+        return allPresets.reduce((prev, current) => {
             const groupIds = _.map(current.presets, 'qtiCategory');
             return prev.concat(groupIds);
         }, []);

--- a/views/js/controller/creator/templates/category-presets.tpl
+++ b/views/js/controller/creator/templates/category-presets.tpl
@@ -3,7 +3,7 @@
 
 <div class="category-preset-group-{{groupId}} toggled">
     {{#each presets}}
-    <div class="grid-row pseudo-label-box category-preset" data-qti-category="{{qtiCategory}}">
+    <div class="grid-row pseudo-label-box category-preset" data-qti-category="{{qtiCategory}}" data-categories="{{categories}}">
         <div class="col-1">
             <label>
                 <input

--- a/views/js/test/creator/helpers/categorySelector/test.js
+++ b/views/js/test/creator/helpers/categorySelector/test.js
@@ -13,13 +13,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2024 (original work) Open Assessment Technologies SA;
  */
 /**
  * @author Christophe Noël <christophe@taotesting.com>
  */
 define([
-
     'jquery',
     'taoQtiTest/controller/creator/helpers/categorySelector'
 ], function($, categorySelectorFactory) {
@@ -33,18 +32,21 @@ define([
                 id: 'preset1.1',
                 label: 'preset1.1',
                 qtiCategory: 'x-tao-option-preset1.1',
+                altCategories: ['x-tao-option-preset1-1'],
                 description: 'Description of preset1.1'
             },
             {
                 id: 'preset1.2',
                 label: 'preset1.2',
                 qtiCategory: 'x-tao-option-preset1.2',
+                altCategories: ['x-tao-option-preset1-2'],
                 description: 'Description of preset1.2'
             },
             {
                 id: 'preset1.3',
                 label: 'preset1.3',
                 qtiCategory: 'x-tao-option-preset1.3',
+                altCategories: ['x-tao-option-preset1-3'],
                 description: 'Description of preset1.3'
             }
         ]
@@ -56,18 +58,21 @@ define([
                 id: 'preset2.1',
                 label: 'preset2.1',
                 qtiCategory: 'x-tao-option-preset2.1',
+                altCategories: [],
                 description: 'Description of preset2.1'
             },
             {
                 id: 'preset2.2',
                 label: 'preset2.2',
                 qtiCategory: 'x-tao-option-preset2.2',
+                altCategories: [],
                 description: 'Description of preset2.2'
             },
             {
                 id: 'preset2.3',
                 label: 'preset2.3',
                 qtiCategory: 'x-tao-option-preset2.3',
+                altCategories: [],
                 description: 'Description of preset2.3'
             }
         ]
@@ -126,7 +131,7 @@ define([
             categorySelector = categorySelectorFactory($container),
             selected = [
                 'x-tao-option-preset1.1',
-                'x-tao-option-preset1.2',
+                'x-tao-option-preset1-2', // use the alternative category
                 'x-tao-option-preset2.3',
                 'custom1',
                 'custom2'
@@ -151,7 +156,8 @@ define([
         var $container = $('#qunit-fixture'),
             categorySelector = categorySelectorFactory($container),
             selected = [
-                'x-tao-option-preset1.1',
+                'x-tao-option-preset1-1', // use the alternative category
+                'x-tao-option-preset1-3', // use the alternative category
                 'x-tao-option-preset2.3',
                 'custom1',
                 'custom3'
@@ -170,7 +176,7 @@ define([
 
         assert.equal($container.find('input[value="x-tao-option-preset1.1"]').prop('checked'), true, 'preset 1.1 is checked');
         assert.equal($container.find('input[value="x-tao-option-preset1.2"]').prop('checked'), false, 'preset 1.2 is NOT checked');
-        assert.equal($container.find('input[value="x-tao-option-preset1.3"]').prop('checked'), false, 'preset 1.3 is NOT checked');
+        assert.equal($container.find('input[value="x-tao-option-preset1.3"]').prop('checked'), true, 'preset 1.3 is checked');
         assert.equal($container.find('input[value="x-tao-option-preset2.1"]').prop('checked'), false, 'preset 2.1 is NOT checked');
         assert.equal($container.find('input[value="x-tao-option-preset2.2"]').prop('checked'), false, 'preset 2.2 is NOT checked');
         assert.equal($container.find('input[value="x-tao-option-preset2.3"]').prop('checked'), true, 'preset 2.3 is checked');
@@ -198,7 +204,8 @@ define([
         var $container = $('#qunit-fixture'),
             categorySelector = categorySelectorFactory($container),
             selected = [
-                'x-tao-option-preset1.1',
+                'x-tao-option-preset1-1', // use the alternative category
+                'x-tao-option-preset1-3', // use the alternative category
                 'x-tao-option-preset2.3',
                 'custom1',
                 'custom3'
@@ -226,6 +233,7 @@ define([
             switch (changeCounter) {
                 case 1: {
                     expectedSelected = [
+                        'x-tao-option-preset1.3',
                         'x-tao-option-preset2.3',
                         'custom1',
                         'custom3'
@@ -242,6 +250,7 @@ define([
                 case 2: {
                     expectedSelected = [
                         'x-tao-option-preset1.1',
+                        'x-tao-option-preset1.3',
                         'x-tao-option-preset2.3',
                         'custom1',
                         'custom3'
@@ -259,6 +268,7 @@ define([
                     expectedSelected = [
                         'x-tao-option-preset1.1',
                         'x-tao-option-preset1.2',
+                        'x-tao-option-preset1.3',
                         'x-tao-option-preset2.3',
                         'custom1',
                         'custom3'
@@ -279,6 +289,7 @@ define([
                 case 4: {
                     expectedSelected = [
                         'x-tao-option-preset1.1',
+                        'x-tao-option-preset1.3',
                         'x-tao-option-preset2.3',
                         'custom1',
                         'custom3'
@@ -299,6 +310,7 @@ define([
                 case 5: {
                     expectedSelected = [
                         'x-tao-option-preset1.1',
+                        'x-tao-option-preset1.3',
                         'x-tao-option-preset2.3',
                         'custom1',
                         'custom3'
@@ -318,6 +330,7 @@ define([
                 case 6: {
                     expectedSelected = [
                         'x-tao-option-preset1.1',
+                        'x-tao-option-preset1.3',
                         'x-tao-option-preset2.3',
                         'custom1',
                         'custom2',


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/AUT-3414

Requires: 
 - [ ] https://github.com/oat-sa/extension-tao-texthelp/pull/70

### Summary

Add support for multiple categories to activate presets in the test authoring.
The concepts is as follows:
- a preset can be activated using any of the declared categories (support for legacy categories)
- when saving the test, only the main declared category of the preset is persisted

The main example for this is the text-to-speech tool which used to be activated using the category `x-tao-option-textToSpeech`. However, TAO Advance expects it to be `x-tao-option-tts`. Both categories will be supported, but only the later will be kept when updating a test.

### How to test
Prerequisite: have the extension taoTextHelp installed with the branch `feature/AUT-3414/align-tts-category`

- create/open a test in Authoring
- activate the test taker tool TextToSpeech
- save the changes
- export the test, then open the archive an check that the category `x-tao-option-textToSpeech` is set appropriately
- check out the branch on both taoQtiTest and taoTextHelp: `git checkout -t origin/feature/AUT-3414/align-tts-category`
- update TAO
- open the same test in Authoring
- check that the taker tool TextToSpeech is still activated
- deactivate the tool, then activate it again
- save the changes
- export the test, then open the archive an check that the category `x-tao-option-tts` is set appropriately