### PR TITLE
Feature/ADF-1789/Forward the translation parameters

### DIFF
--- a/actions/class.Creator.php
+++ b/actions/class.Creator.php
@@ -1,22 +1,22 @@
 <?php
 
 /**
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public License
-* as published by the Free Software Foundation; under version 2
-* of the License (non-upgradable).
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*
-* Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
-*/
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
 
 use oat\taoQtiTest\models\TestCategoryPresetProvider;
 use oat\taoQtiTest\models\TestModelService;
@@ -44,6 +44,10 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule
         $labels = [];
         $testUri   =  $this->getRequestParameter('uri');
         $testModel = $this->getServiceManager()->get(TestModelService::SERVICE_ID);
+
+        // Add support for translation and side-by-side view
+        $this->setData('translation', $this->getRequestParameter('translation') ?? "false");
+        $this->setData('originResourceUri', json_encode($this->getRequestParameter('originResourceUri')));
 
         $items = $testModel->getItems(new core_kernel_classes_Resource(tao_helpers_Uri::decode($testUri)));
         foreach ($items as $item) {
@@ -91,9 +95,9 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule
         $this->setView('creator.tpl');
     }
 
-        /**
-         * Get json's test content, the uri of the test must be provided in parameter
-         */
+    /**
+     * Get json's test content, the uri of the test must be provided in parameter
+     */
     public function getTest()
     {
         $test = $this->getCurrentTest();
@@ -104,11 +108,11 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule
         $this->response = $this->getPsrResponse()->withBody(stream_for($qtiTestService->getJsonTest($test)));
     }
 
-        /**
-         * Save a test, test uri and
-         * The request must use the POST method and contains
-         * the test uri and a json string that represents the QTI Test in the model parameter.
-         */
+    /**
+     * Save a test, test uri and
+     * The request must use the POST method and contains
+     * the test uri and a json string that represents the QTI Test in the model parameter.
+     */
     public function saveTest()
     {
         $saved = false;

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -126,6 +126,7 @@ define([
             options.labels = options.labels || {};
             options.categoriesPresets = featureVisibility.filterVisiblePresets(options.categoriesPresets) || {};
             options.guidedNavigation = options.guidedNavigation === true;
+            options.translation = options.translation === true;
 
             categorySelector.setPresets(options.categoriesPresets);
 
@@ -219,6 +220,8 @@ define([
             binder = DataBindController.takeControl($container, binderOptions).get(model => {
                 creatorContext = qtiTestCreatorFactory($container, {
                     uri: options.uri,
+                    translation: options.translation,
+                    originResourceUri: options.originResourceUri,
                     labels: options.labels,
                     routes: options.routes,
                     guidedNavigation: options.guidedNavigation

--- a/views/templates/creator.tpl
+++ b/views/templates/creator.tpl
@@ -76,6 +76,8 @@ requirejs.config({
                 blueprintByTestSection : '<?=get_data('blueprintsByTestSectionUrl')?>',
                 identifier : '<?=get_data('identifierUrl')?>'
             },
+            translation : <?=get_data('translation')?>,
+            originResourceUri : <?=get_data('originResourceUri')?>,
             categoriesPresets : <?=get_data('categoriesPresets')?>,
             labels : <?=get_data('labels')?>,
             guidedNavigation : <?=get_data('guidedNavigation')?>


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1789

### Summary

Forward the translation parameters to the authoring.

### Details

This is a technical change only. It adds support for the translation mode, forwarding:
- `translation`: `bool` - A flag telling if we are translating a test. Can be `null`.
- `originResourceUri`: `string` - The URI of the original test being translated. Can be `null`.

From the client app, the data is available at the root of the received config from the controller.