### PR TITLE
fix/INV-1203: regenerate text reader images when asset updated

### DIFF
--- a/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
+++ b/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
@@ -97,17 +97,11 @@ class TextReaderPostProcessor implements CustomInteractionPostProcessorInterface
 
     private function normalizePages($pages): array
     {
-        if (is_array($pages)) {
-            return $pages;
+        try {
+            return json_decode($pages, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $_) {
+            return is_array($pages) ? $pages : [];
         }
-
-        if (!is_string($pages) || $pages === '') {
-            return [];
-        }
-
-        $decoded = json_decode($pages, true);
-
-        return is_array($decoded) ? $decoded : [];
     }
 
     private function extractContentUrls(array $properties): array

--- a/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
+++ b/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
@@ -97,10 +97,17 @@ class TextReaderPostProcessor implements CustomInteractionPostProcessorInterface
 
     private function normalizePages($pages): array
     {
+        if (is_array($pages)) {
+            return $pages;
+        }
+        if (!is_string($pages)) {
+            return [];
+        }
         try {
-            return json_decode($pages, true, 512, JSON_THROW_ON_ERROR);
+            $decoded = json_decode($pages, true, 512, JSON_THROW_ON_ERROR);
+            return is_array($decoded) ? $decoded : [];
         } catch (\JsonException $_) {
-            return is_array($pages) ? $pages : [];
+            return [];
         }
     }
 

--- a/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
+++ b/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessor.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor;
 
+use DOMDocument;
 use oat\taoItems\model\render\ItemAssetsReplacement;
 use oat\taoQtiTest\models\classes\render\CustomInteraction\PostProcessor\Api\CustomInteractionPostProcessorInterface;
 
@@ -45,7 +46,119 @@ class TextReaderPostProcessor implements CustomInteractionPostProcessorInterface
                 $value = $this->itemAssetsReplacement->postProcessAssets($value);
             }
         }
+        unset($value);
+
+        $element['properties'] = $this->replaceImageSourcesInPages($element['properties']);
 
         return $element;
+    }
+
+    private function replaceImageSourcesInPages(array $properties): array
+    {
+        if (!isset($properties['pages'])) {
+            return $properties;
+        }
+
+        $pages = $this->normalizePages($properties['pages']);
+        if ($pages === []) {
+            return $properties;
+        }
+
+        $contentUrls = $this->extractContentUrls($properties);
+        if ($contentUrls === []) {
+            return $properties;
+        }
+
+        $updatedPages = [];
+
+        foreach ($pages as $page) {
+            if (!isset($page['content']) || !is_array($page['content'])) {
+                $updatedPages[] = $page;
+                continue;
+            }
+
+            foreach ($page['content'] as $index => $content) {
+                if (!is_string($content) || $content === '') {
+                    continue;
+                }
+
+                $page['content'][$index] = $this->replaceImageSourcesInContent($content, $contentUrls);
+            }
+
+            $updatedPages[] = $page;
+        }
+
+        $properties['pages'] = is_string($properties['pages'])
+            ? json_encode($updatedPages)
+            : $updatedPages;
+
+        return $properties;
+    }
+
+    private function normalizePages($pages): array
+    {
+        if (is_array($pages)) {
+            return $pages;
+        }
+
+        if (!is_string($pages) || $pages === '') {
+            return [];
+        }
+
+        $decoded = json_decode($pages, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function extractContentUrls(array $properties): array
+    {
+        return array_values(
+            array_filter(
+                $properties,
+                static fn ($value, $key): bool => strpos((string) $key, self::CONTENT_PREFIX) === 0
+                    && is_string($value)
+                    && $value !== '',
+                ARRAY_FILTER_USE_BOTH
+            )
+        );
+    }
+
+    private function replaceImageSourcesInContent(string $content, array &$contentUrls): string
+    {
+        if ($contentUrls === []) {
+            return $content;
+        }
+
+        $previousState = libxml_use_internal_errors(true);
+
+        try {
+            $dom = new DOMDocument();
+            $dom->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $content);
+            libxml_clear_errors();
+
+            foreach ($dom->getElementsByTagName('img') as $image) {
+                $replacement = array_shift($contentUrls);
+                if ($replacement === null) {
+                    break;
+                }
+
+                $image->setAttribute('src', $replacement);
+            }
+
+            $body = $dom->getElementsByTagName('body')->item(0);
+            if ($body === null) {
+                return $content;
+            }
+
+            $result = '';
+            foreach ($body->childNodes as $childNode) {
+                $result .= $dom->saveHTML($childNode);
+            }
+
+            return $result;
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousState);
+        }
     }
 }

--- a/test/unit/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessorTest.php
+++ b/test/unit/models/classes/render/CustomInteraction/PostProcessor/TextReaderPostProcessorTest.php
@@ -91,6 +91,32 @@ class TextReaderPostProcessorTest extends TestCase
                     'second' => 'second',
                     'third' => 'third',
                 ]
+            ],
+            'Replace pages image sources with content urls' => [
+                [
+                    'pages' => json_encode([
+                        [
+                            'content' => [
+                                '<img src="assets/cat.jpg" alt="cat" /> page 1',
+                                '<img src="assets/dog.jpg" alt="dog" /> page 2',
+                            ],
+                        ],
+                    ]),
+                    self::CONTENT_PREFIX . 'first' => uniqid(self::CONTENT_PREFIX, true),
+                    self::CONTENT_PREFIX . 'second' => uniqid(self::CONTENT_PREFIX, true),
+                ],
+                [
+                    'pages' => json_encode([
+                        [
+                            'content' => [
+                                '<img src="' . self::CONTENT_REPLACER . '" alt="cat"> page 1',
+                                '<img src="' . self::CONTENT_REPLACER . '" alt="dog"> page 2',
+                            ],
+                        ],
+                    ]),
+                    self::CONTENT_PREFIX . 'first' => self::CONTENT_REPLACER,
+                    self::CONTENT_PREFIX . 'second' => self::CONTENT_REPLACER,
+                ]
             ]
         ];
     }


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/INV-1203

## What's Changed
Fixes an issue where text reader images wouldn't update after their corresponding assets were changed.

## Dependencies PRs
- https://github.com/oat-sa/extension-tao-itemqti/pull/3005
- https://github.com/oat-sa/tao-deliver-be/pull/1689
- https://github.com/oat-sa/extension-tao-mediamanager/pull/567

## How to test
1. Upload an image to the Assets section in backoffice.
2. Create a Text Reader interaction from Custom Interactions and insert this image asset from the toolbar.
3. Create a test with this item, and publish the test.
4. Click Replace Asset and upload a different image for this image in Assets.
5. The image should now be replaced in item and test previews, and in deliveries after republishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Text reader pages now correctly replace embedded image sources with their resolved content URLs so linked images display as expected.
  * Improved HTML parsing and re-serialization to handle edge cases, preserve page content structure, and avoid broken or missing images.
  * Increased reliability of page content rendering when pages include mixed or serialized content formats, reducing display inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->