### PR TITLE
feat: choice response id validation

### DIFF
--- a/model/Container/TestQtiServiceProvider.php
+++ b/model/Container/TestQtiServiceProvider.php
@@ -37,6 +37,8 @@ use oat\taoQtiTest\model\Infrastructure\QtiItemResponseRepository;
 use oat\taoQtiTest\model\Infrastructure\QtiItemResponseValidator;
 use oat\taoQtiTest\model\Infrastructure\QtiToolsStateRepository;
 use oat\taoQtiTest\model\Infrastructure\QtiTestRepository;
+use oat\taoQtiTest\model\Infrastructure\Validation\ChoiceResponseValidationStrategy;
+use oat\taoQtiTest\model\Infrastructure\Validation\ExtraQtiInteractionResponseValidator;
 use oat\taoQtiTest\model\Service\ConcurringSessionService;
 use oat\taoQtiTest\model\Service\ExitTestService;
 use oat\taoQtiTest\model\Service\ListItemsService;
@@ -69,6 +71,7 @@ class TestQtiServiceProvider implements ContainerServiceProviderInterface
                     service(QtiRunnerService::SERVICE_ID),
                     service(FeatureFlagChecker::class),
                     service(QtiItemResponseValidator::class),
+                    service(ExtraQtiInteractionResponseValidator::class),
                 ]
             );
 
@@ -195,5 +198,15 @@ class TestQtiServiceProvider implements ContainerServiceProviderInterface
                 ]
             )
             ->public();
+
+        $services->set(ChoiceResponseValidationStrategy::class, ChoiceResponseValidationStrategy::class);
+        $services
+            ->set(ExtraQtiInteractionResponseValidator::class, ExtraQtiInteractionResponseValidator::class)
+            ->public()
+            ->args(
+                [
+                    service(ChoiceResponseValidationStrategy::class)
+                ]
+            );
     }
 }

--- a/model/Infrastructure/QtiItemResponseRepository.php
+++ b/model/Infrastructure/QtiItemResponseRepository.php
@@ -127,14 +127,13 @@ class QtiItemResponseRepository implements ItemResponseRepositoryInterface
         if ($this->featureFlagChecker->isEnabled('FEATURE_FLAG_RESPONSE_VALIDATOR')) {
             try {
                 $this->itemResponseValidator->validate($serviceContext->getTestSession(), $responses);
-            } catch (AssessmentItemSessionException $e) {
+                $this->extraQtiInteractionResponseValidator->validate(
+                    $this->runnerService->getItemData($serviceContext, $itemDefinition),
+                    $responses
+                );
+            } catch (AssessmentItemSessionException | QtiRunnerInvalidResponsesException $e) {
                 throw new QtiRunnerInvalidResponsesException($e->getMessage());
             }
-
-            $this->extraQtiInteractionResponseValidator->validate(
-                $this->runnerService->getItemData($serviceContext, $itemDefinition),
-                $responses
-            );
 
             $this->runnerService->storeItemResponse($serviceContext, $itemDefinition, $responses);
             return;

--- a/model/Infrastructure/Validation/ChoiceResponseValidationStrategy.php
+++ b/model/Infrastructure/Validation/ChoiceResponseValidationStrategy.php
@@ -17,12 +17,12 @@
  *
  * Copyright (c) 2025 (original work) Open Assessment Technologies SA
  */
+
 declare(strict_types=1);
 
 namespace oat\taoQtiTest\model\Infrastructure\Validation;
 
-use oat\taoQtiTest\models\runner\QtiRunnerItemResponseException;
-use OutOfBoundsException;
+use oat\taoQtiTest\models\classes\runner\QtiRunnerInvalidResponsesException;
 use qtism\runtime\common\State;
 
 class ChoiceResponseValidationStrategy implements InteractionResponseValidationStrategy
@@ -62,8 +62,8 @@ class ChoiceResponseValidationStrategy implements InteractionResponseValidationS
 
             $diff = array_diff($userChoiceIds, $validChoiceIds);
             if ($diff !== []) {
-                throw new QtiRunnerItemResponseException(sprintf(
-                    'Choice identifiers: [%s] not found in the item',
+                throw new QtiRunnerInvalidResponsesException(sprintf(
+                    'Invalid choice identifiers: [%s]',
                     implode(',', $diff)
                 ));
             }

--- a/model/Infrastructure/Validation/ChoiceResponseValidationStrategy.php
+++ b/model/Infrastructure/Validation/ChoiceResponseValidationStrategy.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA
+ */
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\model\Infrastructure\Validation;
+
+use oat\taoQtiTest\models\runner\QtiRunnerItemResponseException;
+use OutOfBoundsException;
+use qtism\runtime\common\State;
+
+class ChoiceResponseValidationStrategy implements InteractionResponseValidationStrategy
+{
+    private const QTI_CLASS = 'choiceInteraction';
+
+    public function isApplicable(array $itemData): bool
+    {
+        if (!isset($itemData['data']['body']['elements']) || !is_array($itemData['data']['body']['elements'])) {
+            return false;
+        }
+
+        foreach ($itemData['data']['body']['elements'] as $element) {
+            if ($element['qtiClass'] === self::QTI_CLASS) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function validate(array $itemData, State $responses): void
+    {
+        foreach ($itemData['data']['body']['elements'] as $element) {
+            if ($element['qtiClass'] !== self::QTI_CLASS || !isset($element['choices'])) {
+                continue;
+            }
+
+            $userChoiceIds = $this->getQtiIdentifiersForChoicesByResponseDeclarationId(
+                $responses,
+                $element['attributes']['responseIdentifier']
+            );
+            $validChoiceIds = [];
+            foreach ($element['choices'] as $choice) {
+                $validChoiceIds[] = $choice['identifier'];
+            }
+
+            $diff = array_diff($userChoiceIds, $validChoiceIds);
+            if ($diff !== []) {
+                throw new QtiRunnerItemResponseException(sprintf(
+                    'Choice identifiers: [%s] not found in the item',
+                    implode(',', $diff)
+                ));
+            }
+        }
+    }
+
+    private function getQtiIdentifiersForChoicesByResponseDeclarationId(State $responses, string $key): array
+    {
+        $result = [];
+        foreach ($responses->getVariable($key)->getValue() as $response) {
+            $result[] = (string) $response->getValue();
+        }
+
+        return $result;
+    }
+}

--- a/model/Infrastructure/Validation/ExtraQtiInteractionResponseValidator.php
+++ b/model/Infrastructure/Validation/ExtraQtiInteractionResponseValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA
+ */
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\model\Infrastructure\Validation;
+
+use qtism\runtime\common\State;
+
+class ExtraQtiInteractionResponseValidator
+{
+    /**
+     * @var InteractionResponseValidationStrategy[]
+     */
+    private array $validationStrategies;
+
+    public function __construct(InteractionResponseValidationStrategy ...$validationStrategies)
+    {
+        $this->validationStrategies = $validationStrategies;
+    }
+
+    public function validate(array $itemData, State $responses): void
+    {
+        foreach ($this->validationStrategies as $validationStrategy) {
+            if (!$validationStrategy->isApplicable($itemData)) {
+                continue;
+            }
+
+            $validationStrategy->validate($itemData, $responses);
+        }
+    }
+}

--- a/model/Infrastructure/Validation/ExtraQtiInteractionResponseValidator.php
+++ b/model/Infrastructure/Validation/ExtraQtiInteractionResponseValidator.php
@@ -17,6 +17,7 @@
  *
  * Copyright (c) 2025 (original work) Open Assessment Technologies SA
  */
+
 declare(strict_types=1);
 
 namespace oat\taoQtiTest\model\Infrastructure\Validation;

--- a/model/Infrastructure/Validation/InteractionResponseValidationStrategy.php
+++ b/model/Infrastructure/Validation/InteractionResponseValidationStrategy.php
@@ -17,11 +17,12 @@
  *
  * Copyright (c) 2025 (original work) Open Assessment Technologies SA
  */
+
 declare(strict_types=1);
 
 namespace oat\taoQtiTest\model\Infrastructure\Validation;
 
-use OutOfBoundsException;
+use oat\taoQtiTest\models\classes\runner\QtiRunnerInvalidResponsesException;
 use qtism\runtime\common\State;
 
 interface InteractionResponseValidationStrategy
@@ -29,9 +30,7 @@ interface InteractionResponseValidationStrategy
     public function isApplicable(array $itemData): bool;
 
     /**
-     * @param array $itemData
-     * @param State $responses
-     * @throws OutOfBoundsException
+     * @throws QtiRunnerInvalidResponsesException
      */
     public function validate(array $itemData, State $responses): void;
 }

--- a/model/Infrastructure/Validation/InteractionResponseValidationStrategy.php
+++ b/model/Infrastructure/Validation/InteractionResponseValidationStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA
+ */
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\model\Infrastructure\Validation;
+
+use OutOfBoundsException;
+use qtism\runtime\common\State;
+
+interface InteractionResponseValidationStrategy
+{
+    public function isApplicable(array $itemData): bool;
+
+    /**
+     * @param array $itemData
+     * @param State $responses
+     * @throws OutOfBoundsException
+     */
+    public function validate(array $itemData, State $responses): void;
+}

--- a/test/unit/model/Infrastructure/Validation/ChoiceResponseValidationStrategyTest.php
+++ b/test/unit/model/Infrastructure/Validation/ChoiceResponseValidationStrategyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\model\Infrastructure\Validation;
+
+use oat\taoQtiTest\model\Infrastructure\Validation\ChoiceResponseValidationStrategy;
+use oat\taoQtiTest\models\classes\runner\QtiRunnerInvalidResponsesException;
+use PHPUnit\Framework\TestCase;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\runtime\common\MultipleContainer;
+use qtism\runtime\common\ResponseVariable;
+use qtism\runtime\common\State;
+use Throwable;
+
+class ChoiceResponseValidationStrategyTest extends TestCase
+{
+    private ChoiceResponseValidationStrategy $subject;
+
+    public function setUp(): void
+    {
+        $this->definedChoiceId1 = new QtiIdentifier('choice_1');
+        $this->definedChoiceId2 = new QtiIdentifier('choice_2');
+        $this->definedResponse1 = new ResponseVariable(
+            'RESPONSE_1',
+            1,
+            0,
+            new MultipleContainer(0, [$this->definedChoiceId1, $this->definedChoiceId2])
+        );
+
+        $this->state = new State();
+        $this->state->setVariable($this->definedResponse1);
+
+        $this->itemDefinition = [
+            'data' => [
+                'body' => [
+                    'elements' => [
+                        'interaction1' => [
+                            'qtiClass' => 'test',
+                        ],
+                        'interaction2' => [
+                            'qtiClass' => 'choiceInteraction',
+                            'attributes' => ['responseIdentifier' => $this->definedResponse1->getIdentifier()],
+                            'choices' => [
+                                'choice_1' => ["identifier" => (string) $this->definedChoiceId1->getValue()],
+                                'choice_2' => ["identifier" => (string) $this->definedChoiceId2->getValue()],
+                            ]
+                        ],
+                    ]
+                ]
+            ],
+        ];
+
+        $this->subject = new ChoiceResponseValidationStrategy();
+    }
+
+    public function testIsApplicable(): void
+    {
+        $this->assertTrue($this->subject->isApplicable($this->itemDefinition));
+
+        unset($this->itemDefinition['data']['body']['elements']['interaction2']);
+        $this->assertFalse($this->subject->isApplicable($this->itemDefinition));
+    }
+
+    public function testValidate(): void
+    {
+        try {
+            $this->subject->validate($this->itemDefinition, $this->state);
+        } catch (Throwable) {
+            $this->fail();
+        }
+
+        $this->expectException(QtiRunnerInvalidResponsesException::class);
+        $this->expectExceptionMessage('Invalid choice identifiers: [fakeChoiceIdByUser]');
+        $this->definedChoiceId2->setValue('fakeChoiceIdByUser');
+        $this->subject->validate($this->itemDefinition, $this->state);
+    }
+}

--- a/test/unit/model/Infrastructure/Validation/ExtraQtiInteractionResponseValidatorTest.php
+++ b/test/unit/model/Infrastructure/Validation/ExtraQtiInteractionResponseValidatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\model\Infrastructure\Validation;
+
+use oat\taoQtiTest\model\Infrastructure\Validation\ExtraQtiInteractionResponseValidator;
+use oat\taoQtiTest\model\Infrastructure\Validation\InteractionResponseValidationStrategy;
+use PHPUnit\Framework\TestCase;
+use qtism\runtime\common\State;
+
+class ExtraQtiInteractionResponseValidatorTest extends TestCase
+{
+    private ExtraQtiInteractionResponseValidator $subject;
+
+    public function setUp(): void
+    {
+        $this->interactionResponseValidationStrategy = $this->createMock(InteractionResponseValidationStrategy::class);
+        $this->interactionResponseValidationStrategy2 = $this->createMock(InteractionResponseValidationStrategy::class);
+
+        $this->subject = new ExtraQtiInteractionResponseValidator(
+            $this->interactionResponseValidationStrategy,
+            $this->interactionResponseValidationStrategy2
+        );
+    }
+
+    public function testValidateCallsApplicableStrategy(): void
+    {
+        $this->interactionResponseValidationStrategy->expects($this->once())
+            ->method('isApplicable')
+            ->willReturn(false);
+        $this->interactionResponseValidationStrategy2->expects($this->once())
+            ->method('isApplicable')
+            ->willReturn(true);
+
+        $this->interactionResponseValidationStrategy->expects($this->never())
+            ->method('validate');
+        $this->interactionResponseValidationStrategy2->expects($this->once())
+            ->method('validate');
+
+        $this->subject->validate([], new State());
+    }
+}


### PR DESCRIPTION
This PR adds pre-validation for choice identifiers selected by a test taker

How to test:
- run a delivery with choice interaction
- fake selected choice identifier in DOM or (move request)
- submit
- check delivery results and Response saved for the item includes a fake one
- enable the FF
- do the same
- ensure that submit in the same case is declined with a message


https://github.com/user-attachments/assets/d22fd4bd-27f1-4d92-bb9d-e7b1e30de003

