### PR TITLE
Feature/ADF-1695/Show multiple preview buttons

### DIFF
--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -142,12 +142,14 @@ define([
                 const translate = text => text && __(text);
 
                 const btnIdx = previewId ? `-${previewId}` : '';
-                const $button = $(templates.menuButton({
-                    id: `previewer${btnIdx}`,
-                    testId: `preview-test${btnIdx}`,
-                    icon: 'preview',
-                    label: translate(label) || __('Preview'),
-                })).on('click', e => {
+                const $button = $(
+                    templates.menuButton({
+                        id: `previewer${btnIdx}`,
+                        testId: `preview-test${btnIdx}`,
+                        icon: 'preview',
+                        label: translate(label) || __('Preview')
+                    })
+                ).on('click', e => {
                     e.preventDefault();
                     if (!$(e.currentTarget).hasClass('disabled')) {
                         creatorContext.trigger('preview', id, previewId);
@@ -156,12 +158,13 @@ define([
                 if (!Object.keys(options.labels).length) {
                     $button.attr('disabled', true).addClass('disabled');
                 }
-                $menu.append($button)
+                $menu.append($button);
                 previewId++;
                 return $button;
-            }
-            const previewButtons = options.providers ? options.providers.map(createPreviewButton) : [createPreviewButton()];
-
+            };
+            const previewButtons = options.providers
+                ? options.providers.map(createPreviewButton)
+                : [createPreviewButton()];
 
             const isTestContainsItems = () => {
                 if ($container.find('.test-content').find('.itemref').length) {
@@ -287,7 +290,9 @@ define([
                 if (creatorContext.isTestHasErrors()) {
                     event.preventDefault();
                     feedback().warning(
-                        __('The test cannot be saved because it currently contains invalid settings.\nPlease fix the invalid settings and try again.')
+                        __(
+                            'The test cannot be saved because it currently contains invalid settings.\nPlease fix the invalid settings and try again.'
+                        )
                     );
                 } else {
                     creatorContext.trigger('save');

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -138,12 +138,15 @@ define([
             //preview button
             let previewId = 0;
             const createPreviewButton = ({ id, label } = {}) => {
+                // configured labels will need to to be registered elsewhere for the translations
+                const translate = text => text && __(text);
+
                 const btnIdx = previewId ? `-${previewId}` : '';
                 const $button = $(templates.menuButton({
                     id: `previewer${btnIdx}`,
                     testId: `preview-test${btnIdx}`,
                     icon: 'preview',
-                    label: label || __('Preview'),
+                    label: translate(label) || __('Preview'),
                 })).on('click', e => {
                     e.preventDefault();
                     if (!$(e.currentTarget).hasClass('disabled')) {

--- a/views/js/controller/creator/templates/index.js
+++ b/views/js/controller/creator/templates/index.js
@@ -33,7 +33,8 @@ define([
     'tpl!taoQtiTest/controller/creator/templates/itemref-props-weight',
     'tpl!taoQtiTest/controller/creator/templates/rubricblock-props',
     'tpl!taoQtiTest/controller/creator/templates/category-presets',
-    'tpl!taoQtiTest/controller/creator/templates/subsection'
+    'tpl!taoQtiTest/controller/creator/templates/subsection',
+    'tpl!taoQtiTest/controller/creator/templates/menu-button'
 ],
 function(
     defaults,
@@ -49,7 +50,8 @@ function(
     itemRefPropsWeight,
     rubricBlockProps,
     categoryPresets,
-    subsection
+    subsection,
+    menuButton
 ){
     'use strict';
 
@@ -66,6 +68,7 @@ function(
         rubricblock : applyTemplateConfiguration(rubricBlock),
         outcomes    : applyTemplateConfiguration(outcomes),
         subsection  : applyTemplateConfiguration(subsection),
+        menuButton  : applyTemplateConfiguration(menuButton),
         properties  : {
             test            : applyTemplateConfiguration(testProps),
             testpart        : applyTemplateConfiguration(testPartProps),

--- a/views/js/controller/creator/templates/menu-button.tpl
+++ b/views/js/controller/creator/templates/menu-button.tpl
@@ -1,0 +1,6 @@
+<li id="{{id}}" class="btn-info small" data-testid="{{testId}}">
+    <span class="li-inner">
+        <span class="icon-{{icon}}"></span>
+        {{label}}
+    </span>
+</li>

--- a/views/templates/creator.tpl
+++ b/views/templates/creator.tpl
@@ -19,17 +19,11 @@
 <!-- test editor  -->
     <section class="test-creator-test test-creator-area test-creator-content">
         <div class="action-bar plain content-action-bar horizontal-action-bar">
-            <ul class="action-group plain clearfix authoring-back-box item-editor-menu">
+            <ul class="test-editor-menu action-group plain clearfix authoring-back-box item-editor-menu">
                 <li id="saver" class="btn-info small" data-testid="save-test">
                     <span class="li-inner">
                         <span class="icon-save"></span>
                         <?=__('Save')?>
-                    </span>
-                </li>
-                <li id="previewer" class="btn-info small" data-testid="preview-test">
-                    <span class="li-inner">
-                        <span class="icon-preview"></span>
-                        <?=__('Preview')?>
                     </span>
                 </li>
             </ul>


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1695

Requires: 
 - [x] https://github.com/oat-sa/extension-tao-test/pull/474

### Summary

Add the possibility of having more than one test previewer.

### Details

It supports multiple preview buttons from the test's property page.

This is made thanks to a configuration applied in `config/tao/client_lib_config_registry.conf.php`, and a change applied to the `structures.xml` file.

- **structures.xml**
Each button must be declared with an identifier starting with `test-preview`. The first button must be `test-preview`, the second `test-preview-1`, etc. The suffix number refers to a position in the configuration (see `client_lib_config_registry.conf.php`).
Example:
```xml
    <structure id="tests" name="Tests" level="1" group="main">
        <sections>
            <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
                <actions allowClassActions="true">
                    <action id="test-preview" name="Preview" url="/taoTests/Tests/index" context="instance" group="content" binding="testPreview">
                        <icon id="icon-preview"/>
                    </action>
                    <action id="test-preview-1" name="Preview (legacy)" url="/taoTests/Tests/index" context="instance" group="content" binding="testPreview">
                        <icon id="icon-preview"/>
                    </action>
                </actions>
            </section>
        </sections>
    </structure>
```

- **client_lib_config_registry.conf.php**
The configuration can be extended with a list of possible providers, aside from the default one. This is done in `config/tao/client_lib_config_registry.conf.php`.
Example:
```php
        'taoTests/controller/tests/action' => array(
            'provider' => 'qtiTestNUI',
            'providers' => array(
                array(
                    'id' => 'qtiTestNUI',
                    'label' => 'Preview'
                ),
                array(
                    'id' => 'qtiTest',
                    'label' => 'Preview (legacy)'
                )
            )
        ),
```

### How to test

- checkout the branch: `git checkout -t origin/feature/ADF-1695/multiple-preview-buttons`
- also checkout the branches from the companion PR
- make sure to have set the appropriate configuration (check the details in the ticket)