### PR TITLE
feature: -added outcomes to test, - added scaleSelector for editing scale lists

### DIFF
--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -136,16 +136,6 @@ define([
             const saveUrl = options.routes.save || '';
             options.testUri = decodeURIComponent(saveUrl.slice(saveUrl.indexOf('uri=') + 4));
 
-            // Add dummy scalesPresets data
-            //@TODO remove this when the backend is ready
-            options.scalesPresets = [
-                { uri: "https://example.com/1", label: "Example 1" },
-                { uri: "https://example.com/2", label: "Example 2" },
-                { uri: "https://example.com/3", label: "Example 3" },
-                { uri: "https://example.com/4", label: "Example 4" },
-                { uri: "https://example.com/5", label: "Example 5" }
-            ];
-
             categorySelector.setPresets(options.categoriesPresets);
             scaleSelector.setPresets(options.scalesPresets);
 

--- a/views/js/controller/creator/creator.js
+++ b/views/js/controller/creator/creator.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
@@ -45,7 +45,8 @@ define([
     'taoQtiTest/controller/creator/helpers/featureVisibility',
     'taoTests/previewer/factory',
     'core/logger',
-    'taoQtiTest/controller/creator/views/subsection'
+    'taoQtiTest/controller/creator/views/subsection',
+    'taoQtiTest/controller/creator/helpers/scaleSelector'
 ], function (
     module,
     $,
@@ -73,7 +74,8 @@ define([
     featureVisibility,
     previewerFactory,
     loggerFactory,
-    subsectionView
+    subsectionView,
+    scaleSelector
 ) {
     ('use strict');
     const logger = loggerFactory('taoQtiTest/controller/creator');
@@ -127,13 +129,25 @@ define([
             options.routes = options.routes || {};
             options.labels = options.labels || {};
             options.categoriesPresets = featureVisibility.filterVisiblePresets(options.categoriesPresets) || {};
+            options.scalesPresets = options.scalesPresets || [];
             options.guidedNavigation = options.guidedNavigation === true;
             options.translation = options.translation === true;
 
             const saveUrl = options.routes.save || '';
             options.testUri = decodeURIComponent(saveUrl.slice(saveUrl.indexOf('uri=') + 4));
 
+            // Add dummy scalesPresets data
+            //@TODO remove this when the backend is ready
+            options.scalesPresets = [
+                { uri: "https://example.com/1", label: "Example 1" },
+                { uri: "https://example.com/2", label: "Example 2" },
+                { uri: "https://example.com/3", label: "Example 3" },
+                { uri: "https://example.com/4", label: "Example 4" },
+                { uri: "https://example.com/5", label: "Example 5" }
+            ];
+
             categorySelector.setPresets(options.categoriesPresets);
+            scaleSelector.setPresets(options.scalesPresets);
 
             //back button
             if (options.translation) {

--- a/views/js/controller/creator/helpers/outcome.js
+++ b/views/js/controller/creator/helpers/outcome.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2025 (original work) Open Assessment Technologies SA ;
  */
 /**
  * Basic helper that is intended to manage outcomes inside a test model.
@@ -212,7 +212,6 @@ define([
          * @throws {TypeError} if the identifier is empty or is not a string
          */
         createOutcome: function createOutcome(identifier, type, cardinality) {
-
             if (!outcomeValidator.validateIdentifier(identifier)) {
                 throw new TypeError('You must provide a valid identifier!');
             }
@@ -224,6 +223,9 @@ define([
                 normalMaximum: false,
                 normalMinimum: false,
                 masteryValue: false,
+                scale: null,
+                externalScored: null,
+                externalScoredDisabled: 1,
                 cardinality: cardinalityHelper.getValid(cardinality, cardinalityHelper.SINGLE),
                 baseType: baseTypeHelper.getValid(type, baseTypeHelper.FLOAT)
             });

--- a/views/js/controller/creator/helpers/outcome.js
+++ b/views/js/controller/creator/helpers/outcome.js
@@ -223,7 +223,6 @@ define([
                 normalMaximum: false,
                 normalMinimum: false,
                 masteryValue: false,
-                scale: null,
                 externalScored: null,
                 externalScoredDisabled: 1,
                 cardinality: cardinalityHelper.getValid(cardinality, cardinalityHelper.SINGLE),

--- a/views/js/controller/creator/helpers/renderOutcomeHelper.js
+++ b/views/js/controller/creator/helpers/renderOutcomeHelper.js
@@ -140,11 +140,16 @@ define([
             })
             .on('blur increment.incrementer decrement.incrementer', 'input', function () {
                 const $outcomeContainer = $(this).closest('.outcome-container');
-                editedOutcomeDeclaration = testModel.outcomeDeclarations.find(
-                    outcome => outcome.identifier === $outcomeContainer.find('input.identifier').val()
-                );
                 const $input = $(this);
-                editedOutcomeDeclaration[$input.attr('name')] = $input.val().trim();
+
+                editedOutcomeDeclaration = testModel.outcomeDeclarations.find(
+                    outcome => outcome.serial === $outcomeContainer.data('serial')
+                );
+                if (editedOutcomeDeclaration) {
+                    editedOutcomeDeclaration[$input.attr('name')] = $input.val().trim();
+                } else {
+                    console.error('Could not find outcome declaration with serial:', $outcomeContainer.data('serial'));
+                }
             });
     }
 

--- a/views/js/controller/creator/helpers/renderOutcomeHelper.js
+++ b/views/js/controller/creator/helpers/renderOutcomeHelper.js
@@ -1,15 +1,20 @@
 define([
-    'taoQtiTest/controller/creator/helpers/outcome',
-    'tpl!taoQtiItem/qtiCreator/tpl/outcomeEditor/listing',
-    'taoQtiItem/qtiCreator/widgets/helpers/formElement',
-    'services/features',
+    'jquery',
+    'lodash',
     'i18n',
+    'taoQtiTest/controller/creator/helpers/outcome',
+    'tpl!taoQtiTest/controller/creator/templates/outcome-listing',
+    'taoQtiItem/qtiCreator/widgets/helpers/formElement',
+    'taoQtiTest/controller/creator/helpers/scaleSelector',
+    'services/features'
 ], function (
+    $,
+    _,
+    __,
     outcomeHelper,
-    outcomeEditorListingTpl,
+    outcomeListingTpl,
     formElement,
-    features,
-    __) {
+    scaleSelectorFactory) {
     'use strict';
     const _ns = '.outcome-container';
 
@@ -18,15 +23,31 @@ define([
      * @param {Object} testModel
      */
     function renderOutcomeDeclarationList(testModel, $editorPanel) {
+        const externalScoredOptions = {
+            none: 'none',
+            human: 'human',
+            externalMachine: 'externalMachine'
+        };
+
         const outcomesData = _.map(outcomeHelper.getNonReservedOutcomeDeclarations(testModel), function (outcome) {
-            let externalScoredDisabled = outcome.attr && outcome.attr('externalScoredDisabled');
             const externalScored = {
-                human: { label: __('Human'), selected: true },
+                none: { label: __('None'), selected: !outcome.externalScored },
+                human: { label: __('Human'), selected: outcome.externalScored === externalScoredOptions.human },
                 externalMachine: {
                     label: __('External Machine'),
-                    selected: outcome.attr && outcome.attr('externalScored') === outcome.externalScoredOptions.externalMachine
+                    selected: outcome.externalScored === externalScoredOptions.externalMachine
                 }
             };
+
+            let scaleValue = '';
+            if (outcome.scale) {
+                if (typeof outcome.scale === 'object' && outcome.scale.uri) {
+                    scaleValue = outcome.scale.uri;
+                } else if (typeof outcome.scale === 'string') {
+                    scaleValue = outcome.scale;
+                }
+            }
+
 
             return {
                 serial: outcome.serial,
@@ -34,22 +55,48 @@ define([
                 interpretation: outcome.interpretation,
                 longInterpretation: outcome.longInterpretation,
                 externalScored: externalScored,
+                externalScoredDisabled: 1,
+                scale: scaleValue,
                 normalMinimum: outcome.normalMinimum === false ? 0 : outcome.normalMinimum,
                 normalMaximum: outcome.normalMaximum === false ? 0 : outcome.normalMaximum,
                 titleDelete: __('Delete'),
-                titleEdit: __('Edit'),
-                externalScoredDisabled: externalScoredDisabled || 0
+                titleEdit: __('Edit')
             };
         });
 
         $editorPanel.find('.outcome-declarations-manual').html(
-            outcomeEditorListingTpl({
+            outcomeListingTpl({
                 outcomes: outcomesData
             })
         );
 
-        let editedOutcomeDeclaration = {};
         formElement.initWidget($editorPanel);
+
+        let editedOutcomeDeclaration = {};
+
+        $editorPanel.find('.outcome-container').each(function() {
+            const $outcomeContainer = $(this);
+            const identifierValue = $outcomeContainer.find('input.identifier').val();
+            const outcome = testModel.outcomeDeclarations.find(o => o.identifier === identifierValue);
+
+            if (outcome) {
+                const $scaleContainer = $outcomeContainer.find('.scales');
+                const scaleSelector = scaleSelectorFactory($scaleContainer);
+
+                scaleSelector.createForm(outcome.scale || '');
+
+                scaleSelector.on('scale-change', function(selectedScale) {
+                    outcome.scale = selectedScale;
+
+                    const $minMaxInputs = $outcomeContainer.find('.minimum-maximum input');
+                    $minMaxInputs.prop('disabled', !!selectedScale);
+                });
+
+                if (outcome.scale) {
+                    $outcomeContainer.find('.minimum-maximum input').prop('disabled', true);
+                }
+            }
+        });
 
         $editorPanel
             .on(`click${_ns}`, '.editable [data-role="edit"]', function () {
@@ -61,6 +108,21 @@ define([
                 );
                 $outcomeContainer.addClass('editing');
                 $outcomeContainer.removeClass('editable');
+
+                const $scaleContainer = $outcomeContainer.find('.scales');
+                const scaleSelector = scaleSelectorFactory($scaleContainer);
+                scaleSelector.createForm(editedOutcomeDeclaration.scale || '');
+
+                scaleSelector.on('scale-change', function(selected) {
+                    editedOutcomeDeclaration.scale = selected || '';
+
+                    const $minMaxInputs = $outcomeContainer.find('.minimum-maximum input');
+                    $minMaxInputs.prop('disabled', !!selected);
+                });
+
+                if (editedOutcomeDeclaration.scale) {
+                    $outcomeContainer.find('.minimum-maximum input').prop('disabled', true);
+                }
 
                 $identifierInput.focus();
             })

--- a/views/js/controller/creator/helpers/renderOutcomeHelper.js
+++ b/views/js/controller/creator/helpers/renderOutcomeHelper.js
@@ -112,7 +112,10 @@ define([
 
                 const scaleSelector = scaleSelectorFactory($interpretationContainer);
 
-                const interpretationValue = editedOutcomeDeclaration?.interpretation || '';
+                let interpretationValue = '';
+                if (editedOutcomeDeclaration.interpretation) {
+                    interpretationValue = editedOutcomeDeclaration.interpretation;
+                }
                 scaleSelector.createForm(interpretationValue);
 
                 scaleSelector.on('interpretation-change', function(interpretationValue) {
@@ -124,7 +127,7 @@ define([
                     $minMaxInputs.prop('disabled', !!interpretationValue);
                 });
 
-                if (editedOutcomeDeclaration?.interpretation) {
+                if (editedOutcomeDeclaration && editedOutcomeDeclaration.interpretation) {
                     $outcomeContainer.find('.minimum-maximum input').prop('disabled', true);
                 }
 

--- a/views/js/controller/creator/helpers/scaleSelector.js
+++ b/views/js/controller/creator/helpers/scaleSelector.js
@@ -1,0 +1,137 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+define([
+    'jquery',
+    'lodash',
+    'i18n',
+    'core/eventifier',
+    'ui/tooltip',
+    'select2'
+], function ($, _, __, eventifier, tooltip) {
+    'use strict';
+
+    let allScalesPresets = [];
+
+    const scaleMap = new Map();
+
+    function scaleSelectorFactory($container) {
+        const $scaleSelect = $container.find('[name=scale-custom]');
+
+        const scaleSelector = {
+            /**
+             * Read the form state and trigger an event with the result
+             * @fires scaleSelector#scale-change
+             */
+            updateScale() {
+                const selectedUri = $scaleSelect.val();
+
+                if (!selectedUri) {
+                    this.trigger('scale-change', null);
+                    return;
+                }
+
+                if (scaleMap.has(selectedUri)) {
+                    const selectedScale = scaleMap.get(selectedUri);
+                    this.trigger('scale-change', selectedScale);
+                } else {
+                    const customScale = {
+                        uri: selectedUri,
+                        label: selectedUri
+                    };
+                    this.trigger('scale-change', customScale);
+                }
+            },
+
+            /**
+             * Create the scale selection form
+             * @param {Object|String} [currentScale] - current scale associated with the outcome
+             */
+            createForm(currentScale) {
+                $scaleSelect
+                    .select2({
+                        width: '100%',
+                        tags: true,
+                        multiple: false,
+                        tokenSeparators: null,
+                        createSearchChoice: (scale) => scale.match(/^[a-zA-Z0-9_-]+$/)
+                            ? { id: scale, text: scale }
+                            : null,
+                        formatNoMatches: () => __('Scale name not allowed'),
+                        maximumInputLength: 32,
+                        data: allScalesPresets.map(preset => ({
+                            id: preset.uri,
+                            text: preset.label
+                        }))
+                    })
+                    .on('change', () => this.updateScale());
+
+                if (currentScale) {
+                    if (typeof currentScale === 'object' && currentScale.uri) {
+                        $scaleSelect.select2('val', currentScale.uri);
+                    } else if (typeof currentScale === 'string') {
+                        $scaleSelect.select2('val', currentScale);
+                    }
+                }
+
+                tooltip.lookup($container);
+            },
+
+            /**
+             * Update the form to match the data model
+             * @param {Object|String} scale - scale associated with an outcome
+             */
+            updateFormState(scale) {
+                if (scale) {
+                    if (typeof scale === 'object' && scale.uri) {
+                        $scaleSelect.select2('val', scale.uri);
+                    } else if (typeof scale === 'string') {
+                        $scaleSelect.select2('val', scale);
+                    }
+                } else {
+                    $scaleSelect.select2('val', '');
+                }
+            }
+        };
+
+        eventifier(scaleSelector);
+        return scaleSelector;
+    }
+
+    /**
+     * @param {Object[]} presets - expected format:
+     * [
+     *  {
+     *    uri: "https://example.com/1",
+     *    label: "Scale 1"
+     *  },
+     *  ...
+     * ]
+     */
+    scaleSelectorFactory.setPresets = function setPresets(presets) {
+        if (Array.isArray(presets)) {
+            allScalesPresets = Array.from(presets);
+
+            scaleMap.clear();
+            allScalesPresets.forEach(scale => {
+                scaleMap.set(scale.uri, scale);
+            });
+        }
+    };
+
+    return scaleSelectorFactory;
+});

--- a/views/js/controller/creator/helpers/scaleSelector.js
+++ b/views/js/controller/creator/helpers/scaleSelector.js
@@ -30,38 +30,46 @@ define([
     const scaleMap = new Map();
 
     function scaleSelectorFactory($container) {
-        const $scaleSelect = $container.find('[name=scale-custom]');
+        const $scaleSelect = $container.find('[name="interpretation"]');
 
         const scaleSelector = {
             /**
              * Read the form state and trigger an event with the result
-             * @fires scaleSelector#scale-change
+             * @fires scaleSelector#interpretation-change
              */
             updateScale() {
                 const selectedUri = $scaleSelect.val();
 
                 if (!selectedUri) {
-                    this.trigger('scale-change', null);
+                    this.trigger('interpretation-change', null);
                     return;
                 }
 
                 if (scaleMap.has(selectedUri)) {
                     const selectedScale = scaleMap.get(selectedUri);
-                    this.trigger('scale-change', selectedScale);
+                    this.trigger('interpretation-change', selectedScale.uri);
                 } else {
-                    const customScale = {
-                        uri: selectedUri,
-                        label: selectedUri
-                    };
-                    this.trigger('scale-change', customScale);
+                    this.trigger('interpretation-change', selectedUri);
                 }
             },
 
             /**
              * Create the scale selection form
-             * @param {Object|String} [currentScale] - current scale associated with the outcome
+             * @param {String} [currentInterpretation] - current interpretation associated with the outcome
              */
-            createForm(currentScale) {
+            createForm(currentInterpretation) {
+                const selectData = allScalesPresets.map(preset => ({
+                    id: preset.uri,
+                    text: preset.label
+                }));
+
+                if (currentInterpretation && !scaleMap.has(currentInterpretation)) {
+                    selectData.push({
+                        id: currentInterpretation,
+                        text: currentInterpretation
+                    });
+                }
+
                 $scaleSelect
                     .select2({
                         width: '100%',
@@ -72,20 +80,18 @@ define([
                             ? { id: scale, text: scale }
                             : null,
                         formatNoMatches: () => __('Scale name not allowed'),
+                        maximumSelectionSize: 1,
                         maximumInputLength: 32,
-                        data: allScalesPresets.map(preset => ({
-                            id: preset.uri,
-                            text: preset.label
-                        }))
+                        data: selectData
                     })
                     .on('change', () => this.updateScale());
 
-                if (currentScale) {
-                    if (typeof currentScale === 'object' && currentScale.uri) {
-                        $scaleSelect.select2('val', currentScale.uri);
-                    } else if (typeof currentScale === 'string') {
-                        $scaleSelect.select2('val', currentScale);
+                if (currentInterpretation) {
+                    if (!$scaleSelect.find(`option[value="${currentInterpretation}"]`).length) {
+                        $scaleSelect.append(new Option(currentInterpretation, currentInterpretation, true, true));
                     }
+
+                    $scaleSelect.val(currentInterpretation).trigger('change');
                 }
 
                 tooltip.lookup($container);
@@ -93,18 +99,26 @@ define([
 
             /**
              * Update the form to match the data model
-             * @param {Object|String} scale - scale associated with an outcome
+             * @param {String} interpretation - interpretation associated with an outcome
              */
-            updateFormState(scale) {
-                if (scale) {
-                    if (typeof scale === 'object' && scale.uri) {
-                        $scaleSelect.select2('val', scale.uri);
-                    } else if (typeof scale === 'string') {
-                        $scaleSelect.select2('val', scale);
+            updateFormState(interpretation) {
+                if (interpretation) {
+                    if (!$scaleSelect.find(`option[value="${interpretation}"]`).length) {
+                        $scaleSelect.append(new Option(interpretation, interpretation, true, true));
                     }
+
+                    $scaleSelect.val(interpretation).trigger('change');
                 } else {
-                    $scaleSelect.select2('val', '');
+                    $scaleSelect.val('').trigger('change');
                 }
+            },
+
+            /**
+             * Clear the current selection
+             */
+            clearSelection() {
+                $scaleSelect.val('').trigger('change');
+                this.updateScale();
             }
         };
 
@@ -128,7 +142,9 @@ define([
 
             scaleMap.clear();
             allScalesPresets.forEach(scale => {
-                scaleMap.set(scale.uri, scale);
+                if (scale && scale.uri) {
+                    scaleMap.set(scale.uri, scale);
+                }
             });
         }
     };

--- a/views/js/controller/creator/templates/index.js
+++ b/views/js/controller/creator/templates/index.js
@@ -34,7 +34,8 @@ define([
     'tpl!taoQtiTest/controller/creator/templates/translation-props',
     'tpl!taoQtiTest/controller/creator/templates/category-presets',
     'tpl!taoQtiTest/controller/creator/templates/subsection',
-    'tpl!taoQtiTest/controller/creator/templates/menu-button'
+    'tpl!taoQtiTest/controller/creator/templates/menu-button',
+    'tpl!taoQtiTest/controller/creator/templates/outcome-listing',
 ], function (
     defaults,
     testPart,
@@ -51,7 +52,8 @@ define([
     translationProps,
     categoryPresets,
     subsection,
-    menuButton
+    menuButton,
+    outcomeListing
 ) {
     'use strict';
 
@@ -69,6 +71,7 @@ define([
         outcomes: applyTemplateConfiguration(outcomes),
         subsection: applyTemplateConfiguration(subsection),
         menuButton: applyTemplateConfiguration(menuButton),
+        outcomeListing: applyTemplateConfiguration(outcomeListing),
         properties: {
             test: applyTemplateConfiguration(testProps),
             testpart: applyTemplateConfiguration(testPartProps),

--- a/views/js/controller/creator/templates/outcome-listing.tpl
+++ b/views/js/controller/creator/templates/outcome-listing.tpl
@@ -1,0 +1,57 @@
+{{#each outcomes}}
+<div class="outcome-container panel subpanel{{#if readonly}} readonly{{else}} editable deletable{{/if}} {{#if hidden}}hidden{{/if}}" data-serial="{{serial}}">
+    <div class="identifier-label" title="{{interpretation}}">
+        <span class="label">{{identifier}}</span>
+        <input class="identifier"
+               name="identifier"
+               value="{{identifier}}"
+               type="text"
+               placeholder="e.g. OUTCOME"
+               data-validate="$notEmpty; $pattern(pattern=^([a-zA-Z_][a-zA-Z0-9_\\.-]*)$);">
+    </div>
+    <span class="trigger icon-bin" title="{{titleDelete}}" data-role="delete"></span>
+    <span class="trigger icon-edit" title="{{titleEdit}}" data-role="edit"></span>
+    <div class="outcome-properties-form">
+        <div class="panel">
+            <label for="interpretation" class="has-icon">{{__ "Interpretation"}}</label>
+            <span class="icon-help" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <div class="tooltip-content">{{__ "A human interpretation of the variable's value."}}</div>
+            <input name="interpretation" value="{{interpretation}}" type="text">
+        </div>
+        <div class="panel longinterpretation">
+            <label for="longInterpretation" class="has-icon">{{__ "Long interpretation"}}</label>
+            <span class="icon-help" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <div class="tooltip-content">{{__ "An optional link to an extended interpretation of the outcome variable."}}</div>
+            <input name="longInterpretation"
+                   placeholder="https://www.example.com/doc.pdf"
+                   value="{{longInterpretation}}"
+                   type="text"
+                   data-validate="$isValidUrl;">
+        </div>
+        <div class="panel externalscored">
+            <label for="externalScored" class="has-icon">{{__ "External Scored"}}</label>
+            <span class="icon-help" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <div class="tooltip-content">{{__ "Select if you want the outcome declaration to be processed by an external system or human scorer. This is typically the case for items asking candidates to write an essay."}}</div>
+            <select name="externalScored" class="select2" data-has-search="false" {{#if externalScoredDisabled}} disabled="disabled" {{/if}}>
+                {{#each externalScored}}
+                    <option value="{{@key}}" {{#if selected}}selected="selected"{{/if}}>{{label}}</option>
+                {{/each}}
+            </select>
+        </div>
+        <div class="panel scales">
+            <label for="scale-custom" class="has-icon">{{__ "Scale"}}</label>
+            <span class="icon-help" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <div class="tooltip-content">{{__ "Select a scale or enter a custom one. When a scale is selected, min/max values will be disabled."}}</div>
+            <input type="text" name="scale-custom" value="{{scale}}"/>
+        </div>
+        <div class="panel minimum-maximum">
+            <label class="has-icon">{{__ "Value"}}</label>
+            <span class="icon-help" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
+            <div class="tooltip-content">{{__ "Defines the maximum magnitude of numeric outcome variables, the maximum must be a positive value and the minimum may be negative."}}</div>
+            <input name="normalMinimum" value="{{normalMinimum}}" data-increment="1" type="text" {{#if scale}}disabled{{/if}} />
+            <label class="spinner">{{__ "to"}}</label>
+            <input name="normalMaximum" value="{{normalMaximum}}" data-increment="1" data-min="0" type="text" {{#if scale}}disabled{{/if}} />
+        </div>
+    </div>
+</div>
+{{/each}}

--- a/views/js/controller/creator/templates/outcome-listing.tpl
+++ b/views/js/controller/creator/templates/outcome-listing.tpl
@@ -12,7 +12,7 @@
     <span class="trigger icon-bin" title="{{titleDelete}}" data-role="delete"></span>
     <span class="trigger icon-edit" title="{{titleEdit}}" data-role="edit"></span>
     <div class="outcome-properties-form">
-        <div class="panel">
+        <div class="panel interpretation">
             <label for="interpretation" class="has-icon">{{__ "Interpretation"}}</label>
             <span class="icon-help" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
             <div class="tooltip-content">{{__ "A human interpretation of the variable's value."}}</div>
@@ -37,12 +37,6 @@
                     <option value="{{@key}}" {{#if selected}}selected="selected"{{/if}}>{{label}}</option>
                 {{/each}}
             </select>
-        </div>
-        <div class="panel scales">
-            <label for="scale-custom" class="has-icon">{{__ "Scale"}}</label>
-            <span class="icon-help" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
-            <div class="tooltip-content">{{__ "Select a scale or enter a custom one. When a scale is selected, min/max values will be disabled."}}</div>
-            <input type="text" name="scale-custom" value="{{scale}}"/>
         </div>
         <div class="panel minimum-maximum">
             <label class="has-icon">{{__ "Value"}}</label>

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
@@ -35,7 +35,8 @@ define([
     'taoQtiTest/controller/creator/helpers/featureVisibility',
     'taoQtiTest/controller/creator/helpers/baseType',
     'taoQtiTest/controller/creator/helpers/outcome',
-    'taoQtiTest/controller/creator/helpers/renderOutcomeHelper'
+    'taoQtiTest/controller/creator/helpers/renderOutcomeHelper',
+    'taoQtiTest/controller/creator/helpers/scaleSelector',
 ], function (
     $,
     _,
@@ -53,7 +54,8 @@ define([
     featureVisibility,
     baseTypeHelper,
     outcome,
-    { renderOutcomeDeclarationList }
+    { renderOutcomeDeclarationList },
+    scaleSelectorFactory
 ) {
     const _ns = '.outcome-declarations-manual';
 
@@ -203,6 +205,18 @@ define([
                 // Add the 'editing' class to the newly created outcome-container
                 const $newOutcomeContainer = $('.outcome-declarations-manual .outcome-container').last();
                 $newOutcomeContainer.addClass('editing');
+
+                const $scaleContainer = $newOutcomeContainer.find('.scales');
+                const scaleSelector = scaleSelectorFactory($scaleContainer);
+                scaleSelector.createForm('');
+
+                scaleSelector.on('scale-change', function(selected) {
+                    newOutcome.scale = selected || '';
+
+                    const $minMaxInputs = $newOutcomeContainer.find('.minimum-maximum input');
+                    $minMaxInputs.prop('disabled', !!selected);
+                });
+
                 $newOutcomeContainer.find('.identifier').focus();
             });
 

--- a/views/js/test/creator/helpers/outcome/test.js
+++ b/views/js/test/creator/helpers/outcome/test.js
@@ -225,6 +225,9 @@ define([
             normalMaximum: false,
             normalMinimum: false,
             masteryValue: false,
+            scale: null,
+            externalScored: null,
+            externalScoredDisabled: 1,
             identifier: 'FOO_BAR',
             cardinality: 0,
             baseType: 3
@@ -241,6 +244,9 @@ define([
             normalMaximum: false,
             normalMinimum: false,
             masteryValue: false,
+            scale: null,
+            externalScored: null,
+            externalScoredDisabled: 1,
             identifier: 'FOO_BAR',
             cardinality: 0,
             baseType: 2
@@ -257,6 +263,9 @@ define([
             normalMaximum: false,
             normalMinimum: false,
             masteryValue: false,
+            scale: null,
+            externalScored: null,
+            externalScoredDisabled: 1,
             identifier: 'FOO_BAR',
             cardinality: 2,
             baseType: 3
@@ -274,6 +283,9 @@ define([
             normalMaximum: false,
             normalMinimum: false,
             masteryValue: false,
+            scale: null,
+            externalScored: null,
+            externalScoredDisabled: 1,
             identifier: 'FOO_BAR',
             cardinality: 1,
             baseType: 1
@@ -290,6 +302,9 @@ define([
             normalMaximum: false,
             normalMinimum: false,
             masteryValue: false,
+            scale: null,
+            externalScored: null,
+            externalScoredDisabled: 1,
             identifier: 'FOO_BAR',
             cardinality: 0,
             baseType: 3
@@ -306,6 +321,9 @@ define([
             normalMaximum: false,
             normalMinimum: false,
             masteryValue: false,
+            scale: null,
+            externalScored: null,
+            externalScoredDisabled: 1,
             identifier: 'FOO_BAR',
             cardinality: 0,
             baseType: 3

--- a/views/js/test/creator/helpers/scaleSelector/test.html
+++ b/views/js/test/creator/helpers/scaleSelector/test.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Authoring - scaleSelector Helper</title>
+    <base href="../../../../../../../tao/views/" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="creator/helpers/scaleSelector.js"></script>
+
+    <script type="text/javascript">
+        // Don't start the test now
+        QUnit.config.autostart = false;
+
+        // Load the config
+        require(['/tao/ClientConfig/config'], function() {
+            // Load the test
+            require(['taoQtiTest/test/creator/helpers/scaleSelector/test'], function() {
+                // Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/creator/helpers/scaleSelector/test.js
+++ b/views/js/test/creator/helpers/scaleSelector/test.js
@@ -1,0 +1,240 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+define([
+    'jquery',
+    'lodash',
+    'taoQtiTest/controller/creator/helpers/scaleSelector'
+], function($, _, scaleSelectorFactory) {
+    'use strict';
+
+    QUnit.module('helpers/scaleSelector');
+
+    QUnit.test('module', function(assert) {
+        assert.expect(1);
+        assert.equal(typeof scaleSelectorFactory, 'function', 'The scaleSelector helper module exposes a function');
+    });
+
+    QUnit.cases.init([
+        { title: 'createForm' },
+        { title: 'updateFormState' },
+        { title: 'updateScale' }
+    ]).test('helpers/scaleSelector API ', function(data, assert) {
+        var $container = $('<div><input name="scale-custom" /></div>');
+        var scaleSelector = scaleSelectorFactory($container);
+
+        assert.equal(typeof scaleSelector[data.title], 'function', 'The scaleSelector instance exposes a "' + data.title + '" function');
+    });
+
+    QUnit.test('setPresets() - static method', function(assert) {
+        assert.expect(1);
+        var testPresets = [
+            { uri: "https://test.com/1", label: "Test Scale 1" },
+            { uri: "https://test.com/2", label: "Test Scale 2" }
+        ];
+
+        assert.equal(typeof scaleSelectorFactory.setPresets, 'function', 'The static setPresets method exists');
+
+        scaleSelectorFactory.setPresets(testPresets);
+    });
+
+    QUnit.test('createForm() - initializes the form with no scale', function(assert) {
+        var ready = assert.async();
+        assert.expect(2);
+
+        var $container = $('<div><input name="scale-custom" /></div>');
+        $('#qunit-fixture').append($container);
+
+        var testPresets = [
+            { uri: "https://test.com/1", label: "Test Scale 1" },
+            { uri: "https://test.com/2", label: "Test Scale 2" }
+        ];
+        scaleSelectorFactory.setPresets(testPresets);
+
+        var scaleSelector = scaleSelectorFactory($container);
+
+        var originalSelect2 = $.fn.select2;
+        $.fn.select2 = function(options) {
+            assert.ok(true, 'select2 was initialized');
+            assert.deepEqual(options.data.map(item => ({ id: item.id, text: item.text })),
+                testPresets.map(preset => ({ id: preset.uri, text: preset.label })),
+                'select2 was initialized with the correct preset data');
+
+            $.fn.select2 = originalSelect2;
+            ready();
+
+            return this;
+        };
+
+        scaleSelector.createForm();
+    });
+
+    QUnit.test('createForm() - initializes the form with existing scale', function(assert) {
+        var ready = assert.async();
+        assert.expect(3);
+
+        var $container = $('<div><input name="scale-custom" /></div>');
+        $('#qunit-fixture').append($container);
+
+        var testPresets = [
+            { uri: "https://test.com/1", label: "Test Scale 1" },
+            { uri: "https://test.com/2", label: "Test Scale 2" }
+        ];
+        scaleSelectorFactory.setPresets(testPresets);
+
+        var scaleSelector = scaleSelectorFactory($container);
+        var currentScale = { uri: "https://test.com/1", label: "Test Scale 1" };
+
+        var select2ValCalled = false;
+        var originalSelect2 = $.fn.select2;
+        $.fn.select2 = function(options) {
+            assert.ok(true, 'select2 was initialized');
+            this.select2 = function(method, value) {
+                if (method === 'val') {
+                    assert.equal(value, currentScale.uri, 'select2 val was set to the current scale URI');
+                    select2ValCalled = true;
+                }
+                return this;
+            };
+            return this;
+        };
+
+        scaleSelector.createForm(currentScale);
+
+        setTimeout(function() {
+            assert.ok(select2ValCalled, 'select2 val was called');
+            $.fn.select2 = originalSelect2;
+            ready();
+        }, 10);
+    });
+
+    QUnit.test('updateFormState() - updates the form state', function(assert) {
+        var ready = assert.async();
+        assert.expect(3);
+
+        var $container = $('<div><input name="scale-custom" /></div>');
+        $('#qunit-fixture').append($container);
+
+        var testPresets = [
+            { uri: "https://test.com/1", label: "Test Scale 1" },
+            { uri: "https://test.com/2", label: "Test Scale 2" }
+        ];
+        scaleSelectorFactory.setPresets(testPresets);
+
+        var scaleSelector = scaleSelectorFactory($container);
+        var newScale = { uri: "https://test.com/1", label: "Test Scale 1" };
+
+        var originalSelect2 = $.fn.select2;
+        $.fn.select2 = function() {
+            this.select2 = function(method, value) {
+                if (method === 'val') {
+                    // Make sure the assertion matches the newScale.uri value
+                    assert.equal(value, newScale.uri, 'select2 val was set to the new scale URI');
+                }
+                return this;
+            };
+            return this;
+        };
+
+        scaleSelector.createForm();
+
+        scaleSelector.updateFormState(newScale);
+
+        scaleSelector.updateFormState("https://test.com/1");
+        assert.ok(true, 'updateFormState with string doesn\'t cause errors');
+
+        $.fn.select2 = originalSelect2;
+        ready();
+    });
+
+    QUnit.test('updateScale() - triggers scale-change event with current selection', function(assert) {
+        var ready = assert.async();
+        assert.expect(2);
+
+        var $container = $('<div><input name="scale-custom" /></div>');
+        $('#qunit-fixture').append($container);
+
+        var testPresets = [
+            { uri: "https://test.com/1", label: "Test Scale 1" },
+            { uri: "https://test.com/2", label: "Test Scale 2" }
+        ];
+        scaleSelectorFactory.setPresets(testPresets);
+
+        var scaleSelector = scaleSelectorFactory($container);
+
+        var originalTrigger = scaleSelector.trigger;
+        scaleSelector.trigger = function(eventName, data) {
+            if (eventName === 'scale-change') {
+                if (data && data.uri === "https://test.com/1") {
+                    assert.deepEqual(data, testPresets[0], 'scale-change event was triggered with the correct scale');
+
+                    $container.find('[name=scale-custom]').val = function() {
+                        return "https://nonexistent.com";
+                    };
+
+                    scaleSelector.trigger = function(eventName, data) {
+                        if (eventName === 'scale-change') {
+                            assert.deepEqual(
+                                data,
+                                { uri: "https://nonexistent.com", label: "https://nonexistent.com" },
+                                'For nonexistent URI, creates a custom scale with URI as label'
+                            );
+
+                            scaleSelector.trigger = originalTrigger;
+                            ready();
+                        }
+                    };
+
+                    scaleSelector.updateScale();
+                }
+            }
+
+            return originalTrigger.apply(this, arguments);
+        };
+
+        $container.find('[name=scale-custom]').val = function() {
+            return "https://test.com/1";
+        };
+
+        scaleSelector.createForm();
+
+        scaleSelector.updateScale();
+    });
+
+    QUnit.test('updateScale() - triggers scale-change with null when no selection', function(assert) {
+        var ready = assert.async();
+        assert.expect(1);
+
+        var $container = $('<div><input name="scale-custom" /></div>');
+        $('#qunit-fixture').append($container);
+
+        var scaleSelector = scaleSelectorFactory($container);
+
+        scaleSelector.createForm();
+
+        $container.find('[name=scale-custom]').val = function() {
+            return "";
+        };
+
+        scaleSelector.on('scale-change', function(scale) {
+            assert.strictEqual(scale, null, 'scale-change event was triggered with null');
+            ready();
+        });
+
+        scaleSelector.updateScale();
+    });
+});


### PR DESCRIPTION
## Ticket:
 - https://oat-sa.atlassian.net/browse/AUT-4198
## What's Changed
- Outcomes Editor in Test Authoring
- Scale select 

## TODO
- backend for loading and saving needs to be implemented
- for testing its needs to be mocked with dummy data in `tao/taoQtiTest/views/js/controller/creator/creator.js` L:138 
` options.scalesPresets = [
                { uri: "https://example.com/1", label: "Example 1" },
                { uri: "https://example.com/2", label: "Example 2" },
                { uri: "https://example.com/3", label: "Example 3" },
                { uri: "https://example.com/4", label: "Example 4" },
                { uri: "https://example.com/5", label: "Example 5" }
            ];`

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## How to test
- Go to Test Authoring click on test settings and in Outcomes section click "Add an outcome declaration" to add new outcome
- Select or add custom Scales from the new select 
- Use dummy data because this is only FE change

## Video 


https://github.com/user-attachments/assets/d24f247b-2834-4631-ba3b-6d88c01467a9


