### PR TITLE
Integration/rfe 1520/export import qti3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     "oat-sa/generis": ">=16.0.0",
     "oat-sa/tao-core": ">=54.27.0",
     "oat-sa/extension-tao-item": ">=12.4.0",
-    "oat-sa/extension-tao-itemqti": ">=30.23.0",
+    "oat-sa/extension-tao-itemqti": ">=30.26.0",
     "oat-sa/extension-tao-test": ">=16.4.3",
     "oat-sa/extension-tao-delivery": ">=15.0.0",
     "oat-sa/extension-tao-outcome": ">=13.0.0",

--- a/config/default/TestModel.conf.php
+++ b/config/default/TestModel.conf.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2016-2024 (original work) Open Assessment Technologies SA;
  */
 
 use oat\taoQtiTest\models\compilation\CompilationService;
@@ -26,6 +26,7 @@ return new TestModelService([
         new oat\taoQtiTest\models\export\Formats\Metadata\TestPackageExport(),
         new oat\taoQtiTest\models\export\Formats\Package2p1\TestPackageExport(),
         new oat\taoQtiTest\models\export\Formats\Package2p2\TestPackageExport(),
+        new oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport(),
     ],
     'importHandlers' => [
         new taoQtiTest_models_classes_import_TestImport()

--- a/migrations/Version202501141150192260_taoQtiTest.php
+++ b/migrations/Version202501141150192260_taoQtiTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiTest\models\TestModelService;
+use oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202501141150192260_taoQtiTest extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add QTI 3.0 Package Export handler to TestModel service configuration';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $testModelService = $this->getServiceLocator()->get(TestModelService::SERVICE_ID);
+
+        if (!$testModelService->hasOption('exportHandlers')) {
+            return;
+        }
+
+        $handlers = $testModelService->getOption('exportHandlers');
+
+        $hasHandler = false;
+        foreach ($handlers as $handler) {
+            if ($handler instanceof TestPackageExport) {
+                $hasHandler = true;
+                break;
+            }
+        }
+
+        if (!$hasHandler) {
+            $handlers[] = new TestPackageExport();
+            $testModelService->setOption('exportHandlers', $handlers);
+            $this->getServiceLocator()->register(TestModelService::SERVICE_ID, $testModelService);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $testModelService = $this->getServiceLocator()->get(TestModelService::SERVICE_ID);
+
+        if (!$testModelService->hasOption('exportHandlers')) {
+            return;
+        }
+
+        $handlers = $testModelService->getOption('exportHandlers');
+
+        $filteredHandlers = array_filter($handlers, function($handler) {
+            return !($handler instanceof TestPackageExport);
+        });
+
+        $testModelService->setOption('exportHandlers', $filteredHandlers);
+        $this->getServiceLocator()->register(TestModelService::SERVICE_ID, $testModelService);
+    }
+}

--- a/models/classes/Qti/Converter/AssessmentSectionConverter.php
+++ b/models/classes/Qti/Converter/AssessmentSectionConverter.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\Qti\Converter;
+
+use oat\taoQtiItem\model\qti\converter\AbstractQtiConverter;
+
+class AssessmentSectionConverter extends AbstractQtiConverter
+{
+    private const ROOT_ELEMENT = 'qti-assessment-section';
+
+    protected function getRootElement(): string
+    {
+        return self::ROOT_ELEMENT;
+    }
+}

--- a/models/classes/Qti/Converter/TestConverter.php
+++ b/models/classes/Qti/Converter/TestConverter.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\Qti\Converter;
+
+use oat\taoQtiItem\model\qti\converter\AbstractQtiConverter;
+
+class TestConverter extends AbstractQtiConverter
+{
+    private const ROOT_ELEMENT = 'qti-assessment-test';
+
+    protected function getRootElement(): string
+    {
+        return self::ROOT_ELEMENT;
+    }
+}

--- a/models/classes/Qti/ServiceProvider/QtiServiceProvider.php
+++ b/models/classes/Qti/ServiceProvider/QtiServiceProvider.php
@@ -24,6 +24,10 @@ namespace oat\taoQtiTest\models\Qti\ServiceProvider;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\log\LoggerService;
+use oat\taoQtiItem\model\qti\converter\CaseConversionService;
+use oat\taoQtiItem\model\ValidationService;
+use oat\taoQtiTest\models\Qti\Converter\AssessmentSectionConverter;
+use oat\taoQtiTest\models\Qti\Converter\TestConverter;
 use oat\taoQtiTest\models\Qti\Identifier\Service\QtiIdentifierSetter;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use taoQtiTest_models_classes_QtiTestService;
@@ -42,5 +46,21 @@ class QtiServiceProvider implements ContainerServiceProviderInterface
                 service(taoQtiTest_models_classes_QtiTestService::class),
                 service(LoggerService::SERVICE_ID),
             ]);
+
+        $services
+            ->set(TestConverter::class)
+            ->args([
+                service(CaseConversionService::class),
+                service(ValidationService::SERVICE_ID)
+            ])
+            ->public();
+
+        $services
+            ->set(AssessmentSectionConverter::class)
+            ->args([
+                service(CaseConversionService::class),
+                service(ValidationService::SERVICE_ID)
+            ])
+            ->public();
     }
 }

--- a/models/classes/QtiTestUtils.php
+++ b/models/classes/QtiTestUtils.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoQtiTest\models;
 
+use InvalidArgumentException;
 use oat\generis\Helper\SystemHelper;
 use oat\taoQtiItem\model\qti\Resource;
 use qtism\data\storage\xml\XmlDocument;
@@ -28,6 +29,7 @@ use oat\oatbox\filesystem\FileSystemService;
 use oat\oatbox\filesystem\Directory;
 use qtism\data\AssessmentTest;
 use oat\oatbox\service\ConfigurableService;
+use taoItems_models_classes_TemplateRenderer;
 
 /**
  * Miscellaneous utility methods for the QtiTest extension.
@@ -54,7 +56,7 @@ class QtiTestUtils extends ConfigurableService
      * @param boolean $copy If set to false, the file will not be actually copied.
      * @param string $rename A new filename  e.g. 'file.css' to be used at storage time.
      * @return string The path were the file was copied/has to be copied (depending on the $copy argument).
-     * @throws \InvalidArgumentException If one of the above arguments is invalid.
+     * @throws InvalidArgumentException If one of the above arguments is invalid.
      * @throws \common_Exception
      */
     public function storeQtiResource(Directory $testContent, $qtiResource, $origin, $copy = true, $rename = '')
@@ -71,7 +73,7 @@ class QtiTestUtils extends ConfigurableService
         } elseif (is_string($qtiResource) === true) {
             $filePath = $qtiResource;
         } else {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "The 'qtiResource' argument must be a string or a taoQTI_models_classes_QTI_Resource object."
             );
         }
@@ -130,8 +132,16 @@ class QtiTestUtils extends ConfigurableService
      */
     public function emptyImsManifest($version = '2.1')
     {
-        $manifestFileName = ($version === '2.1') ? 'imsmanifest' : 'imsmanifestQti22';
-        $templateRenderer = new \taoItems_models_classes_TemplateRenderer(
+        $manifestFileName = match ($version) {
+            '2.1' => 'imsmanifest',
+            '2.2' => 'imsmanifestQti22',
+            '3.0' => 'imsmanifestQti30',
+            default => throw new InvalidArgumentException(
+                'Invalid version provided. Only "2.1", "2.2" and "3.0" are supported.'
+            ),
+        };
+
+        $templateRenderer = new taoItems_models_classes_TemplateRenderer(
             ROOT_PATH . 'taoQtiItem/model/qti/templates/' . $manifestFileName . '.tpl.php',
             [
                 'qtiItems' => [],

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -1640,7 +1640,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      */
     private function convertAssessmentSectionRefs(QtiComponentCollection $assessmentSectionRefs, string $folder): void
     {
-        if(!$this->getPsrContainer()->has(AssessmentSectionConverter::class)) {
+        if (!$this->getPsrContainer()->has(AssessmentSectionConverter::class)) {
             return;
         }
 

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -22,20 +22,23 @@ use oat\generis\model\data\event\ResourceCreated;
 use oat\oatbox\filesystem\Directory;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\filesystem\FileSystemService;
+use oat\oatbox\reporting\Report;
 use oat\tao\model\IdentifierGenerator\Generator\IdentifierGeneratorInterface;
 use oat\tao\model\IdentifierGenerator\Generator\IdentifierGeneratorProxy;
 use oat\tao\model\resources\ResourceAccessDeniedException;
 use oat\tao\model\resources\SecureResourceServiceInterface;
 use oat\tao\model\TaoOntology;
 use oat\taoItems\model\Command\DeleteItemCommand;
+use oat\taoQtiItem\model\qti\converter\ManifestConverter;
 use oat\taoQtiItem\model\qti\ImportService;
 use oat\taoQtiItem\model\qti\metadata\importer\MetadataImporter;
-use oat\taoQtiItem\model\qti\metadata\imsManifest\MetaMetadataExtractor;
 use oat\taoQtiItem\model\qti\metadata\importer\MetaMetadataImportMapper;
 use oat\taoQtiItem\model\qti\metadata\importer\PropertyDoesNotExistException;
+use oat\taoQtiItem\model\qti\metadata\imsManifest\MetaMetadataExtractor;
 use oat\taoQtiItem\model\qti\metadata\MetadataGuardianResource;
 use oat\taoQtiItem\model\qti\metadata\MetadataService;
 use oat\taoQtiItem\model\qti\metadata\ontology\MappedMetadataInjector;
+use oat\taoQtiItem\model\qti\PackageParser;
 use oat\taoQtiItem\model\qti\Resource;
 use oat\taoQtiItem\model\qti\Service;
 use oat\taoQtiTest\models\cat\AdaptiveSectionInjectionException;
@@ -43,21 +46,23 @@ use oat\taoQtiTest\models\cat\CatEngineNotFoundException;
 use oat\taoQtiTest\models\cat\CatService;
 use oat\taoQtiTest\models\classes\event\TestImportedEvent;
 use oat\taoQtiTest\models\metadata\MetadataTestContextAware;
+use oat\taoQtiTest\models\Qti\Converter\AssessmentSectionConverter;
+use oat\taoQtiTest\models\Qti\Converter\TestConverter;
 use oat\taoQtiTest\models\render\QtiPackageImportPreprocessing;
 use oat\taoQtiTest\models\test\AssessmentTestXmlFactory;
 use oat\taoTests\models\event\TestUpdatedEvent;
 use Psr\Container\ContainerInterface;
 use qtism\common\utils\Format;
 use qtism\data\AssessmentItemRef;
+use qtism\data\AssessmentSectionRef;
 use qtism\data\QtiComponentCollection;
 use qtism\data\SectionPartCollection;
 use qtism\data\storage\StorageException;
 use qtism\data\storage\xml\marshalling\UnmarshallingException;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\data\storage\xml\XmlStorageException;
-use taoTests_models_classes_TestsService as TestService;
-use oat\oatbox\reporting\Report;
 use taoQtiTest_models_classes_import_TestImportForm as TestImportForm;
+use taoTests_models_classes_TestsService as TestService;
 
 /**
  * the QTI TestModel service.
@@ -201,7 +206,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      * Save the json formated test into the test resource.
      *
      * @param core_kernel_classes_Resource $test
-     * @param string                       $json
+     * @param string $json
      *
      * @return bool true if saved
      *
@@ -212,7 +217,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
     {
         $saved = false;
 
-        if (! empty($json)) {
+        if (!empty($json)) {
             $this->verifyItemPermissions($test, $json);
 
             $doc = $this->getDoc($test);
@@ -266,7 +271,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         return false;
     }
 
-      /**
+    /**
      * Save the QTI test : set the items sequence and some options.
      *
      * @param core_kernel_classes_Resource $test A Resource describing a QTI Assessment Test.
@@ -280,7 +285,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         try {
             $doc = $this->getDoc($test);
             $this->setItemsToDoc($doc, $items);
-            $saved  = $this->saveDoc($test, $doc);
+            $saved = $this->saveDoc($test, $doc);
         } catch (StorageException $e) {
             throw new taoQtiTest_models_classes_QtiTestServiceException(
                 "An error occured while dealing with the QTI-XML test: " . $e->getMessage(),
@@ -306,7 +311,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         do {
             $identifier = $this->generateIdentifier($doc, $qtiType, $index);
             $index++;
-        } while (! $this->isIdentifierUnique($components, $identifier));
+        } while (!$this->isIdentifierUnique($components, $identifier));
 
         return $identifier;
     }
@@ -363,7 +368,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         ?string $packageLabel = null
     ) {
         $testClass = $targetClass;
-        $report = new common_report_Report(common_report_Report::TYPE_INFO);
+        $report = new Report(Report::TYPE_INFO);
         $validPackage = false;
         $validManifest = false;
         $testsFound = false;
@@ -381,24 +386,30 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         // phpcs:enable Generic.Files.LineLength
 
         try {
-            $qtiPackageParser = new taoQtiTest_models_classes_PackageParser($file);
+            $qtiPackageParser = new PackageParser($file);
             $qtiPackageParser->validate();
             $validPackage = true;
         } catch (Exception $e) {
-            $report->add(common_report_Report::createFailure($invalidArchiveMsg));
+            $report->add(Report::createError($invalidArchiveMsg));
         }
 
         // Validate the manifest (well formed XML, valid against the schema).
         if ($validPackage === true) {
             $folder = $qtiPackageParser->extract();
-
             if (is_dir($folder) === false) {
-                $report->add(common_report_Report::createFailure($invalidArchiveMsg));
+                $report->add(Report::createError($invalidArchiveMsg));
             } else {
-                $qtiManifestParser = new taoQtiTest_models_classes_ManifestParser($folder . 'imsmanifest.xml');
+                $file = $folder . 'imsmanifest.xml';
+                $qtiManifestParser = new taoQtiTest_models_classes_ManifestParser($file);
                 $this->propagate($qtiManifestParser);
+                // For taoSetup PsrContainer is not available
+                // It is not required to perform manifest conversion in this process
+                // therefore we can skip it during taoSetup
+                if ($this->getPsrContainer()->has(ManifestConverter::class)) {
+                    $this->getManifestConverter()->convertToQti2($file, $qtiManifestParser);
+                }
+                // We validate manifest file against QTI 3.0
                 $qtiManifestParser->validate();
-
                 if ($qtiManifestParser->isValid() === true) {
                     $validManifest = true;
 
@@ -411,10 +422,10 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
                     if ($testsFound !== true) {
                         $report->add(
-                            common_report_Report::createFailure(
-                                // phpcs:disable Generic.Files.LineLength
+                            Report::createError(
+                            // phpcs:disable Generic.Files.LineLength
                                 __("Package is valid but no tests were found. Make sure that it contains valid QTI tests.")
-                                // phpcs:enable Generic.Files.LineLength
+                            // phpcs:enable Generic.Files.LineLength
                             )
                         );
                     } else {
@@ -447,7 +458,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
                     }
                 } else {
                     $msg = __("The 'imsmanifest.xml' file found in the archive is not valid.");
-                    $report->add(common_report_Report::createFailure($msg));
+                    $report->add(Report::createError($msg));
                 }
 
                 // Cleanup the folder where the archive was extracted.
@@ -457,10 +468,10 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
         if ($report->containsError() === true) {
             $report->setMessage(__('The IMS QTI Test Package could not be imported.'));
-            $report->setType(common_report_Report::TYPE_ERROR);
+            $report->setType(Report::TYPE_ERROR);
         } else {
             $report->setMessage(__('IMS QTI Test Package successfully imported.'));
-            $report->setType(common_report_Report::TYPE_SUCCESS);
+            $report->setType(Report::TYPE_SUCCESS);
         }
 
         if (
@@ -577,7 +588,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
 
         // Create the report that will hold information about the import
         // of $qtiTestResource in TAO.
-        $report = new common_report_Report(common_report_Report::TYPE_INFO);
+        $report = new Report(Report::TYPE_INFO);
 
         // Load and validate the manifest
         $qtiManifestParser = new taoQtiTest_models_classes_ManifestParser($folder . 'imsmanifest.xml');
@@ -615,17 +626,25 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         // -- Check if the file referenced by the test QTI resource exists.
         if (is_readable($expectedTestFile) === false) {
             $report->add(
-                common_report_Report::createFailure(
+                Report::createError(
                     __('No file found at location "%s".', $qtiTestResource->getFile())
                 )
             );
         } else {
+            //Convert to QTI 2.2
+            if ($this->getPsrContainer()->has(TestConverter::class)) {
+                $this->getTestConverter()->convertToQti2($expectedTestFile);
+            }
             // -- Load the test in a QTISM flavour.
             $testDefinition = new XmlDocument();
 
             try {
                 $testDefinition->load($expectedTestFile, true);
-
+                $this->convertAssessmentSectionRefs(
+                    $testDefinition->getDocumentComponent()
+                        ->getComponentsByClassName('assessmentSectionRef'),
+                    $folder
+                );
                 // If any, assessmentSectionRefs will be resolved and included as part of the main test definition.
                 $testDefinition->includeAssessmentSectionRefs(true);
                 $testLabel = $packageLabel ?? $this->getTestLabel($reportCtx->testMetadata, $testDefinition);
@@ -1079,7 +1098,6 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      */
     public function getDoc(core_kernel_classes_Resource $test)
     {
-
         $doc = new XmlDocument('2.1');
         $doc->loadFromString($this->getQtiTestFile($test)->read());
         return $doc;
@@ -1165,7 +1183,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      * Get root qti test directory or crate if not exists
      *
      * @param core_kernel_classes_Resource $test
-     * @param boolean                      $createTestFile Whether or not create an empty QTI XML test file. Default is
+     * @param boolean $createTestFile Whether or not create an empty QTI XML test file. Default is
      *                                                     (boolean) true.
      *
      * @return Directory
@@ -1271,7 +1289,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      * Create the default content directory of a QTI test.
      *
      * @param core_kernel_classes_Resource $test
-     * @param boolean $createTestFile  Whether or not create an empty QTI XML test file. Default is (boolean) true.
+     * @param boolean $createTestFile Whether or not create an empty QTI XML test file. Default is (boolean) true.
      * @param boolean $preventOverride Prevent data to be overriden Default is (boolean) true.
      *
      * @return Directory the content directory
@@ -1433,7 +1451,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      */
     protected function getMetadataImporter()
     {
-        if (! $this->metadataImporter) {
+        if (!$this->metadataImporter) {
             $this->metadataImporter = $this->getServiceLocator()->get(MetadataService::SERVICE_ID)->getImporter();
         }
         return $this->metadataImporter;
@@ -1600,5 +1618,35 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
         }
 
         return reset($labelMetadata)->getValue();
+    }
+
+    private function getManifestConverter(): ManifestConverter
+    {
+        return $this->getPsrContainer()->get(ManifestConverter::class);
+    }
+
+    private function getTestConverter(): TestConverter
+    {
+        return $this->getPsrContainer()->get(TestConverter::class);
+    }
+
+    private function getSectionConverter(): AssessmentSectionConverter
+    {
+        return $this->getPsrContainer()->get(AssessmentSectionConverter::class);
+    }
+
+    /**
+     * @param AssessmentSectionRef[] $testDefinition
+     */
+    private function convertAssessmentSectionRefs(QtiComponentCollection $assessmentSectionRefs, string $folder): void
+    {
+        if(!$this->getPsrContainer()->has(AssessmentSectionConverter::class)) {
+            return;
+        }
+
+        foreach ($assessmentSectionRefs as $assessmentSectionRef) {
+            $file = $folder . $assessmentSectionRef->getHref();
+            $this->getSectionConverter()->convertToQti2($file);
+        }
     }
 }

--- a/models/classes/export/Formats/Package3p0/QtiItemExporter.php
+++ b/models/classes/export/Formats/Package3p0/QtiItemExporter.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\export\Formats\Package3p0;
+
+use oat\taoQtiItem\model\Export\Qti3Package\Exporter;
+use oat\taoQtiTest\models\export\QtiItemExporterTrait;
+use oat\taoQtiTest\models\export\QtiItemExporterInterface;
+
+class QtiItemExporter implements QtiItemExporterInterface
+{
+    use QtiItemExporterTrait;
+
+    private Exporter $exporter;
+
+    public function __construct(Exporter $exporter)
+    {
+        $this->exporter = $exporter;
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        return $this->exporter->$name(...$arguments);
+    }
+}

--- a/models/classes/export/Formats/Package3p0/QtiTestExporter.php
+++ b/models/classes/export/Formats/Package3p0/QtiTestExporter.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\export\Formats\Package3p0;
+
+use core_kernel_classes_Resource as Resource;
+use DOMDocument;
+use oat\taoQtiItem\model\Export\Qti3Package\Exporter;
+use oat\taoQtiItem\model\Export\Qti3Package\ExporterFactory;
+use oat\taoQtiItem\model\Export\Qti3Package\TransformationService;
+use oat\taoQtiTest\models\export\AbstractQtiTestExporter;
+use oat\taoQtiTest\models\export\QtiItemExporterInterface;
+
+class QtiTestExporter extends AbstractQtiTestExporter
+{
+    protected const TEST_RESOURCE_TYPE = 'imsqti_test_xmlv3p0';
+
+    private const QTI_SCHEMA_NAMESPACE = 'http://www.imsglobal.org/xsd/imsqtiasi_v3p0';
+    private const XML_SCHEMA_INSTANCE = 'http://www.w3.org/2001/XMLSchema-instance';
+    private const XSI_SCHEMA_LOCATION = 'http://www.imsglobal.org/xsd/imsqtiasi_v3p0';
+    // phpcs:ignore Generic.Files.LineLength.TooLong
+    private const XSI_SCHEMA_LOCATION_XSD = 'https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0_v1p0.xsd';
+    private TransformationService $transformationService;
+
+    private Exporter $exporter;
+
+
+    protected function getItemExporter(Resource $item): QtiItemExporterInterface
+    {
+        $factory = $this->getExporterFactory();
+        $this->exporter =  $factory->create($item, $this->getZip(), $this->getManifest());
+
+        return new QtiItemExporter($this->exporter);
+    }
+
+    protected function adjustTestXml(string $xml): string
+    {
+        return $this->itemContentPostProcessing($xml);
+    }
+
+    protected function itemContentPostProcessing($content): string
+    {
+        $transformationService = $this->exporter->getTransformationService();
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML($content);
+
+        $newDom = new DOMDocument('1.0', 'UTF-8');
+        $newDom->preserveWhiteSpace = false;
+        $newDom->formatOutput = true;
+
+        $oldRoot = $dom->documentElement;
+        $newRoot = $newDom->createElement($transformationService->createQtiElementName($oldRoot->nodeName));
+
+        //QTI3 namespace
+        $newRoot->setAttribute('xmlns', self::QTI_SCHEMA_NAMESPACE);
+        $newRoot->setAttribute('xmlns:xsi', self::XML_SCHEMA_INSTANCE);
+        $newRoot->setAttribute(
+            'xsi:schemaLocation',
+            sprintf('%s %s', self::XSI_SCHEMA_LOCATION, self::XSI_SCHEMA_LOCATION_XSD)
+        );
+
+        $transformationService->transformAttributes($oldRoot, $newRoot);
+
+        $newDom->appendChild($newRoot);
+
+        $transformationService->transformChildren($oldRoot, $newRoot, $newDom);
+
+        return $newDom->saveXML();
+    }
+
+    private function getExporterFactory(): ExporterFactory
+    {
+        return $this->getServiceManager()->getContainer()->get(ExporterFactory::class);
+    }
+}

--- a/models/classes/export/Formats/Package3p0/TestPackageExport.php
+++ b/models/classes/export/Formats/Package3p0/TestPackageExport.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\export\Formats\Package3p0;
+
+use core_kernel_classes_Resource as Resource;
+use oat\taoQtiTest\models\export\AbstractTestExport;
+use oat\taoQtiTest\models\export\QtiTestExporterInterface;
+use taoQtiTest_models_classes_QtiTestServiceException as QtiTestServiceException;
+
+class TestPackageExport extends AbstractTestExport
+{
+    protected const VERSION = '3.0';
+
+    public function getLabel(): string
+    {
+        return __('QTI Test Package %s', self::VERSION);
+    }
+
+    protected function getFormTitle(): string
+    {
+        return __('Export QTI %s Test Package', self::VERSION);
+    }
+
+    /**
+     * @throws QtiTestServiceException
+     */
+    protected function getTestExporter(Resource $instance): QtiTestExporterInterface
+    {
+        return new QtiTestExporter($instance, $this->getZip(), $this->getEmptyManifest());
+    }
+}
+
+// for backward compatibility
+// phpcs:disable PSR1.Files.SideEffects
+class_alias(TestPackageExport::class, 'taoQtiTest_models_classes_export_TestExport30');
+// phpcs:enable PSR1.Files.SideEffects


### PR DESCRIPTION
# Feature Description
This change allow TAO user to import/export QTI 3 Packages into Authoring. 

## Import
Process will downgrade QTI 3 package to QTI 2.2. 
All kebab case conventions will be converted into camel-case. 

## Export
New QTI 3 export option. 
Test that are stored in QTI 2.X will be exported to QTI 3
![Screenshot 2025-01-27 at 13 34 13](https://github.com/user-attachments/assets/4ac288d4-e9b7-4eec-83da-fd2ba9ffa722)
