### PR TITLE
Backport fix import QTI Package without metadata

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2024 (original work) Open Assessment Technologies SA;
  */
 
 use League\Flysystem\FileExistsException;
@@ -497,7 +497,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
             // 2. Restore overwritten item contents.
             foreach ($data->overwrittenItems as $overwrittenItemId => $backupName) {
-                common_Logger::d("Restoring content for item '${overwrittenItemId}'...");
+                common_Logger::d("Restoring content for item '{$overwrittenItemId}'...");
                 @Service::singleton()->restoreContentByRdfItem(
                     new core_kernel_classes_Resource($overwrittenItemId),
                     $backupName
@@ -776,7 +776,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
                     // If items did not produce errors, we import the test definition.
                     if ($itemError === false) {
-                        common_Logger::i("Importing test with manifest identifier '${qtiTestResourceIdentifier}'...");
+                        common_Logger::i("Importing test with manifest identifier '{$qtiTestResourceIdentifier}'...");
 
                         // Second step is to take care of the test definition and the related media (auxiliary files).
 
@@ -805,7 +805,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
                             if ($this->getServiceManager()->getContainer()->has(MappedMetadataInjector::class)) {
                                 $this->getServiceManager()->getContainer()->get(MappedMetadataInjector::class)->inject(
                                     $mappedProperties['testProperties'] ?? [],
-                                    $metadataValues[$qtiTestResourceIdentifier],
+                                    $metadataValues[$qtiTestResourceIdentifier] ?? [],
                                     $testResource
                                 );
                             }
@@ -1447,7 +1447,6 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
     private function getMetaMetadataExtractor(): MetaMetadataExtractor
     {
         return $this->getPsrContainer()->get(MetaMetadataExtractor::class);
-        return $this->getServiceManager()->getContainer()->get(MetaMetadataExtractor::class);
     }
 
     private function getSecureResourceService(): SecureResourceServiceInterface


### PR DESCRIPTION
This will fix importing QTI Packages without metadata