### PR TITLE
fix: update test and linter fix, add rulePaths for eslint

### DIFF
--- a/views/js/controller/creator/helpers/scoring.js
+++ b/views/js/controller/creator/helpers/scoring.js
@@ -338,7 +338,7 @@ define([
             addGradeOutcome(outcomes, descriptor.identifier, scoring.scalePresets);
         },
 
-        grade_max: function writerGradeMax(descriptor, scoring, outcomes, categories) {
+        grade_max: function writerGradeMax(descriptor, scoring, outcomes) {
             addGradeMaxOutcome(outcomes, descriptor.identifier, scoring.scalePresets);
         }
     };
@@ -1019,12 +1019,16 @@ define([
      */
     function detectScoring(modelOverseer) {
         var model = modelOverseer.getModel();
+        var config = modelOverseer.getConfig();
         let modes = processingModes;
         if(!features.isVisible('taoQtiTest/creator/test/property/scoring/custom')) {
             delete modes.custom;
         }
+        if (!config.scalePresets || !Array.isArray(config.scalePresets) || config.scalePresets.length === 0) {
+            delete modes.grade;
+        }
         return {
-            modes: processingModes,
+            modes: modes,
             scoreIdentifier: defaultScoreIdentifier,
             weightIdentifier: getWeightIdentifier(model),
             cutScore: getCutScore(model),


### PR DESCRIPTION
## Ticket:
- https://oat-sa.atlassian.net/browse/AUT-4288
## What's Changed
- Hide  `Lowest Grade Archived ` if no scale list available

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## How to test
- Go to Test Authoring, click test properties and open Scoring section.
- If scales aren't present in config there will be no `Lowest Grade Archived ` option
- If you set scales the option will be available
You can simulate scales by replacing [scalesPresets set block in `taoQtiTest/actions/class.Creator.php`](https://github.com/oat-sa/extension-tao-testqti/blob/7c68452d8660698e01f9c9c1f5024627505bbc32/actions/class.Creator.php#L96-L103) with 
`$this->setData(
            'scalesPresets',
            json_encode([
                [
                    'uri' => 'http://example.com/scale/1',
                    'label' => 'Test Scale 1-10',
                    'values' => ['1' => 1, '2' => 2, '3' => 3, '4' => 4, '5' => 5, '6' => 6, '7' => 7, '8' => 8, '9' => 9, '10' => 10]
                ]
            ])
        );`

## Video

https://github.com/user-attachments/assets/34b8eb75-de10-4818-827a-f813d7713ab5

