### PR TITLE
fix: update qti-sdk version with 0.28.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "ext-zip": "*",
     "oat-sa/lib-test-cat": "2.4.0",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "qtism/qtism": ">=0.28.9",
+    "qtism/qtism": ">=0.28.10",
     "oat-sa/generis": ">=16.0.0",
     "oat-sa/tao-core": ">=54.39.1",
     "oat-sa/extension-tao-item": ">=12.4.0",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-353

We need to add Unicode modifier for patterns for properly calculating JP symbols

For example:
```
var_dump( preg_match('/^[\s\S]{0,5}$/s', 'あいうえお')) ; // int(0)
but
var_dump( preg_match('/^[\s\S]{0,5}$/su', '12345') );   // int(1)
var_dump( preg_match('/^[\s\S]{0,5}$/su', 'abcdf') );   // int(1)
var_dump( preg_match('/^[\s\S]{0,5}$/su', 'あいうえお') ); // int(1)
```
How to test:

- Create an item and set Constraints Max Length = 5
- Publish a test with this item
- Validate that 12345, abcdf and あいうえお works