### PR TITLE
[Fix] Identical identifiers during test duplication

### DIFF
--- a/models/classes/UniqueId/Listener/TestCreationListener.php
+++ b/models/classes/UniqueId/Listener/TestCreationListener.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2024-2025 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
@@ -66,10 +66,6 @@ class TestCreationListener
             return;
         }
 
-        if (!$this->featureFlagChecker->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')) {
-            return;
-        }
-
         $test = $this->getEventTest($event);
 
         if ($test->getRootId() !== TaoOntology::CLASS_URI_TEST) {
@@ -78,14 +74,17 @@ class TestCreationListener
 
         $identifier = $this->identifierGenerator->generate([IdentifierGeneratorInterface::OPTION_RESOURCE => $test]);
 
-        $test->editPropertyValues(
-            $this->ontology->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER),
-            $identifier
-        );
         $this->qtiIdentifierSetter->set([
             AbstractQtiIdentifierSetter::OPTION_RESOURCE => $test,
             AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => $identifier,
         ]);
+
+        if ($this->featureFlagChecker->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')) {
+            $test->editPropertyValues(
+                $this->ontology->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER),
+                $identifier
+            );
+        }
     }
 
     private function getEventTest(Event $event): core_kernel_classes_Resource

--- a/test/unit/models/classes/UniqueId/Listener/TestCreatingListenerTest.php
+++ b/test/unit/models/classes/UniqueId/Listener/TestCreatingListenerTest.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2024-2025 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
@@ -73,69 +73,6 @@ class TestCreatingListenerTest extends TestCase
 
     public function testFeatureDisabled(): void
     {
-        $this->featureFlagChecker
-            ->expects($this->once())
-            ->method('isEnabled')
-            ->with('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')
-            ->willReturn(false);
-
-        $this->identifierGenerator
-            ->expects($this->never())
-            ->method('generate');
-
-        $this->resource
-            ->expects($this->never())
-            ->method($this->anything());
-
-        $this->qtiIdentifierSetter
-            ->expects($this->never())
-            ->method('set');
-
-        $this->sut->populateUniqueId(new TestCreatedEvent('testUri'));
-    }
-
-    public function testIsNotTest(): void
-    {
-        $this->featureFlagChecker
-            ->expects($this->once())
-            ->method('isEnabled')
-            ->with('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')
-            ->willReturn(true);
-
-        $this->ontology
-            ->expects($this->once())
-            ->method('getResource')
-            ->with('testUri')
-            ->willReturn($this->resource);
-
-        $this->resource
-            ->expects($this->once())
-            ->method('getRootId')
-            ->willReturn('notTestRootId');
-
-        $this->identifierGenerator
-            ->expects($this->never())
-            ->method('generate');
-
-        $this->resource
-            ->expects($this->never())
-            ->method('editPropertyValues');
-
-        $this->qtiIdentifierSetter
-            ->expects($this->never())
-            ->method('set');
-
-        $this->sut->populateUniqueId(new TestCreatedEvent('testUri'));
-    }
-
-    public function testSuccess(): void
-    {
-        $this->featureFlagChecker
-            ->expects($this->once())
-            ->method('isEnabled')
-            ->with('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')
-            ->willReturn(true);
-
         $this->ontology
             ->expects($this->once())
             ->method('getResource')
@@ -153,6 +90,92 @@ class TestCreatingListenerTest extends TestCase
             ->with([IdentifierGeneratorInterface::OPTION_RESOURCE => $this->resource])
             ->willReturn('QWERTYUI');
 
+        $this->qtiIdentifierSetter
+            ->expects($this->once())
+            ->method('set')
+            ->with([
+                AbstractQtiIdentifierSetter::OPTION_RESOURCE => $this->resource,
+                AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => 'QWERTYUI',
+            ]);
+
+        $this->featureFlagChecker
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->with('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')
+            ->willReturn(false);
+
+        $this->resource
+            ->expects($this->never())
+            ->method('editPropertyValues');
+
+        $this->sut->populateUniqueId(new TestCreatedEvent('testUri'));
+    }
+
+    public function testIsNotTest(): void
+    {
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
+            ->with('testUri')
+            ->willReturn($this->resource);
+
+        $this->resource
+            ->expects($this->once())
+            ->method('getRootId')
+            ->willReturn('notTestRootId');
+
+        $this->identifierGenerator
+            ->expects($this->never())
+            ->method('generate');
+
+        $this->qtiIdentifierSetter
+            ->expects($this->never())
+            ->method('set');
+
+        $this->featureFlagChecker
+            ->expects($this->never())
+            ->method('isEnabled');
+
+        $this->resource
+            ->expects($this->never())
+            ->method('editPropertyValues');
+
+        $this->sut->populateUniqueId(new TestCreatedEvent('testUri'));
+    }
+
+    public function testSuccess(): void
+    {
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
+            ->with('testUri')
+            ->willReturn($this->resource);
+
+        $this->resource
+            ->expects($this->once())
+            ->method('getRootId')
+            ->willReturn(TaoOntology::CLASS_URI_TEST);
+
+        $this->identifierGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with([IdentifierGeneratorInterface::OPTION_RESOURCE => $this->resource])
+            ->willReturn('QWERTYUI');
+
+        $this->qtiIdentifierSetter
+            ->expects($this->once())
+            ->method('set')
+            ->with([
+                AbstractQtiIdentifierSetter::OPTION_RESOURCE => $this->resource,
+                AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => 'QWERTYUI',
+            ]);
+
+        $this->featureFlagChecker
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->with('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')
+            ->willReturn(true);
+
         $property = $this->createMock(core_kernel_classes_Property::class);
 
         $this->ontology
@@ -165,14 +188,6 @@ class TestCreatingListenerTest extends TestCase
             ->expects($this->once())
             ->method('editPropertyValues')
             ->with($property, 'QWERTYUI');
-
-        $this->qtiIdentifierSetter
-            ->expects($this->once())
-            ->method('set')
-            ->with([
-                AbstractQtiIdentifierSetter::OPTION_RESOURCE => $this->resource,
-                AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => 'QWERTYUI',
-            ]);
 
         $this->sut->populateUniqueId(new TestCreatedEvent('testUri'));
     }


### PR DESCRIPTION
# [AUT-3772](https://oat-sa.atlassian.net/browse/AUT-3772)

## Changes
* Now identifier for QTI schema will be generated every time

## How to test
1. Navigate to tests tab
2. Create new Test
3. Author it and check `Identifier` value
4. Duplicate/Copy this test
5. Check `Identifier` for the new duplicated/copied test

* Old behaviour: identifier remain the same
* Fixed behaviour: new identifier generated

## Require PRs
- [ ] https://github.com/oat-sa/tao-core/pull/4206
- [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/2687

[AUT-3772]: https://oat-sa.atlassian.net/browse/AUT-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ