### PR TITLE
Fix: allow save permanently answer on time out 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-extension-tao-testqti
-=====================
+# extension-tao-testqti
 
 [![codecov](https://codecov.io/gh/oat-sa/extension-tao-testqti/branch/master/graph/badge.svg?token=L2pTXu17kz)](https://codecov.io/gh/oat-sa/extension-tao-testqti)
 
 Extension to create QTI tests into TAO
 
-
-About the new test runner
-=========================
+## About the new test runner
 
 The new test runner uses now a more consistent format for the config, but a mapping is made to convert the current server config to the new format. So if new entries are added to current config, the class has to be updated to support this new entry.
 
@@ -15,35 +12,36 @@ Now the review plugin is related to the item categories, so the category `x-tao-
 
 Here is a list of known category options:
 
-| Option | Description |
-| --- | --- |
-| `x-tao-option-reviewScreen` | Enable the review/navigation panel |
-| `x-tao-option-markReview` | Enable the mark for review button when the review/navigation panel is enabled |
-| `x-tao-option-exit` | Allow to finish and exit the test |
-| `x-tao-option-nextSection` | Enable the next section button |
-| `x-tao-option-nextSectionWarning` | Enable the next section button, display a confirm message |
-| `x-tao-proctored-auto-pause` | Enable autopause before entering the next section |
+| Option                            | Description                                                                   |
+| --------------------------------- | ----------------------------------------------------------------------------- |
+| `x-tao-option-reviewScreen`       | Enable the review/navigation panel                                            |
+| `x-tao-option-markReview`         | Enable the mark for review button when the review/navigation panel is enabled |
+| `x-tao-option-exit`               | Allow to finish and exit the test                                             |
+| `x-tao-option-nextSection`        | Enable the next section button                                                |
+| `x-tao-option-nextSectionWarning` | Enable the next section button, display a confirm message                     |
+| `x-tao-proctored-auto-pause`      | Enable autopause before entering the next section                             |
 
-
-REST API
-========
+## REST API
 
 [QTI Test REST API](https://editor.swagger.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Foat-sa%2Fextension-tao-testqti%2Fmaster%2Fdoc%2Fswagger.json)
 
-Results variables transmission
-==============================
+## Results variables transmission
 
 Provided by triggering corresponding events
+
 ```PHP
 oat\taoQtiTest\models\event\ResultItemVariablesTransmissionEvent::class
 oat\taoQtiTest\models\event\ResultTestVariablesTransmissionEvent::class
 ```
 
 Asynchronous handling of this event can be provided by running next command
+
 ```bash
 php index.php 'oat\taoQtiTest\scripts\tools\ResultVariableTransmissionEvenHandlerSwitcher' --class 'oat\taoQtiTest\models\classes\eventHandler\ResultTransmissionEventHandler\AsynchronousResultTransmissionEventHandler'
 ```
-or manually updating DI config file `taoQtiTest/ResultTransmissionEventHandler` by next code 
+
+or manually updating DI config file `taoQtiTest/ResultTransmissionEventHandler` by next code
+
 ```PHP
 <?php
 /**
@@ -53,11 +51,11 @@ or manually updating DI config file `taoQtiTest/ResultTransmissionEventHandler` 
 return new oat\taoQtiTest\models\classes\eventHandler\ResultTransmissionEventHandler\AsynchronousResultTransmissionEventHandler();
 ```
 
-Environment variables
-=====================
+## Environment variables
 
-| Var                                           | Description                                                                         |
-|-----------------------------------------------|-------------------------------------------------------------------------------------|
-| FEATURE_FLAG_FORCE_DISPLAY_TEST_ITEM_FEEDBACK | Even if itemSessionControl `showFeedback` option is false, show item feedback modal |
-| FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS        | When set, forces restoring the timers state from the browser storage on test init   |
+| Var                                                      | Description                                                                                                                                                                                                                                                   |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FEATURE_FLAG_FORCE_DISPLAY_TEST_ITEM_FEEDBACK            | Even if itemSessionControl `showFeedback` option is false, show item feedback modal                                                                                                                                                                           |
+| FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS                   | When set, forces restoring the timers state from the browser storage on test init                                                                                                                                                                             |
 | FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE | Typed environment variable, controlling whether a delivery execution state should be kept as is or reset each time it starts. If `"false"` the state will be reset on each restart. Default behavior. If `"true"` the state will be maintained upon a restart |
+| FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION           | When true, timeout transitions are treated as late submissions and item responses are automatically saved/persisted regardless of itemSessionControl allowLateSubmission. Default: false.                                                                     |

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -702,7 +702,7 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
                 $this->getServiceContext(),
                 $this->hasRequestParameter('start'),
                 $this->hasRequestParameter('late'),
-                (bool)$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
+                $this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
             );
 
             $this->setNavigationContextToCommand($command);

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2023 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2016-2025 (original work) Open Assessment Technologies SA.
  */
 
 /**
@@ -63,6 +63,7 @@ use oat\taoQtiTest\models\runner\StorageManager;
 use qtism\runtime\tests\AssessmentTestSessionState;
 use taoQtiTest_helpers_TestRunnerUtils as TestRunnerUtils;
 use oat\oatbox\session\SessionService;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
 
 /**
  * Class taoQtiTest_actions_Runner
@@ -697,10 +698,17 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $this->validateSecurityToken();
             $this->validateDeliveryExecutionInteractionAccessibility();
 
+            $container = $this->getServiceLocator()->getContainer();
+            $isPermanentLateSubmission = $container->has(FeatureFlagChecker::class)
+                ? $container->get(FeatureFlagChecker::class)
+                            ->isFeatureEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
+                : false;
+
             $command = new TimeoutCommand(
                 $this->getServiceContext(),
                 $this->hasRequestParameter('start'),
-                $this->hasRequestParameter('late')
+                $this->hasRequestParameter('late'),
+                $isPermanentLateSubmission
             );
 
             $this->setNavigationContextToCommand($command);

--- a/actions/class.Runner.php
+++ b/actions/class.Runner.php
@@ -698,17 +698,11 @@ class taoQtiTest_actions_Runner extends tao_actions_ServiceModule
             $this->validateSecurityToken();
             $this->validateDeliveryExecutionInteractionAccessibility();
 
-            $container = $this->getServiceLocator()->getContainer();
-            $isPermanentLateSubmission = $container->has(FeatureFlagChecker::class)
-                ? $container->get(FeatureFlagChecker::class)
-                            ->isFeatureEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
-                : false;
-
             $command = new TimeoutCommand(
                 $this->getServiceContext(),
                 $this->hasRequestParameter('start'),
                 $this->hasRequestParameter('late'),
-                $isPermanentLateSubmission
+                (bool)$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
             );
 
             $this->setNavigationContextToCommand($command);

--- a/model/Service/TimeoutCommand.php
+++ b/model/Service/TimeoutCommand.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2025 (original work) Open Assessment Technologies SA;
  *
  * @author Ricardo Quintanilha <ricardo.quintanilha@taotesting.com>
  */
@@ -35,23 +35,14 @@ final class TimeoutCommand implements
     use NavigationContextAwareTrait;
     use ToolsStateAwareTrait;
 
-    /** @var QtiRunnerServiceContext */
-    private $serviceContext;
-
-    /** @var bool */
-    private $hasStartTimer;
-
-    /** @var bool */
-    private $lateSubmissionAllowed;
+    public const FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION = 'FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION';
 
     public function __construct(
-        QtiRunnerServiceContext $serviceContext,
-        bool $hasStartTimer,
-        bool $lateSubmissionAllowed
+        private readonly QtiRunnerServiceContext $serviceContext,
+        private readonly bool $hasStartTimer,
+        private readonly bool $lateSubmissionAllowed,
+        private readonly bool $permanentLateSubmission = false,
     ) {
-        $this->serviceContext = $serviceContext;
-        $this->hasStartTimer = $hasStartTimer;
-        $this->lateSubmissionAllowed = $lateSubmissionAllowed;
     }
 
     public function getServiceContext(): QtiRunnerServiceContext
@@ -66,6 +57,6 @@ final class TimeoutCommand implements
 
     public function isLateSubmissionAllowed(): bool
     {
-        return $this->lateSubmissionAllowed;
+        return $this->lateSubmissionAllowed || $this->permanentLateSubmission;
     }
 }

--- a/models/classes/runner/synchronisation/action/Timeout.php
+++ b/models/classes/runner/synchronisation/action/Timeout.php
@@ -23,6 +23,7 @@ namespace oat\taoQtiTest\models\runner\synchronisation\action;
 use common_exception_InconsistentData as InconsistentData;
 use common_Logger;
 use Exception;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\taoQtiTest\model\Service\TimeoutCommand;
 use oat\taoQtiTest\model\Service\TimeoutService;
 use oat\taoQtiTest\models\runner\synchronisation\TestRunnerAction;
@@ -49,10 +50,17 @@ class Timeout extends TestRunnerAction
                 $this->setOffline();
             }
 
+            $container = $this->getServiceLocator()->getContainer();
+            $isPermanentLateSubmission = $container->has(FeatureFlagChecker::class)
+                ? $container->get(FeatureFlagChecker::class)
+                            ->isFeatureEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
+                : false;
+
             $command = new TimeoutCommand(
                 $this->getServiceContext(),
                 $this->hasRequestParameter('start'),
-                $this->hasRequestParameter('late')
+                $this->hasRequestParameter('late'),
+                $isPermanentLateSubmission
             );
 
             $this->setNavigationContextToCommand($command);

--- a/models/classes/runner/synchronisation/action/Timeout.php
+++ b/models/classes/runner/synchronisation/action/Timeout.php
@@ -50,17 +50,11 @@ class Timeout extends TestRunnerAction
                 $this->setOffline();
             }
 
-            $container = $this->getServiceLocator()->getContainer();
-            $isPermanentLateSubmission = $container->has(FeatureFlagChecker::class)
-                ? $container->get(FeatureFlagChecker::class)
-                            ->isFeatureEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
-                : false;
-
             $command = new TimeoutCommand(
                 $this->getServiceContext(),
                 $this->hasRequestParameter('start'),
                 $this->hasRequestParameter('late'),
-                $isPermanentLateSubmission
+                (bool)$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
             );
 
             $this->setNavigationContextToCommand($command);

--- a/models/classes/runner/synchronisation/action/Timeout.php
+++ b/models/classes/runner/synchronisation/action/Timeout.php
@@ -54,7 +54,7 @@ class Timeout extends TestRunnerAction
                 $this->getServiceContext(),
                 $this->hasRequestParameter('start'),
                 $this->hasRequestParameter('late'),
-                (bool)$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
+                $this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(TimeoutCommand::FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION)
             );
 
             $this->setNavigationContextToCommand($command);

--- a/test/unit/model/Service/TimeoutServiceTest.php
+++ b/test/unit/model/Service/TimeoutServiceTest.php
@@ -37,19 +37,29 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class TimeoutServiceTest extends TestCase
 {
-    /** @var TimeoutService */
+    /**
+     * @var TimeoutService
+     */
     private $subject;
 
-    /** @var RunnerService|MockObject */
+    /**
+     * @var RunnerService|MockObject
+     */
     private $runnerService;
 
-    /** @var RunnerServiceContext|MockObject */
+    /**
+     * @var RunnerServiceContext|MockObject
+     */
     private $serviceContext;
 
-    /** @var ItemResponseRepositoryInterface|MockObject */
+    /**
+     * @var ItemResponseRepositoryInterface|MockObject
+     */
     private $itemResponseRepository;
 
-    /** @var ToolsStateRepositoryInterface|MockObject */
+    /**
+     * @var ToolsStateRepositoryInterface|MockObject
+     */
     private $toolsStateRepository;
 
     protected function setUp(): void
@@ -116,6 +126,19 @@ class TimeoutServiceTest extends TestCase
         $this->expectTestContext(['itemIdentifier' => 'item-2']);
 
         $this->itemResponseRepository->expects($this->never())
+            ->method('save');
+
+        $this->executeAction();
+    }
+
+    public function testSkipsItemResponseWithAutoSaveOnTimeout(): void
+    {
+        $this->expectTestContext(['itemIdentifier' => 'item-2']);
+        $this->featureFlagChecker->method('isFeatureEnabled')
+            ->with('FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION')
+            ->willReturn(true);
+
+        $this->itemResponseRepository->expects($this->once())
             ->method('save');
 
         $this->executeAction();
@@ -210,9 +233,17 @@ class TimeoutServiceTest extends TestCase
             ->willReturn($testMap);
     }
 
-    private function createCommand(bool $hastStartTimer = false, bool $lateSubmissionAllowed = false): TimeoutCommand
-    {
-        $command = new TimeoutCommand($this->serviceContext, $hastStartTimer, $lateSubmissionAllowed);
+    private function createCommand(
+        bool $hasStartTimer = false,
+        bool $lateSubmissionAllowed = false,
+        bool $permanentLateSubmission =  false
+    ): TimeoutCommand {
+        $command = new TimeoutCommand(
+            $this->serviceContext,
+            $hasStartTimer,
+            $lateSubmissionAllowed,
+            $permanentLateSubmission
+        );
 
         $command->setNavigationContext('', 'item', null);
 

--- a/test/unit/model/Service/TimeoutServiceTest.php
+++ b/test/unit/model/Service/TimeoutServiceTest.php
@@ -134,7 +134,7 @@ class TimeoutServiceTest extends TestCase
     public function testSkipsItemResponseWithAutoSaveOnTimeout(): void
     {
         $this->expectTestContext(['itemIdentifier' => 'item-2']);
-        $this->featureFlagChecker->method('isFeatureEnabled')
+        $this->featureFlagChecker->method('isEnabled')
             ->with('FEATURE_FLAG_TIMEOUT_PERMANENT_LATE_SUBMISSION')
             ->willReturn(true);
 


### PR DESCRIPTION
#  Allow save permanently answer on time out [TR-6647](https://oat-sa.atlassian.net/browse/TR-6647)

## Description
This PR allow to save answer on timeout inspire of lateSubmission settings on itme. 
This PR is trying to return expected behaviour for Infosign when they move via test without external interaction just with put answer and wait timeout 


## Demo
https://github.com/user-attachments/assets/75b17138-5b6d-4d15-9708-816ea222e09c



[TR-6647]: https://oat-sa.atlassian.net/browse/TR-6647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a feature flag to allow permanent late submissions during timeout.
- Documentation
  - Refreshed README formatting (headings, tables) for clarity.
  - Added documentation for a new environment variable controlling permanent late submissions on timeout.
- Tests
  - Added test coverage for timeout behavior when the new feature flag is enabled.
- Chores
  - Updated copyright years across modified files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->