### PR TITLE
feature: extend category field, add validation for tao attachemnts

### DIFF
--- a/views/js/controller/creator/helpers/categorySelector.js
+++ b/views/js/controller/creator/helpers/categorySelector.js
@@ -40,6 +40,24 @@ define([
     let allQtiCategoriesPresets = [];
     let categoryToPreset = new Map();
 
+    /**
+     * Validates a category string.
+     * A category is valid if it's a legacy category name or
+     * has the format "x-tao-attachment-" + UUIDv4.
+     * @param {string} category - The category to validate.
+     * @returns {boolean} - True if the category is valid, false otherwise.
+     */
+    function isValidCategory(category) {
+        const genericCategoryRegex = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+        const attachmentCategoryRegex = /^x-tao-attachment-([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+
+        if (category.startsWith('x-tao-attachment-')) {
+            return attachmentCategoryRegex.test(category);
+        }
+
+        return genericCategoryRegex.test(category);
+    }
+
     function categorySelectorFactory($container) {
         const $presetsContainer = $container.find('.category-presets');
         const $customCategoriesSelect = $container.find('[name=category-custom]');
@@ -114,11 +132,11 @@ define([
                         tags: customCategories,
                         multiple: true,
                         tokenSeparators: [',', ' ', ';'],
-                        createSearchChoice: (category) => category.match(/^[a-zA-Z_][a-zA-Z0-9_-]*$/)
+                        createSearchChoice: (category) => isValidCategory(category)
                             ? { id: category, text: category }
                             : null,
                         formatNoMatches: () => __('Category name not allowed'),
-                        maximumInputLength: 32
+                        maximumInputLength: 60
                     })
                     .on('change', () => this.updateCategories());
 
@@ -225,6 +243,9 @@ define([
             }, []);
         }
     };
+
+    // exposed for testing purpose
+    categorySelectorFactory._isValidCategory = isValidCategory;
 
     return categorySelectorFactory;
 });

--- a/views/js/test/creator/helpers/categorySelector/test.js
+++ b/views/js/test/creator/helpers/categorySelector/test.js
@@ -400,4 +400,23 @@ define([
         $preset.click();
     });
 
+    QUnit.module('isValidCategory');
+
+    QUnit.cases.init([
+        { title: 'a_valid_category', expected: true },
+        { title: 'a-valid-category-123', expected: true },
+        { title: 'UPPERCASE', expected: true },
+        { title: 'x-tao-attachment-f47ac10b-58cc-4372-a567-0e02b2c3d479', expected: true },
+        { title: 'x-tao-attachment-F47AC10B-58CC-4372-A567-0E02B2C3D479', expected: true, message: 'allows uppercase UUID' },
+        { title: '-invalid-category', expected: false, message: 'does not allow starting with a dash' },
+        { title: 'invalid-category!', expected: false, message: 'does not allow special characters' },
+        { title: 'invalid category', expected: false, message: 'does not allow spaces' },
+        { title: '', expected: false, message: 'does not allow empty string' },
+        { title: 'x-tao-attachment-not-a-uuid', expected: false, message: 'does not allow invalid UUID' },
+        { title: 'x-tao-attachment-', expected: false, message: 'does not allow empty UUID' }
+    ]).test('validates categories', function (data, assert) {
+        assert.expect(1);
+        var message = data.message || (data.expected ? 'should be valid' : 'should be invalid');
+        assert.equal(categorySelectorFactory._isValidCategory(data.title), data.expected, '"' + data.title + '" ' + message);
+    });
 });


### PR DESCRIPTION
## Ticket: 
- https://oat-sa.atlassian.net/browse/AUT-4299
## What's Changed
-  Extend category field, add validation for tao attachemnts

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## Dependencies PRs
- https://github.com/oat-sa/tao-portal/pull/2826

## How to test
- Go to Test Authoring
- Create new test or use existing one (don't forget to add at least one item to new test)
- Click gears and add category `x-tao-attachment` for example `x-tao-attachment-99a57af0-0385-434c-b1e2-086184abf1e4`
- You can copy asset id from Portal but you need logic from dependency PR
- Save  

## Video

https://github.com/user-attachments/assets/9de77080-2f4b-44be-964a-362243aed4cb


