### PR TITLE
Feature/ADF-1789/Sync items translations

### DIFF
--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -242,28 +242,31 @@ define([
                 Promise.resolve()
                     .then(() => {
                         if (options.translation) {
-                            return Promise.all([
-                                translationHelper
-                                    .updateModelFromOrigin(model, options.routes.getOrigin)
-                                    .then(originModel => (options.originModel = originModel)),
-                                translationHelper
-                                    .getTranslationConfig(options.testUri, options.originResourceUri)
-                                    .then(translationConfig => Object.assign(options, translationConfig))
-                            ])
-                                .then(() =>
-                                    translationHelper.getItemsTranslationStatus(
-                                        options.originModel,
-                                        options.translationLanguageUri
+                            return translationService.syncTranslation(options.originResourceUri).then(() => {
+                                feedback().success(__('The translation has been synchronized with the original test.'));
+                                Promise.all([
+                                    translationHelper
+                                        .updateModelFromOrigin(model, options.routes.getOrigin)
+                                        .then(originModel => (options.originModel = originModel)),
+                                    translationHelper
+                                        .getTranslationConfig(options.testUri, options.originResourceUri)
+                                        .then(translationConfig => Object.assign(options, translationConfig))
+                                ])
+                                    .then(() =>
+                                        translationHelper.getItemsTranslationStatus(
+                                            options.originModel,
+                                            options.translationLanguageUri
+                                        )
                                     )
-                                )
-                                .then(itemsStatus => {
-                                    testModelHelper.eachItemInTest(model, itemRef => {
-                                        const itemRefUri = itemRef.href;
-                                        if (itemsStatus[itemRefUri]) {
-                                            itemRef.translationStatus = itemsStatus[itemRefUri];
-                                        }
+                                    .then(itemsStatus => {
+                                        testModelHelper.eachItemInTest(model, itemRef => {
+                                            const itemRefUri = itemRef.href;
+                                            if (itemsStatus[itemRefUri]) {
+                                                itemRef.translationStatus = itemsStatus[itemRefUri];
+                                            }
+                                        });
                                     });
-                                });
+                            });
                         }
                     })
                     .catch(err => {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1789

Requires: 
 - [x] https://github.com/oat-sa/tao-core/pull/4122

### Summary

Synchronize the translation with the original upon opening a test for authoring

### Details

When opening a translation in the authoring, a first query is made to synchronize it with the original. A feedback message is briefly shown.

### How to test

- check out the branch: `git checkout -t origin/feature/ADF-1789/sync-items-translations`
- make sure to have the companion branch checked out and up to date too on the other extensions: `feat/HKD-6/integration`
- make sure to have the Feature Flags activated
```
FEATURE_FLAG_TRANSLATION_ENABLED=true
FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER=true
```
- make sure to have the Item Translator role assigned to your user
- open a test translation: a feedback message is briefly shown. In the console, a `sync` request is sent to the translation API


