### PR TITLE
fix: Don't fetch the current item for a null test session

### DIFF
--- a/model/Container/TestQtiServiceProvider.php
+++ b/model/Container/TestQtiServiceProvider.php
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021-2023 (original work) Open Assessment Technologies SA;
- *
- * @author Ricardo Quintanilha <ricardo.quintanilha@taotesting.com>
+ * Copyright (c) 2021-2024 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -47,7 +45,9 @@ use oat\taoQtiTest\model\Service\SkipService;
 use oat\taoQtiTest\model\Service\StoreTraceVariablesService;
 use oat\taoQtiTest\model\Service\TimeoutService;
 use oat\taoQtiTest\models\runner\QtiRunnerService;
+use oat\taoQtiTest\models\runner\time\TimerAdjustmentServiceInterface;
 use oat\taoQtiTest\models\TestModelService;
+use oat\taoQtiTest\models\TestSessionService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -172,6 +172,8 @@ class TestQtiServiceProvider implements ContainerServiceProviderInterface
                     service(DeliveryExecutionService::SERVICE_ID),
                     service(FeatureFlagChecker::class),
                     service(StateServiceInterface::SERVICE_ID),
+                    service(TestSessionService::SERVICE_ID),
+                    service(TimerAdjustmentServiceInterface::SERVICE_ID),
                 ]
             );
     }

--- a/test/unit/model/Service/ConcurringSessionServiceTest.php
+++ b/test/unit/model/Service/ConcurringSessionServiceTest.php
@@ -72,9 +72,9 @@ class ConcurringSessionServiceTest extends TestCase
             $this->deliveryExecutionService,
             $this->featureFlagChecker,
             $this->stateService,
-            $this->currentSession,
             $this->testSessionService,
-            $this->timerAdjustmentService
+            $this->timerAdjustmentService,
+            $this->currentSession
         );
     }
 


### PR DESCRIPTION
**Associated Jira issue:** [INF-268](https://oat-sa.atlassian.net/browse/INF-268)

Fixes a race condition that happens when the same test taker launches two executions concurrently, causing the logic to pause the timers for the first one that got processed to try to fetch a test session that may not have been persisted yet.

**Changelog:**
- Don't call `getCurrentAssessmentItemRef()` on `null` when an execution does not have a test session assigned (yet)
  - If there's no test session, there's no current item nor item duration to adjust
- Don't try to `suspend()` the same delivery execution twice

This fixes a customer-reported error, and has already been validated on their side. The error was:

```
/var/www/html/taoQtiTest/model/Service/ConcurringSessionService.php@146:
   Uncaught Error: Call to a member function getCurrentAssessmentItemRef() on null in
     /var/www/html/taoQtiTest/model/Service/ConcurringSessionService.php:146

Stack trace:
#0 /var/www/html/ltiDeliveryProvider/controller/DeliveryTool.php(145):
    oat\taoQtiTest\model\Service\ConcurringSessionService->adjustTimers(
        Object(oat\taoDelivery\model\execution\DeliveryExecution)
    )
#1 [internal function]: oat\ltiDeliveryProvider\controller\DeliveryTool->run() 
...
```

[INF-268]: https://oat-sa.atlassian.net/browse/INF-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ