### PR TITLE
fix: add custom logic under FF for submiting info items with force co…

### DIFF
--- a/model/Infrastructure/QtiItemResponseValidator.php
+++ b/model/Infrastructure/QtiItemResponseValidator.php
@@ -26,7 +26,6 @@ use oat\taoQtiTest\models\runner\QtiRunnerEmptyResponsesException;
 use qtism\runtime\common\State;
 use qtism\runtime\tests\AssessmentItemSessionException;
 use qtism\runtime\tests\AssessmentTestSession;
-use qtism\runtime\tests\Utils as TestUtils;
 
 class QtiItemResponseValidator
 {
@@ -37,36 +36,63 @@ class QtiItemResponseValidator
      */
     public function validate(AssessmentTestSession $testSession, State $responses): void
     {
-        if (
-            $this->getAllowSkip($testSession) &&
-            $responses->containsNullOnly() &&
-            !$this->getResponseValidation($testSession)
-        ) {
+        $itemSession       = $testSession->getCurrentAssessmentItemSession();
+        $item              = $itemSession->getAssessmentItem();
+        $outcomeDecls      = $item->getOutcomeDeclarations();
+        $responseDecls     = $item->getResponseDeclarations();
+        $itemConstraints   = $item->getResponseValidityConstraints();
+
+        $allowSkip         = $this->getAllowSkip($testSession);
+        $nullOnly          = $responses->containsNullOnly();
+        $validateRequired  = $this->getResponseValidation($testSession);
+
+        $hasConstraints    = $itemConstraints->count() > 0;
+        $hasOutcomes       = $outcomeDecls->count() > 0;
+        $hasResponses      = $responseDecls->count() > 0;
+        $noDeclOrConst     = !$hasConstraints && !$hasOutcomes && !$hasResponses;
+
+        // 1) Skip allowed & nothing answered & no forced validation
+        if ($allowSkip && $nullOnly && ! $validateRequired) {
             return;
         }
 
-        if (
-            !$this->getAllowSkip($testSession) &&
-            $responses->containsNullOnly() &&
-            $this->getResponseValidation($testSession)
-        ) {
+        // 2) Skip allowed & nothing answered & validation *on* & no declarations/constraints
+        if (!$allowSkip && $nullOnly && !$validateRequired && !$noDeclOrConst) {
             throw new QtiRunnerEmptyResponsesException();
         }
 
-        $currentAssessmentItemSession = $testSession->getCurrentAssessmentItemSession();
-        if ($this->getResponseValidation($testSession)) {
-            $currentAssessmentItemSession
-                ->checkResponseValidityConstraints($responses);
+        // 3) Skip *not* allowed & nothing answered & validation *on* & no declarations/constraints
+        if (!$allowSkip && $nullOnly && $validateRequired && $noDeclOrConst) {
+            return;
         }
 
-        # Covering cases when force contraint is false but the item has response validity constraints
-        if (
-            !$this->getResponseValidation($testSession) &&
-            $currentAssessmentItemSession->getAssessmentItem()->getResponseValidityConstraints()->count()
-        ) {
-            $currentAssessmentItemSession->getItemSessionControl()->setValidateResponses(true);
-            $currentAssessmentItemSession
-                ->checkResponseValidityConstraints($responses);
+        // 4) Skip *not* allowed & nothing answered & validation *on* => error
+        if (!$allowSkip && $nullOnly && $validateRequired) {
+            throw new QtiRunnerEmptyResponsesException();
+        }
+
+        // 5) If skip allowed, nothing answered, validation *on* and item has constraints/outcomes/responses
+        if ($allowSkip && $nullOnly && $validateRequired && $hasConstraints) {
+            throw new QtiRunnerEmptyResponsesException();
+        }
+
+        // 6) If validation is on, always run the constraint check
+        if ($validateRequired) {
+            $itemSession->checkResponseValidityConstraints($responses);
+            return;
+        }
+
+        if (!$validateRequired && $allowSkip && $hasConstraints && $hasOutcomes && $hasResponses) {
+            return;
+        }
+
+        // 7) Force-enable validation when off but item *does* have constraints/outcomes/responses
+        if (!$validateRequired && $hasConstraints && $hasOutcomes && $hasResponses) {
+            $itemSession
+            ->getItemSessionControl()
+            ->setValidateResponses(true);
+
+            $itemSession->checkResponseValidityConstraints($responses);
         }
     }
 

--- a/test/unit/model/Infrastructure/QtiItemResponseValidatorTest.php
+++ b/test/unit/model/Infrastructure/QtiItemResponseValidatorTest.php
@@ -33,6 +33,7 @@ use qtism\runtime\tests\Route;
 use qtism\runtime\tests\RouteItem;
 use qtism\runtime\tests\RouteItemSessionControl;
 use qtism\data\AssessmentItem;
+use qtism\data\state\OutcomeDeclarationCollection;
 use qtism\data\state\ResponseValidityConstraintCollection;
 
 use function PHPUnit\Framework\once;
@@ -75,6 +76,28 @@ class QtiItemResponseValidatorTest extends TestCase
     {
         $assessmentTestSession = $this->createMock(AssessmentTestSession::class);
         $responses = $this->createMock(State::class);
+        $assessmentItemSession = $this->createMock(AssessmentItemSession::class);
+        $getAssessmentItem = $this->createMock(AssessmentItem::class);
+        $outcomeDeclarationCollection = $this->createMock(OutcomeDeclarationCollection::class);
+        $responseDeclarationCollection = $this->createMock(ResponseValidityConstraintCollection::class);
+
+        $responseDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $outcomeDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $getAssessmentItem
+            ->expects($this->once())
+            ->method('getOutcomeDeclarations')
+            ->willReturn($outcomeDeclarationCollection);
+
+        $getAssessmentItem
+            ->expects($this->once())
+            ->method('getResponseDeclarations')
+            ->willReturn($responseDeclarationCollection);
 
         $assessmentTestSession
             ->method('getRoute')
@@ -93,8 +116,13 @@ class QtiItemResponseValidatorTest extends TestCase
             ->willReturn(false);
 
         $assessmentTestSession
-            ->expects($this->never())
-            ->method('getCurrentAssessmentItemSession');
+            ->expects($this->once())
+            ->method('getCurrentAssessmentItemSession')
+            ->willReturn($assessmentItemSession);
+
+        $assessmentItemSession->expects($this->once())
+            ->method('getAssessmentItem')
+            ->willReturn($getAssessmentItem);
 
         $this->subject->validate($assessmentTestSession, $responses);
 
@@ -105,6 +133,34 @@ class QtiItemResponseValidatorTest extends TestCase
     {
         $assessmentTestSession = $this->createMock(AssessmentTestSession::class);
         $responses = $this->createMock(State::class);
+        $assessmentItemSession = $this->createMock(AssessmentItemSession::class);
+
+        $getAssessmentItem = $this->createMock(AssessmentItem::class);
+        $outcomeDeclarationCollection = $this->createMock(OutcomeDeclarationCollection::class);
+        $responseDeclarationCollection = $this->createMock(ResponseValidityConstraintCollection::class);
+
+        $responseDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $outcomeDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $getAssessmentItem
+            ->expects($this->once())
+            ->method('getOutcomeDeclarations')
+            ->willReturn($outcomeDeclarationCollection);
+
+        $getAssessmentItem
+            ->expects($this->once())
+            ->method('getResponseDeclarations')
+            ->willReturn($responseDeclarationCollection);
+
+        $assessmentTestSession
+            ->expects($this->once())
+            ->method('getCurrentAssessmentItemSession')
+            ->willReturn($assessmentItemSession);
 
         $assessmentTestSession
             ->method('getRoute')
@@ -121,6 +177,10 @@ class QtiItemResponseValidatorTest extends TestCase
         $responses
             ->method('containsNullOnly')
             ->willReturn(true);
+
+        $assessmentItemSession->expects($this->once())
+            ->method('getAssessmentItem')
+            ->willReturn($getAssessmentItem);
 
         $this->expectException(QtiRunnerEmptyResponsesException::class);
 
@@ -132,6 +192,27 @@ class QtiItemResponseValidatorTest extends TestCase
         $assessmentTestSession = $this->createMock(AssessmentTestSession::class);
         $responses = $this->createMock(State::class);
         $assessmentItemSession = $this->createMock(AssessmentItemSession::class);
+        $getAssessmentItem = $this->createMock(AssessmentItem::class);
+        $outcomeDeclarationCollection = $this->createMock(OutcomeDeclarationCollection::class);
+        $responseDeclarationCollection = $this->createMock(ResponseValidityConstraintCollection::class);
+
+        $responseDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $outcomeDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $getAssessmentItem
+            ->expects($this->once())
+            ->method('getOutcomeDeclarations')
+            ->willReturn($outcomeDeclarationCollection);
+
+        $getAssessmentItem
+            ->expects($this->once())
+            ->method('getResponseDeclarations')
+            ->willReturn($responseDeclarationCollection);
 
         $assessmentTestSession
             ->method('getRoute')
@@ -158,6 +239,10 @@ class QtiItemResponseValidatorTest extends TestCase
             ->method('checkResponseValidityConstraints')
             ->with($responses);
 
+        $assessmentItemSession->expects($this->once())
+            ->method('getAssessmentItem')
+            ->willReturn($getAssessmentItem);
+
         $this->subject->validate($assessmentTestSession, $responses);
     }
 
@@ -168,6 +253,26 @@ class QtiItemResponseValidatorTest extends TestCase
         $assessmentItemSession = $this->createMock(AssessmentItemSession::class);
         $assessmentItem = $this->createMock(AssessmentItem::class);
         $responseValidityConstraintCollection = new ResponseValidityConstraintCollection();
+        $outcomeDeclarationCollection = $this->createMock(OutcomeDeclarationCollection::class);
+        $responseDeclarationCollection = $this->createMock(ResponseValidityConstraintCollection::class);
+
+        $responseDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $outcomeDeclarationCollection
+            ->method('count')
+            ->willReturn(1);
+
+        $assessmentItem
+            ->expects($this->once())
+            ->method('getOutcomeDeclarations')
+            ->willReturn($outcomeDeclarationCollection);
+
+        $assessmentItem
+            ->expects($this->once())
+            ->method('getResponseDeclarations')
+            ->willReturn($responseDeclarationCollection);
 
         $assessmentTestSession
             ->method('getRoute')


### PR DESCRIPTION
## What's Changed
- Support next case (should be submitted without errors:
Info item
Allow Skipping: OFF
Enforce Item Constraints: ON


expected:
![image](https://github.com/user-attachments/assets/ae2866b1-f9c2-455e-8df9-0ec4f6bf23a0)

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## How to test
- Install TAO with FEATURE_FLAG_RESPONSE_VALIDATOR = true
- Create an info item with Allow Skipping: OFF and Enforce Item Constraints: ON
- Create a delivery and try to submit the item 
- The item should be submitted without errors


Example:
[test_1_1750759400.zip](https://github.com/user-attachments/files/20881302/test_1_1750759400.zip)
