### PR TITLE
Feat/aut 3590/fix form checkbox

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -801,11 +801,15 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
                             // 4. Import metadata for the resource (use same mechanics as item resources).
                             // Metadata will be set as property values.
                             $this->getMetadataImporter()->inject($qtiTestResource->getIdentifier(), $testResource);
-                            $this->getServiceManager()->getContainer()->get(MappedMetadataInjector::class)->inject(
-                                $mappedProperties['testProperties'] ?? [],
-                                $metadataValues[$qtiTestResourceIdentifier],
-                                $testResource
-                            );
+                            //todo: fix taoSetup to be aware of containers. This is only workaround.
+                            if ($this->getServiceManager()->getContainer()->has(MappedMetadataInjector::class)) {
+                                $this->getServiceManager()->getContainer()->get(MappedMetadataInjector::class)->inject(
+                                    $mappedProperties['testProperties'] ?? [],
+                                    $metadataValues[$qtiTestResourceIdentifier],
+                                    $testResource
+                                );
+                            }
+
 
                             // 5. if $targetClass does not contain any instances
                             // (because everything resolved by class lookups),

--- a/models/classes/import/class.TestImportForm.php
+++ b/models/classes/import/class.TestImportForm.php
@@ -125,8 +125,8 @@ class taoQtiTest_models_classes_import_TestImportForm extends tao_helpers_form_F
     {
         if (!$this->isMetadataDisabled()) {
             $metadataImport = tao_helpers_form_FormFactory::getElement(self::METADATA_FORM_ELEMENT_NAME, 'Checkbox');
-            $metadataImport->setOptions([self::METADATA_FORM_ELEMENT_NAME => __('Import metadata or fail')]);
-            $metadataImport->setDescription(__('Metadata import'));
+            $metadataImport->setOptions([self::METADATA_FORM_ELEMENT_NAME => __('QTI metadata as properties')]);
+            $metadataImport->setDescription(__('Import'));
             $metadataImport->setLevel(1);
             $this->form->addElement($metadataImport);
             $this->form->addToGroup('file', self::METADATA_FORM_ELEMENT_NAME);


### PR DESCRIPTION
Fix label for import checkbox on test import form.
taoSetup when importing test will not use container if not exist. This is workaround. 

![Screenshot 2024-05-16 at 10 18 30](https://github.com/oat-sa/extension-tao-testqti/assets/16231681/adc10d98-373d-4c2b-83fa-339b4df53a9a)
