### PR TITLE
Prevent Metadata exporter gather list from property without range

### DIFF
--- a/models/classes/metadata/metaMetadata/PropertyMapper.php
+++ b/models/classes/metadata/metaMetadata/PropertyMapper.php
@@ -64,7 +64,7 @@ class PropertyMapper
 
     private function isIgnoredForCollectionGathering(Property $property): bool
     {
-        return in_array($property->getUri(), $this->getIgnoredProperties());
+        return in_array($property->getUri(), $this->getIgnoredProperties()) || $property->getRange() === null;
     }
 
     private function getIgnoredProperties(): array

--- a/test/unit/models/classes/metadata/metaMetadata/PropertyMapperTest.php
+++ b/test/unit/models/classes/metadata/metaMetadata/PropertyMapperTest.php
@@ -50,6 +50,7 @@ class PropertyMapperTest extends TestCase
         $property = $this->createMock(Property::class);
         $resourceMock = $this->createMock(Resource::class);
         $property->method('getUri')->willReturn('uri');
+        $property->method('getRange')->willReturn('range');
         $resourceMock->method('getUri')->willReturn('resource_uri');
 
         $property


### PR DESCRIPTION
This change will prevent from exporting item properties that has no range defined