### PR TITLE
fix: handle import of props without metadata

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -1535,8 +1535,19 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         if ($importMetadata === true) {
             $metaMetadataValues = $this->getMetaMetadataExtractor()->extract($domManifest);
             $reportCtx->metaMetadata = $metaMetadataValues;
-            return $this->getMetaMetadataImporter()
+
+            $mappedMetadataValues = $this->getMetaMetadataImporter()
                 ->mapMetaMetadataToProperties($metaMetadataValues, $targetItemClass, $testClass);
+
+            if (empty($mappedMetadataValues)) {
+                $metadataValues = $this->getMetadataImporter()->extract($domManifest);
+                $mappedMetadataValues = $this->getMetaMetadataImporter()->mapMetadataToProperties(
+                    $metadataValues,
+                    $targetItemClass,
+                    $testClass
+                );
+            }
+            return $mappedMetadataValues;
         }
 
         return [];


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3992
## What's Changed

- Handle import of props without metadata

## Dependencies PRs

- 


## How to test
- Have a import package without metadata section
- Import it 
## Video

https://github.com/user-attachments/assets/0d60bac0-a5ee-4c9d-a45e-a18ca0934b01

