### PR TITLE
Backport/INF-314/Revert empty value of serialized timeConstraint to null [2024.08]

### DIFF
--- a/models/classes/runner/time/QtiTimeConstraint.php
+++ b/models/classes/runner/time/QtiTimeConstraint.php
@@ -229,9 +229,9 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
 
     /**
      * Serialize the constraint the expected way by the TestContext and the TestMap
-     * @return array
+     * @return array|null
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         $source = $this->getSource();
         $timeLimits = $source->getTimeLimits();
@@ -271,6 +271,6 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
                 ];
             }
         }
-        return [];
+        return null;
     }
 }

--- a/models/classes/runner/time/QtiTimeConstraint.php
+++ b/models/classes/runner/time/QtiTimeConstraint.php
@@ -231,7 +231,7 @@ class QtiTimeConstraint extends TimeConstraint implements \JsonSerializable
      * Serialize the constraint the expected way by the TestContext and the TestMap
      * @return array|null
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): ?array
     {
         $source = $this->getSource();
         $timeLimits = $source->getTimeLimits();


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-314

Backport of https://github.com/oat-sa/extension-tao-testqti/pull/2595

To be released as v48.9.3 and used in tao-community 2028.4.x

TODO:
- [ ] integrate backported package after merging: https://github.com/oat-sa/tao-test-runner-qti-fe/pull/534