### PR TITLE
[AUT-4560] fix: added width property fallback for select2 dropdown

### DIFF
--- a/views/js/controller/creator/templates/test-props.tpl
+++ b/views/js/controller/creator/templates/test-props.tpl
@@ -164,7 +164,7 @@
                 <label for="test-outcome-processing">{{__ 'Outcome processing'}}</label>
             </div>
             <div class="col-6">
-                <select name="test-outcome-processing" class="select2" data-bind="scoring.outcomeProcessing" data-bind-encoder="string" data-has-search="false">
+                <select name="test-outcome-processing" class="select2" data-width="100%" data-bind="scoring.outcomeProcessing" data-bind-encoder="string" data-has-search="false">
                 {{#each modes}}
                     <option value="{{key}}" {{#if selected}}selected="selected"{{/if}}>{{label}}</option>
                 {{/each}}


### PR DESCRIPTION
## Ticket: https://oat-sa.atlassian.net/browse/AUT-4560

## What's Changed
- Additional property in template for control overwritten select2 config

<img width="1840" height="972" alt="chrome_mKbvscBLAt" src="https://github.com/user-attachments/assets/b71ac4f4-124c-4c2c-80c4-0291ea060a01" />


> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/..

## How to test
- Tests > Manage test properties > Scoring > Outcome processing
- Outcome processing DD width should be 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustment with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->