### PR TITLE
chore: update guzzle client with new feature version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,11 +60,11 @@
   "require": {
     "ext-dom": "*",
     "ext-zip": "*",
-    "oat-sa/lib-test-cat": "2.3.7",
+    "oat-sa/lib-test-cat": "dev-feat/FUN-1740/update-guzzle-client as 99.99.99",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "qtism/qtism": ">=0.28.3",
     "oat-sa/generis": ">=15.36.4",
-    "oat-sa/tao-core": ">=54.14.7",
+    "oat-sa/tao-core": "dev-feat/FUN-1740/update-guzzle-client as 99.99.99",
     "oat-sa/extension-tao-item" : ">=12.1.0",
     "oat-sa/extension-tao-itemqti" : ">=30.12.0",
     "oat-sa/extension-tao-test" : ">=16.0.0",

--- a/composer.json
+++ b/composer.json
@@ -60,11 +60,11 @@
   "require": {
     "ext-dom": "*",
     "ext-zip": "*",
-    "oat-sa/lib-test-cat": "dev-feat/FUN-1740/update-guzzle-client as 99.99.99",
+    "oat-sa/lib-test-cat": "2.4.0",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "qtism/qtism": ">=0.28.3",
     "oat-sa/generis": ">=15.36.4",
-    "oat-sa/tao-core": "dev-feat/FUN-1740/update-guzzle-client as 99.99.99",
+    "oat-sa/tao-core": ">=54.21.0",
     "oat-sa/extension-tao-item" : ">=12.1.0",
     "oat-sa/extension-tao-itemqti" : ">=30.12.0",
     "oat-sa/extension-tao-test" : ">=16.0.0",

--- a/manifest.php
+++ b/manifest.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2


### PR DESCRIPTION
Update Guzzle with the 7.x

For updating Elastic Lib with the version which is support elastic search 8 we need to update guzzle as it requires in the latest version of the Elastic Lib

Depends on https://github.com/oat-sa/lib-test-cat/pull/46