### PR TITLE
chore: remove unnecessary parameter

### DIFF
--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -136,9 +136,19 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
         }
     }
 
-    protected function getItemClassUri(): ?string
+    /**
+     * @throws common_exception_RestApi
+     */
+    protected function getItemClassUri(): string
     {
-        return $this->getPostParameter(self::ITEM_CLASS_URI);
+        $itemClassUri = $this->getPostParameter(self::ITEM_CLASS_URI, TaoOntology::CLASS_URI_ITEM);
+        $itemClass = $this->getClass($itemClassUri);
+
+        if (!$itemClass->exists()) {
+            throw new common_exception_RestApi('Class does not exist. Please use valid ' . self::ITEM_CLASS_URI);
+        }
+
+        return $itemClassUri;
     }
 
     /**
@@ -153,7 +163,7 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
         }
 
         if (!in_array($isOverwriteTest, ['true', 'false'])) {
-            throw new \common_exception_RestApi(
+            throw new common_exception_RestApi(
                 'isOverwriteTest parameter should be boolean (true or false).'
             );
         }

--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -138,18 +138,7 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
 
     protected function getItemClassUri(): ?string
     {
-        $itemClassUri = $this->getPostParameter(self::ITEM_CLASS_URI);
-        $subclassLabel = $this->getSubclassLabel();
-
-        if ($subclassLabel) {
-            foreach ($this->getClass($itemClassUri)->getSubClasses() as $subclass) {
-                if ($subclass->getLabel() === $subclassLabel) {
-                    $itemClassUri = $subclass->getUri();
-                }
-            }
-        }
-
-        return $itemClassUri;
+        return $this->getPostParameter(self::ITEM_CLASS_URI);
     }
 
     /**
@@ -325,23 +314,6 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
      * @return string|null
      * @throws common_exception_RestApi
      */
-    private function getSubclassLabel(): ?string
-    {
-        $subclassLabel = $this->getPostParameter(self::SUBCLASS_LABEL);
-
-        if ($subclassLabel !== null && !is_string($subclassLabel)) {
-            throw new common_exception_RestApi(
-                sprintf('%s parameter should be string', self::SUBCLASS_LABEL)
-            );
-        }
-
-        return $subclassLabel;
-    }
-
-    /**
-     * @return string|null
-     * @throws common_exception_RestApi
-     */
     private function getOverwriteTestUri(): ?string
     {
         $overwriteTestUri = $this->getPostParameter(self::OVERWRITE_TEST_URI);
@@ -379,18 +351,7 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
      */
     private function getTestClass(): core_kernel_classes_Class
     {
-        $testClass = $this->getClassFromRequest(new core_kernel_classes_Class(TaoOntology::CLASS_URI_TEST));
-        $subclassLabel = $this->getSubclassLabel();
-
-        if ($subclassLabel) {
-            foreach ($testClass->getSubClasses() as $subClass) {
-                if ($subClass->getLabel() === $subclassLabel) {
-                    $testClass = $subClass;
-                }
-            }
-        }
-
-        return $testClass;
+        return $this->getClassFromRequest(new core_kernel_classes_Class(TaoOntology::CLASS_URI_TEST));
     }
 
     /**

--- a/actions/class.RestQtiTests.php
+++ b/actions/class.RestQtiTests.php
@@ -46,7 +46,6 @@ class taoQtiTest_actions_RestQtiTests extends AbstractRestQti
      */
     private const OVERWRITE_TEST = 'overwriteTest';
 
-    private const SUBCLASS_LABEL = 'subclassLabel';
     private const OVERWRITE_TEST_URI = 'overwriteTestUri';
     private const PACKAGE_LABEL = 'packageLabel';
 

--- a/models/classes/tasks/ImportQtiTest.php
+++ b/models/classes/tasks/ImportQtiTest.php
@@ -94,7 +94,7 @@ class ImportQtiTest extends AbstractTaskAction implements \JsonSerializable
             $params[self::PARAM_ITEM_MUST_EXIST] ?? false,
             $params[self::PARAM_ITEM_MUST_BE_OVERWRITTEN] ?? false,
             $params[self::PARAM_OVERWRITE_TEST] ?? false,
-            $params[self::PARAM_ITEM_CLASS_URI] ?? false,
+            $params[self::PARAM_ITEM_CLASS_URI] ?? null,
             $params[self::PARAM_OVERWRITE_TEST_URI] ?? null,
             $params[self::PARAM_PACKAGE_LABEL] ?? null,
         );


### PR DESCRIPTION
# [ADF-1765](https://oat-sa.atlassian.net/browse/ADF-1765)

## Changes
* `subclassLabel` POST parameter removed from the code. Now we will provide direct URIs to test/item classes

[ADF-1765]: https://oat-sa.atlassian.net/browse/ADF-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ