### PR TITLE
chore: fix performance downgrade by reverting code to previous

### DIFF
--- a/models/classes/runner/QtiRunnerServiceContext.php
+++ b/models/classes/runner/QtiRunnerServiceContext.php
@@ -47,9 +47,7 @@ use oat\taoQtiTest\models\cat\CatService;
 use oat\taoQtiTest\models\ExtendedStateService;
 use oat\taoQtiTest\models\SectionPauseService;
 use oat\taoQtiTest\models\event\SelectAdaptiveNextItemEvent;
-use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
 use qtism\data\AssessmentTest;
 use qtism\data\AssessmentItemRef;
 use qtism\data\ExtendedAssessmentItemRef;
@@ -1167,29 +1165,18 @@ class QtiRunnerServiceContext extends RunnerServiceContext
     }
 
     /**
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
+     * @throws ServiceNotFoundException
      */
     private function getSectionPauseService(): SectionPauseService
     {
-        return $this->getPsrContainer()->get(SectionPauseService::SERVICE_ID);
+        return $this->getServiceManager()->get(SectionPauseService::SERVICE_ID);
     }
 
     /**
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
+     * @throws ServiceNotFoundException
      */
     private function getCatService(): CatService
     {
-        return $this->getPsrContainer()->get(CatService::SERVICE_ID);
-    }
-
-    private function getPsrContainer(): ContainerInterface
-    {
-        if (!$this->container instanceof ContainerInterface) {
-            $this->container = $this->getServiceManager()->getContainer();
-        }
-
-        return $this->container;
+        return $this->getServiceManager()->get(CatService::SERVICE_ID);
     }
 }


### PR DESCRIPTION
ticket: https://oat-sa.atlassian.net/browse/LSI-5144

this PR aims to revert the code introduced in #2383 which causes performance drop.

Unfortunately, this fix cannot be directly tested in terms of situation where performance drop has happened. In situations different from benchmark or real campaign, meaning without quite heavy load, - it would just work not causing and not solving anything.

Grafana access would be shared via Keeper.

Grafana board with the benchmark attempt using the less-performant code: [link](https://lsigrafana.unit.taocloud.org/d/BNjw96hVz/invalsi?from=2024-12-26T13:17:30Z&to=2024-12-26T13:34:30Z&timezone=browser&var-InfluxBD=ee7ddt3lz7rwgb&var-CW=ce30ip75vottsb&var-application=delivery&var-customer_name=&var-cluster=frdep05tpb&var-node_type=&var-node=i-07d465da255961865&var-transaction=). As it may fail because of the time zones, the time range is 2024-12-26 14:17:30 CET to 2024-12-26 14:34:30. Benchmarking attempt was cancelled, when CPU usage went over 90%.

Grafana board with the benchmark attempt, reverting the less-performant code: [link](https://lsigrafana.unit.taocloud.org/d/BNjw96hVz/invalsi?from=2024-12-27T10:56:30Z&to=2024-12-27T11:38:30Z&timezone=browser&var-InfluxBD=ee7ddt3lz7rwgb&var-CW=ce30ip75vottsb&var-application=delivery&var-customer_name=&var-cluster=frdep05tpb&var-node_type=&var-node=i-07d465da255961865&var-transaction=). As it may fail because of the time zones, the time range is 2024-12-27 11:56:30 CET to 2024-12-27 12:38:30. Benchmarking attempt was finished not going higher than 66% CPU.