### PR TITLE
feat: render two preview buttons for translated tests

### DIFF
--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -136,9 +136,8 @@ define([
                 creatorContext.trigger('creatorclose');
             });
 
-            //preview button
             let previewId = 0;
-            const createPreviewButton = ({ id, label } = {}) => {
+            const createPreviewButton = ({ id, label, uri = '' } = {}) => {
                 // configured labels will need to to be registered elsewhere for the translations
                 const translate = text => text && __(text);
 
@@ -153,7 +152,7 @@ define([
                 ).on('click', e => {
                     e.preventDefault();
                     if (!$(e.currentTarget).hasClass('disabled')) {
-                        creatorContext.trigger('preview', id, previewId);
+                        creatorContext.trigger('preview', id, uri);
                     }
                 });
                 if (!Object.keys(options.labels).length) {
@@ -163,9 +162,19 @@ define([
                 previewId++;
                 return $button;
             };
-            const previewButtons = options.providers
-                ? options.providers.map(createPreviewButton)
-                : [createPreviewButton()];
+
+            let previewButtons;
+            
+            if(options.translation) {
+                previewButtons = [
+                    createPreviewButton({label: 'Preview original', uri: options.originResourceUri }), 
+                    createPreviewButton({label: 'Preview translation' })
+                ];
+            }else{
+                previewButtons = options.providers
+                    ? options.providers.map(createPreviewButton)
+                    : [createPreviewButton()];
+            }
 
             const isTestContainsItems = () => {
                 if ($container.find('.test-content').find('.itemref').length) {
@@ -263,10 +272,10 @@ define([
                     }
                 });
 
-                creatorContext.on('preview', provider => {
+                creatorContext.on('preview', (provider, uri) => {
                     if (isTestContainsItems() && !creatorContext.isTestHasErrors()) {
                         const saveUrl = options.routes.save;
-                        const testUri = saveUrl.slice(saveUrl.indexOf('uri=') + 4);
+                        const testUri = uri || saveUrl.slice(saveUrl.indexOf('uri=') + 4);
                         const config = module.config();
                         const type = provider || config.provider || 'qtiTest';
                         return previewerFactory(type, decodeURIComponent(testUri), {

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -164,13 +164,13 @@ define([
             };
 
             let previewButtons;
-            
-            if(options.translation) {
+
+            if (options.translation) {
                 previewButtons = [
-                    createPreviewButton({label: 'Preview original', uri: options.originResourceUri }), 
-                    createPreviewButton({label: 'Preview translation' })
+                    createPreviewButton({ label: 'Preview original', uri: options.originResourceUri }),
+                    createPreviewButton({ label: 'Preview translation' })
                 ];
-            }else{
+            } else {
                 previewButtons = options.providers
                     ? options.providers.map(createPreviewButton)
                     : [createPreviewButton()];


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/ADF-1790

### Description

When editing translation of the test render two preview buttons to allow launch preview or original or translated test

### How to test

Enter translation of the test, try to preview original or translated test