### PR TITLE
Fix/aut 4073 add property checking

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -1579,7 +1579,9 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
             $metadataValues = $this->getMetadataImporter()->extract($domManifest);
             $notMatchingProperties = $this->checkMissingClassProperties($metadataValues, $mappedMetadataValues);
             if (!empty($notMatchingProperties)) {
-                throw new PropertyDoesNotExistException($notMatchingProperties);
+                $message['checksum_result'] = false;
+                $message['label'] = implode(', ', $notMatchingProperties);
+                throw new PropertyDoesNotExistException($message);
             }
             if (empty($mappedMetadataValues)) {
                 $mappedMetadataValues = $this->getMetaMetadataImporter()->mapMetadataToProperties(

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -200,7 +200,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
      * @param array $mappedMetadataValues
      * @return array
      */
-    public function checkMissingClassProperties(array $metadataValues, array $mappedMetadataValues): array
+    private function checkMissingClassProperties(array $metadataValues, array $mappedMetadataValues): array
     {
         $metadataValueUris = $this->getMetadataImporter()->metadataValueUris($metadataValues);
         return array_diff(

--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -1557,8 +1557,19 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
             $mappedMetadataValues = $this->getMetaMetadataImporter()
                 ->mapMetaMetadataToProperties($metaMetadataValues, $targetItemClass, $testClass);
 
+            $metadataValues = $this->getMetadataImporter()->extract($domManifest);
+            $metadataValueUris = $this->getMetadataImporter()->metadataValueUris($metadataValues);
+            $notMatchingProperties = array_diff(
+                $metadataValueUris,
+                array_keys($mappedMetadataValues['testProperties'])
+            );
+            if (!empty($notMatchingProperties)) {
+                throw new taoQtiTest_models_classes_QtiTestServiceException(sprintf(
+                    __('Target class is missing the following metadata properties: %s'),
+                    implode(', ', $notMatchingProperties)
+                ));
+            }
             if (empty($mappedMetadataValues)) {
-                $metadataValues = $this->getMetadataImporter()->extract($domManifest);
                 $mappedMetadataValues = $this->getMetaMetadataImporter()->mapMetadataToProperties(
                     $metadataValues,
                     $targetItemClass,


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4073

## Description
If we try to import item with metadata properties which doesn't exist in class the import fails
## What's Changed
- add property checking to items,

## Dependencies PRs

- https://github.com/oat-sa/extension-tao-itemqti/pull/2676


## Video

https://github.com/user-attachments/assets/212172f5-13fa-4d72-a4d5-9508cc16d2f4


