### PR TITLE
fix: AUT-4485 remove checksum dependency in taoQtiTest metadata export

### DIFF
--- a/models/classes/metadata/MetadataServiceProvider.php
+++ b/models/classes/metadata/MetadataServiceProvider.php
@@ -26,7 +26,6 @@ use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\model\GenerisRdf;
 use oat\generis\model\WidgetRdf;
-use oat\taoQtiItem\model\import\ChecksumGenerator;
 use oat\taoQtiTest\models\classes\metadata\metaMetadata\PropertyMapper;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -42,7 +41,6 @@ class MetadataServiceProvider implements ContainerServiceProviderInterface
 
         $services->set(PropertyMapper::class, PropertyMapper::class)
             ->args([
-                service(ChecksumGenerator::class),
                 [
                     'label' => RDFS_LABEL,
                     'domain' => RDFS_DOMAIN,

--- a/models/classes/metadata/metaMetadata/PropertyMapper.php
+++ b/models/classes/metadata/metaMetadata/PropertyMapper.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2024-2026 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -24,21 +24,14 @@ namespace oat\taoQtiTest\models\classes\metadata\metaMetadata;
 
 use core_kernel_classes_Property as Property;
 use core_kernel_classes_Resource as Resource;
-use oat\generis\model\OntologyRdf;
-use oat\taoQtiItem\model\import\ChecksumGenerator;
-use taoTests_models_classes_TestsService;
 
 class PropertyMapper
 {
-    public const DATATYPE_CHECKSUM = 'checksum';
-
     private array $metaMetadataCollectionToExport;
-    private ChecksumGenerator $checksumGenerator;
 
-    public function __construct(ChecksumGenerator $checksumGenerator, array $metaMetadataCollectionToExport)
+    public function __construct(array $metaMetadataCollectionToExport)
     {
         $this->metaMetadataCollectionToExport = $metaMetadataCollectionToExport;
-        $this->checksumGenerator = $checksumGenerator;
     }
 
     public function getMetadataProperties(Property $property): array
@@ -50,29 +43,11 @@ class PropertyMapper
             $metaProperty = $property->getOnePropertyValue(new Property($stringProperty));
             if ($metaProperty !== null) {
                 $fields[$key] = $metaProperty instanceof Resource
-                        ? $metaProperty->getUri()
-                        : (string) $metaProperty;
+                    ? $metaProperty->getUri()
+                    : (string) $metaProperty;
             }
         }
 
-        if (!$this->isIgnoredForCollectionGathering($property)) {
-            $fields[self::DATATYPE_CHECKSUM] = $this->checksumGenerator->getRangeChecksum($property);
-        }
-
         return $fields;
-    }
-
-    private function isIgnoredForCollectionGathering(Property $property): bool
-    {
-        return in_array($property->getUri(), $this->getIgnoredProperties()) || $property->getRange() === null;
-    }
-
-    private function getIgnoredProperties(): array
-    {
-        return [
-            OntologyRdf::RDF_TYPE,
-            taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL,
-            RDFS_LABEL
-        ];
     }
 }

--- a/test/unit/models/classes/metadata/metaMetadata/PropertyMapperTest.php
+++ b/test/unit/models/classes/metadata/metaMetadata/PropertyMapperTest.php
@@ -26,19 +26,15 @@ use core_kernel_classes_Literal;
 use core_kernel_classes_Property as Property;
 use core_kernel_classes_Resource as Resource;
 use oat\generis\model\GenerisRdf;
-use oat\taoQtiItem\model\import\ChecksumGenerator;
 use oat\taoQtiTest\models\classes\metadata\metaMetadata\PropertyMapper;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PropertyMapperTest extends TestCase
 {
-    private ChecksumGenerator|MockObject $checksumGeneratorMock;
     private PropertyMapper $subject;
 
     public function setUp(): void
     {
-        $this->checksumGeneratorMock = $this->createMock(ChecksumGenerator::class);
         $metaMetadataCollectionToExport = [
             'label' => RDFS_LABEL,
             'domain' => RDFS_DOMAIN,
@@ -46,7 +42,7 @@ class PropertyMapperTest extends TestCase
             'multiple' => GenerisRdf::PROPERTY_MULTIPLE
         ];
 
-        $this->subject  = new PropertyMapper($this->checksumGeneratorMock, $metaMetadataCollectionToExport);
+        $this->subject = new PropertyMapper($metaMetadataCollectionToExport);
     }
 
     public function testGetMetadataProperties(): void
@@ -54,7 +50,6 @@ class PropertyMapperTest extends TestCase
         $property = $this->createMock(Property::class);
         $resourceMock = $this->createMock(Resource::class);
         $property->method('getUri')->willReturn('uri');
-        $property->method('getRange')->willReturn('range');
         $resourceMock->method('getUri')->willReturn('resource_uri');
 
         $property
@@ -66,11 +61,6 @@ class PropertyMapperTest extends TestCase
                 null
             );
 
-        $this->checksumGeneratorMock
-            ->method('getRangeChecksum')
-            ->willReturn('c315a4bd4fa0f4479b1ea4b5998aa548eed3b670');
-
-
         $result = $this->subject->getMetadataProperties($property);
 
         $this->assertIsArray($result);
@@ -79,11 +69,9 @@ class PropertyMapperTest extends TestCase
         $this->assertArrayHasKey('domain', $result);
         $this->assertArrayHasKey('alias', $result);
         $this->assertArrayNotHasKey('multiple', $result);
-        $this->assertArrayHasKey(PropertyMapper::DATATYPE_CHECKSUM, $result);
         $this->assertEquals('uri', $result['uri']);
         $this->assertEquals('resource_uri', $result['label']);
         $this->assertEquals('value', $result['domain']);
         $this->assertEquals('literal_value', $result['alias']);
-        $this->assertEquals('c315a4bd4fa0f4479b1ea4b5998aa548eed3b670', $result['checksum']);
     }
 }


### PR DESCRIPTION
## Summary
- Backport AUT-4485 metadata export compatibility by removing direct dependency on the removed `ChecksumGenerator` service.
- Simplify `PropertyMapper` constructor and mapping output to avoid generating checksum metadata.
- Update service wiring and unit tests so container compilation succeeds on v49.2.9 line.