### PR TITLE
Fix/INF-314/Revert empty value of serialized timeConstraint to null

### DIFF
--- a/models/classes/runner/time/QtiTimeConstraint.php
+++ b/models/classes/runner/time/QtiTimeConstraint.php
@@ -229,9 +229,9 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
 
     /**
      * Serialize the constraint the expected way by the TestContext and the TestMap
-     * @return array
+     * @return array|null
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         $source = $this->getSource();
         $timeLimits = $source->getTimeLimits();
@@ -271,6 +271,6 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
                 ];
             }
         }
-        return [];
+        return null;
     }
 }


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INF-314

## What's Changed
Revert a regression introduced [here](https://github.com/oat-sa/extension-tao-testqti/pull/2542/files#diff-aaaa9b2d494e27b0c261de3002367e5d274b30b20bb46a8f00adffdb29513900). When publishing a test, the `timeConstraint`, if not set, should give `null` like before.

- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## TODO 
- [ ] Update with package from https://github.com/oat-sa/tao-test-runner-qti-fe/pull/532

## How to test
Import the following test package and publish it to CurrentGen.
[inf-314_qtitimeconstraint_1745412576.zip](https://github.com/user-attachments/files/19868720/inf-314_qtitimeconstraint_1745412576.zip)

See that in the 2nd item of the test you have a "Previous" button:
![Screenshot 2025-04-23 at 14 41 53](https://github.com/user-attachments/assets/52e54026-59ef-48be-a76d-62baf9ddcd28)
Revert the change, and publish again, and you'll lose this button.
