### PR TITLE
feature: AUT-3528 add preset for x-tao-printable

### DIFF
--- a/models/classes/QtiCategoryPresetProvider.php
+++ b/models/classes/QtiCategoryPresetProvider.php
@@ -218,7 +218,7 @@ class QtiCategoryPresetProvider implements TestCategoryPresetProviderInterface
                 ]),
                 TestCategoryPreset::fromArray([
                     'id'            => 'printable',
-                    'label'         => __('Print out'),
+                    'label'         => __('Print Out'),
                     'qtiCategory'   => 'x-tao-printable',
                     'description'   => __('Allow a Test Taker to print out the item.'),
                     'order'         => 700,

--- a/models/classes/QtiCategoryPresetProvider.php
+++ b/models/classes/QtiCategoryPresetProvider.php
@@ -222,7 +222,6 @@ class QtiCategoryPresetProvider implements TestCategoryPresetProviderInterface
                     'qtiCategory'   => 'x-tao-printable',
                     'description'   => __('Allow a Test Taker to print out the item.'),
                     'order'         => 700,
-                    'pluginId'      => 'printable'
                 ]),
                 TestCategoryPreset::fromArray([
                     'id'            => 'apiptts',

--- a/models/classes/QtiCategoryPresetProvider.php
+++ b/models/classes/QtiCategoryPresetProvider.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoQtiTest\models;
@@ -215,6 +215,14 @@ class QtiCategoryPresetProvider implements TestCategoryPresetProviderInterface
                     'description'   => __('Allows Test-taker to zoom in and out the item content.'),
                     'order'         => 700,
                     'pluginId'      => 'zoom'
+                ]),
+                TestCategoryPreset::fromArray([
+                    'id'            => 'printable',
+                    'label'         => __('Print out'),
+                    'qtiCategory'   => 'x-tao-printable',
+                    'description'   => __('Allow a Test Taker to print out the item.'),
+                    'order'         => 700,
+                    'pluginId'      => 'printable'
                 ]),
                 TestCategoryPreset::fromArray([
                     'id'            => 'apiptts',


### PR DESCRIPTION
[AUT-3528](https://oat-sa.atlassian.net/browse/AUT-3528)
Added a preset for `x-tao-pritnable` option.[

Feature Flag control PR](https://github.com/oat-sa/extension-tao-deliver-connect/pull/241)

[AUT-3528]: https://oat-sa.atlassian.net/browse/AUT-3528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ