### PR TITLE
feat: enable outcome processing injection when choosing grade scoring

### DIFF
--- a/actions/class.Creator.php
+++ b/actions/class.Creator.php
@@ -20,6 +20,7 @@
 
 use oat\generis\model\OntologyAwareTrait;
 use oat\taoBackOffice\model\lists\ListService;
+use oat\taoQtiItem\model\qti\metadata\exporter\scale\ScalePreprocessor;
 use oat\taoQtiItem\model\QtiCreator\Scales\RemoteScaleListService;
 use oat\taoQtiTest\models\TestCategoryPresetProvider;
 use oat\taoQtiTest\models\TestModelService;
@@ -246,9 +247,7 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule
 
     private function getScalePresets(): string
     {
-        $listElements = $this->getRemoteListService()->getListElements(
-            $this->getClass(RemoteScaleListService::SCALES_URI)
-        );
+        $listElements = $this->getScaleProcessor()->getScaleRemoteList();
 
         if (!is_iterable($listElements)) {
             throw new InvalidArgumentException('List elements should be iterable');
@@ -269,5 +268,10 @@ class taoQtiTest_actions_Creator extends tao_actions_CommonModule
         }
 
         return $json;
+    }
+
+    private function getScaleProcessor(): ScalePreprocessor
+    {
+        return $this->getServiceManager()->getContainer()->get(ScalePreprocessor::class);
     }
 }

--- a/views/js/controller/creator/helpers/outcome.js
+++ b/views/js/controller/creator/helpers/outcome.js
@@ -41,6 +41,8 @@ define([
         'SCORE_RATIO_WEIGHTED',
         'PASS_ALL',
         'PASS_ALL_RENDERING',
+        'GRADE',
+        'GRADE_MAX'
     ];
 
     var outcomeHelper = {

--- a/views/js/controller/creator/helpers/processingRule.js
+++ b/views/js/controller/creator/helpers/processingRule.js
@@ -162,6 +162,25 @@ define([
         },
 
         /**
+         * Creates a `min` rule
+         * @param {Object|Array} expressions - The expressions to find the minimum value among
+         * @returns {Object}
+         * @throws {TypeError} if the expressions are not valid QTI elements
+         */
+        min: function min(expressions) {
+            var processingRule = processingRuleHelper.create('min', null, forceArray(expressions));
+
+            processingRule.minOperands = 1;
+            processingRule.maxOperands = -1; // unlimited max operands
+            processingRule.acceptedCardinalities = [
+                cardinalityHelper.SINGLE, cardinalityHelper.MULTIPLE, cardinalityHelper.ORDERED
+            ];
+            processingRule.acceptedBaseTypes = [baseTypeHelper.INTEGER, baseTypeHelper.FLOAT];
+
+            return processingRule;
+        },
+
+        /**
          * Creates a `testVariables` rule
          * @param {String} identifier
          * @param {String|Number} [type]

--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -72,6 +72,12 @@ define([
             description: __('The score will be processed for the entire test. A sum of all SCORE outcomes will be computed and divided by the sum of MAX SCORE, the result will be compared to the cut score (or pass ratio), then the PASS_TOTAL outcome will be set accordingly.')
                          + ' ' +
                          __('If the category option is set, the score will also be processed per categories, and each results will take place in the PASS_xxx outcome, where xxx is the name of the category.')
+        },
+        grade: {
+            key: 'grade',
+            label: __('Minimum Grade'),
+            description: __('Description placeholder'),
+            error: __('Error placeholder')
         }
     };
 
@@ -135,6 +141,21 @@ define([
                     feedbackFailed: 'not_passed',
                     categoryIdentifier: 'PASS_CATEGORY_%s',
                     categoryFeedback: 'PASS_CATEGORY_%s_RENDERING'
+                }
+            ],
+            clean: true
+        },
+        grade: {
+            key: 'grade',
+            signature: /^GRADE(_MAX)?$/,
+            outcomes: [
+                {
+                    writer: 'grade',
+                    identifier: 'GRADE',
+                },
+                {
+                    writer: 'grade_max',
+                    identifier: 'GRADE_MAX',
                 }
             ],
             clean: true
@@ -304,6 +325,15 @@ define([
             }
 
             return outcomes;
+        },
+
+        grade: function writerGrade(descriptor, scoring, outcomes) {
+            addGradeMinOutcomeProcessing(outcomes, descriptor.identifier, scoring.scalePresets)
+            addGradeOutcome(outcomes, descriptor.identifier, scoring.scalePresets);
+        },
+
+        grade_max: function writerGradeMax(descriptor, scoring, outcomes, categories) {
+            addGradeMaxOutcome(outcomes, descriptor.identifier, scoring.scalePresets);
         }
     };
 
@@ -375,6 +405,7 @@ define([
 
             model = modelOverseer.getModel();
             scoring = model.scoring;
+            scoring.scalePresets = model.scalePresets;
             outcomes = getOutcomes(model);
 
             // write the score processing mode by generating the outcomes variables, but only if the mode has been set
@@ -562,6 +593,95 @@ define([
 
         outcomeHelper.addOutcome(model, outcome);
         outcomeHelper.addOutcomeProcessing(model, processingRule);
+    }
+
+    function addGradeOutcome(outcomes, identifier, scalePresets) {
+        var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.FLOAT);
+        outcome.interpretation = getCommonScaleUri(outcomes, scalePresets);
+
+        outcomeHelper.addOutcome(outcomes, outcome);
+    }
+
+    function addGradeMaxOutcome(outcomes, identifier, scalePresets) {
+        var commonScaleUri = getCommonScaleUri(outcomes, scalePresets);
+        const errorMessage = $('.test-outcome-processing-error[data-key="grade"]');
+        if (commonScaleUri === null) {
+            errorMessage.removeClass('hidden');
+            return;
+        }
+
+        errorMessage.addClass('hidden');
+        var outcome = outcomeHelper.createOutcome(identifier, baseTypeHelper.FLOAT);
+        outcome.interpretation = commonScaleUri;
+
+        outcome.defaultValue = {
+            'qti-type': 'defaultValue',
+            'values': [{
+                'qti-type': 'value',
+                'value': getMaxScaleValue(outcomes, scalePresets),
+                'baseType': baseTypeHelper.FLOAT
+            }]
+        };
+
+        outcomeHelper.addOutcome(outcomes, outcome);
+    }
+
+    function getMaxScaleValue(outcomes, scalePresets) {
+
+        const scale = _.find(scalePresets, { uri: getCommonScaleUri(outcomes, scalePresets) });
+
+        if (!scale || !scale.values) {
+            return null
+        }
+
+        return _.max(_.map(Object.keys(scale.values), Number));
+    }
+
+    function getCommonScaleUri(outcomes, scalePresets) {
+        var scaleUris = _.map(scalePresets, 'uri');
+
+        var urlInterpretations = _.chain(outcomes.outcomeDeclarations)
+            .map('interpretation')
+            .filter(function(i) {
+                return typeof i === 'string' && _.includes(scaleUris, i);
+            })
+            .uniq()
+            .value();
+
+        if (urlInterpretations.length !== 1) {
+            return null;
+        }
+
+        return urlInterpretations[0];
+    }
+
+    function addGradeMinOutcomeProcessing(outcomes, gradeIdentifier, scalesPresets) {
+        var commonScaleUri = getCommonScaleUri(outcomes, scalesPresets)
+
+        if (commonScaleUri === null) {
+            return;
+        }
+        var scaleOrientedOutcomeDeclarations = _.filter(outcomes.outcomeDeclarations, function(outcome) {
+            return outcome.interpretation === commonScaleUri;
+        });
+
+
+        // Create an array of variable expressions for each identifier
+        var scaleVariableExpressions = scaleOrientedOutcomeDeclarations.map(function(outcome) {
+            return processingRuleHelper.variable(outcome.identifier);
+        });
+
+        // Create a min expression with all the variables
+        var minExpression = processingRuleHelper.min(scaleVariableExpressions);
+
+        // Create a setOutcomeValue rule that assigns the min to the GRADE
+        var processingRule = processingRuleHelper.setOutcomeValue(
+            gradeIdentifier,
+            minExpression
+        );
+
+        // Add the processing rule to the model
+        outcomeHelper.addOutcomeProcessing(outcomes, processingRule);
     }
 
     /**

--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -217,6 +217,12 @@
                     <span class="icon-info"></span>
                     {{description}}
                 </div>
+                {{#if error}}
+                <div class="feedback-error test-outcome-processing-error hidden" data-key="{{key}}">
+                    <span class="icon-error"></span>
+                    {{error}}
+                </div>
+                {{/if}}
                 {{/each}}
             </div>
         </div>

--- a/views/js/controller/creator/views/test.js
+++ b/views/js/controller/creator/views/test.js
@@ -131,19 +131,22 @@ define([
             const $weightIdentifierLine = $('.test-weight-identifier', $view);
             const $descriptions = $('.test-outcome-processing-description', $view);
             const $generate = $('[data-action="generate-outcomes"]', $view);
+            const $scoringError = $('.test-outcome-processing-error', $view);
             const $addOutcomeDeclaration = $('[data-action="add-outcome-declaration"]', $view);
             let scoringState = JSON.stringify(testModel.scoring);
             const weightVisible = features.isVisible('taoQtiTest/creator/test/property/scoring/weight');
 
             function changeScoring(scoring) {
-                const noOptions = !!scoring && ['none', 'custom'].indexOf(scoring.outcomeProcessing) === -1;
+                const noOptions = !!scoring && ['none', 'custom', 'grade'].indexOf(scoring.outcomeProcessing) === -1;
                 const newScoringState = JSON.stringify(scoring);
 
                 hider.toggle($cutScoreLine, !!scoring && scoring.outcomeProcessing === 'cut');
                 hider.toggle($categoryScoreLine, noOptions);
                 hider.toggle($weightIdentifierLine, noOptions && weightVisible);
                 hider.hide($descriptions);
+                hider.hide($scoringError);
                 hider.show($descriptions.filter('[data-key="' + scoring.outcomeProcessing + '"]'));
+                testModel.scalePresets = config.scalePresets;
 
                 if (scoringState !== newScoringState) {
                     /**


### PR DESCRIPTION
Add new outcomeProcessing scoring option that will take all scales in outcome declaration and generate:
- OutcomeDeclaration `GRADING`
- OutcomeDeclaration `GRADING_MAX`
- OutomceProcessing containig `setOutcomeValue` with `min` operation including variables that has interpretation defined from scales presets. 