### PR TITLE
[INF-337] fix: additional hash chunk for file name prefix

### DIFF
--- a/models/classes/files/QtiFlysystemFileManager.php
+++ b/models/classes/files/QtiFlysystemFileManager.php
@@ -89,7 +89,8 @@ class QtiFlysystemFileManager extends ConfigurableService implements FileManager
 
     private function generateId()
     {
-        $hash = md5(uniqid((string) mt_rand(), true));
+        $random = random_bytes(16); 
+        $hash = hash('sha256', uniqid('', true) . $random);
         $prefix = substr($hash, 0, 5);
         $parts = str_split($prefix);
         $subPath = implode(DIRECTORY_SEPARATOR, $parts);

--- a/models/classes/files/QtiFlysystemFileManager.php
+++ b/models/classes/files/QtiFlysystemFileManager.php
@@ -89,6 +89,9 @@ class QtiFlysystemFileManager extends ConfigurableService implements FileManager
 
     private function generateId()
     {
-        return $this->filePrefix . uniqid() . mt_rand(0, 1000000);
+        $hash = md5(uniqid(mt_rand(), true));
+        $prefix = substr($hash, 0, 2);
+        $id = $prefix . \"/\" . $hash;
+        return $this->filePrefix . $id;
     }
 }

--- a/models/classes/files/QtiFlysystemFileManager.php
+++ b/models/classes/files/QtiFlysystemFileManager.php
@@ -89,7 +89,7 @@ class QtiFlysystemFileManager extends ConfigurableService implements FileManager
 
     private function generateId()
     {
-        $random = random_bytes(16); 
+        $random = random_bytes(16);
         $hash = hash('sha256', uniqid('', true) . $random);
         $prefix = substr($hash, 0, 5);
         $parts = str_split($prefix);

--- a/models/classes/files/QtiFlysystemFileManager.php
+++ b/models/classes/files/QtiFlysystemFileManager.php
@@ -91,7 +91,7 @@ class QtiFlysystemFileManager extends ConfigurableService implements FileManager
     {
         $hash = md5(uniqid(mt_rand(), true));
         $prefix = substr($hash, 0, 2);
-        $id = $prefix . \"/\" . $hash;
+        $id = $prefix . DIRECTORY_SEPARATOR . $hash;
         return $this->filePrefix . $id;
     }
 }

--- a/models/classes/files/QtiFlysystemFileManager.php
+++ b/models/classes/files/QtiFlysystemFileManager.php
@@ -89,9 +89,11 @@ class QtiFlysystemFileManager extends ConfigurableService implements FileManager
 
     private function generateId()
     {
-        $hash = md5(uniqid(mt_rand(), true));
-        $prefix = substr($hash, 0, 2);
-        $id = $prefix . DIRECTORY_SEPARATOR . $hash;
+        $hash = md5(uniqid((string) mt_rand(), true));
+        $prefix = substr($hash, 0, 5);
+        $parts = str_split($prefix);
+        $subPath = implode(DIRECTORY_SEPARATOR, $parts);
+        $id = $subPath . DIRECTORY_SEPARATOR . $hash;
         return $this->filePrefix . $id;
     }
 }


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INF-337

## What's Changed
- Changes for file hash creation, additional prefix for s3 performance improvements

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/..

## How to test
- Explain here how to test or make a small demo to our team how this works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the format and structure of generated file IDs for enhanced organization and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->