### PR TITLE
Fix/adf 1969/exclude translated properties from export and clone

### DIFF
--- a/models/classes/class.QtiTestService.php
+++ b/models/classes/class.QtiTestService.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2024 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA;
  */
 
 use oat\generis\model\data\event\ResourceCreated;
@@ -65,6 +65,7 @@ use qtism\data\storage\xml\XmlDocument;
 use qtism\data\storage\xml\XmlStorageException;
 use taoQtiTest_models_classes_import_TestImportForm as TestImportForm;
 use taoTests_models_classes_TestsService as TestService;
+use oat\taoQtiTest\models\classes\metadata\importer\TestMetadataImporter;
 
 /**
  * the QTI TestModel service.
@@ -1475,7 +1476,7 @@ class taoQtiTest_models_classes_QtiTestService extends TestService
     protected function getMetadataImporter()
     {
         if (!$this->metadataImporter) {
-            $this->metadataImporter = $this->getServiceLocator()->get(MetadataService::SERVICE_ID)->getImporter();
+            $this->metadataImporter = $this->getPsrContainer()->get(TestMetadataImporter::class);
         }
         return $this->metadataImporter;
     }

--- a/models/classes/metadata/importer/TestMetadataImporter.php
+++ b/models/classes/metadata/importer/TestMetadataImporter.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\models\classes\metadata\importer;
+
+use oat\tao\model\TaoOntology;
+use oat\taoQtiItem\model\qti\metadata\importer\MetadataImporter;
+
+class TestMetadataImporter extends MetadataImporter
+{
+    protected array $excludedProperties = [
+        TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES
+    ];
+}


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/ADF-1969

## What's Changed
Exclude translated into locales from metadata during test import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new metadata importer that excludes specific properties from import operations.

* **Chores**
  * Updated copyright year in file headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->