### PR TITLE
Hotfix: avoid  getCurrentAssessmentAtemRef on null

### DIFF
--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -168,7 +168,7 @@ class ConcurringSessionService
 
         $testSession = $this->getTestSessionService()->getTestSession($execution);
 
-        if ($testSession->getCurrentAssessmentItemRef()) {
+        if ($testSession && $testSession->getCurrentAssessmentItemRef()) {
             $duration = $testSession->getTimerDuration(
                 $testSession->getCurrentAssessmentItemRef()->getIdentifier(),
                 $testSession->getTimerTarget()

--- a/model/Service/ConcurringSessionService.php
+++ b/model/Service/ConcurringSessionService.php
@@ -167,54 +167,55 @@ class ConcurringSessionService
         );
 
         $testSession = $this->getTestSessionService()->getTestSession($execution);
+        if (!$testSession || !$testSession->getCurrentAssessmentItemRef()) {
+            return;
+        }
 
-        if ($testSession && $testSession->getCurrentAssessmentItemRef()) {
-            $duration = $testSession->getTimerDuration(
-                $testSession->getCurrentAssessmentItemRef()->getIdentifier(),
-                $testSession->getTimerTarget()
-            );
+        $duration = $testSession->getTimerDuration(
+            $testSession->getCurrentAssessmentItemRef()->getIdentifier(),
+            $testSession->getTimerTarget()
+        );
+
+        $this->logger->debug(
+            sprintf(
+                'Timer duration on execution %s timer adjustment = %f',
+                $execution->getIdentifier(),
+                $duration->getSeconds(true)
+            )
+        );
+
+        $ids = [
+            $execution->getIdentifier(),
+            $execution->getOriginalIdentifier()
+        ];
+
+        foreach ($ids as $executionId) {
+            $key = "itemDuration-{$executionId}";
+
+            if (!$this->currentSession->hasAttribute($key)) {
+                continue;
+            }
+
+            $oldDuration = $this->currentSession->getAttribute($key);
+            $this->currentSession->removeAttribute($key);
 
             $this->logger->debug(
                 sprintf(
-                    'Timer duration on execution %s timer adjustment = %f',
+                    'Timer duration on execution %s pause was %f',
                     $execution->getIdentifier(),
-                    $duration->getSeconds(true)
+                    $oldDuration
                 )
             );
 
-            $ids = [
-                $execution->getIdentifier(),
-                $execution->getOriginalIdentifier()
-            ];
+            $delta = (int) ceil($duration->getSeconds(true) - $oldDuration);
 
-            foreach ($ids as $executionId) {
-                $key = "itemDuration-{$executionId}";
+            if ($delta > 0) {
+                $this->logger->debug(sprintf('Adjusting timers by %d s', $delta));
 
-                if (!$this->currentSession->hasAttribute($key)) {
-                    continue;
-                }
+                $this->getTimerAdjustmentService()->increase($testSession, $delta);
 
-                $oldDuration = $this->currentSession->getAttribute($key);
-                $this->currentSession->removeAttribute($key);
-
-                $this->logger->debug(
-                    sprintf(
-                        'Timer duration on execution %s pause was %f',
-                        $execution->getIdentifier(),
-                        $oldDuration
-                    )
-                );
-
-                $delta = (int) ceil($duration->getSeconds(true) - $oldDuration);
-
-                if ($delta > 0) {
-                    $this->logger->debug(sprintf('Adjusting timers by %d s', $delta));
-
-                    $this->getTimerAdjustmentService()->increase($testSession, $delta);
-
-                    $testSession->suspend();
-                    $this->getTestSessionService()->persist($testSession);
-                }
+                $testSession->suspend();
+                $this->getTestSessionService()->persist($testSession);
             }
         }
     }

--- a/test/unit/model/Service/ConcurringSessionServiceTest.php
+++ b/test/unit/model/Service/ConcurringSessionServiceTest.php
@@ -422,4 +422,28 @@ class ConcurringSessionServiceTest extends TestCase
 
         $this->subject->pauseActiveDeliveryExecutionsForUser($execution);
     }
+
+    public function testAdjustTimersSkipsAdjustmentIfNoTestSessionExists(): void
+    {
+        $execution = $this->createMock(DeliveryExecution::class);
+        $execution
+            ->method('getIdentifier')
+            ->willReturn('https://example.com/execution/1');
+
+        $this->testSessionService
+            ->expects($this->once())
+            ->method('getTestSession')
+            ->with($execution)
+            ->willReturn(null);
+
+        $this->currentSession
+            ->expects($this->never())
+            ->method('removeAttribute');
+
+        $this->testSessionService
+            ->expects($this->never())
+            ->method('persist');
+
+        $this->subject->adjustTimers($execution);
+    }
 }


### PR DESCRIPTION
This PR aims to add a fix similar with https://github.com/oat-sa/extension-tao-testqti/pull/2469/files#diff-be1605fd62af343d118c742ba9c27603c98978aeff03b929a54110c9ba97cda6R177