### PR TITLE
fix: load mathjax module

### DIFF
--- a/views/js/controller/runner/runner.js
+++ b/views/js/controller/runner/runner.js
@@ -35,7 +35,8 @@ define([
     'util/locale',
     'taoTests/runner/providerLoader',
     'taoTests/runner/runner',
-    'css!taoQtiTestCss/new-test-runner'
+    'css!taoQtiTestCss/new-test-runner',
+    'mathJax'
 ], function (
     $,
     _,
@@ -49,7 +50,8 @@ define([
     urlUtil,
     locale,
     providerLoader,
-    runner
+    runner,
+    MathJax
 ) {
     'use strict';
 
@@ -83,6 +85,8 @@ define([
          * @param {Object[]} config.providers - the collection of providers to load
          */
         start(config) {
+            MathJax && logger.debug('MathJax loaded'); // if loaded mathML would be rendered using it
+
             let exitReason;
             const $container = $('.runner');
 

--- a/views/js/controller/runner/runner.js
+++ b/views/js/controller/runner/runner.js
@@ -85,8 +85,6 @@ define([
          * @param {Object[]} config.providers - the collection of providers to load
          */
         start(config) {
-            MathJax && logger.debug('MathJax loaded'); // if loaded mathML would be rendered using it
-
             let exitReason;
             const $container = $('.runner');
 
@@ -94,6 +92,8 @@ define([
                 serviceCallId : config.serviceCallId,
                 plugins : config && config.providers && Object.keys(config.providers.plugins)
             });
+
+            MathJax && logger.debug('MathJax loaded'); // if loaded mathML would be rendered using it
 
             let preventFeedback = false;
             let errorFeedback = null;


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INF-470

## What's Changed
- Load MathJax module for correct mathML rendering https://github.com/oat-sa/extension-tao-itemqti-pci/pull/487/changes#diff-e280309b54450e44de30df69a48538de2e920e1d55b08e484baaf19f5b0bc8c3R55

>>
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful- [ ] 

## How to test
- Same as in https://github.com/oat-sa/extension-tao-itemqti-pci/pull/487 but run CG test runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated MathJax support for rendering mathematical equations and notation in the application.

* **Improvements**
  * Added a startup message when math rendering is available to make initialization status clearer in runtime logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->