### PR TITLE
fix: fix next section validating

### DIFF
--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -675,18 +675,13 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule
         if ($this->beforeAction()) {
             $session = $this->getTestSession();
 
-            if (!taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session)) {
-                taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
+            try {
+                taoQtiTest_helpers_TestRunnerUtils::assertNextSectionAllowed(
                     $session,
                     null,
-                    __CLASS__ . '::nextSection'
+                    $this->getRequestParameter('serviceCallId')
                 );
-                $this->notifyError(__('Next section navigation is not allowed.'), 403);
 
-                return;
-            }
-
-            try {
                 $session->moveNextAssessmentSection();
 
                 if (
@@ -697,6 +692,10 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule
                 }
             } catch (AssessmentTestSessionException $e) {
                 $this->handleAssessmentTestSessionException($e);
+            } catch (common_exception_Unauthorized $e) {
+                $this->notifyError($e->getMessage(), 403);
+
+                return;
             }
 
             $this->afterAction();

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -675,6 +675,17 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule
         if ($this->beforeAction()) {
             $session = $this->getTestSession();
 
+            if (!taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session)) {
+                taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
+                    $session,
+                    null,
+                    __CLASS__ . '::nextSection'
+                );
+                $this->notifyError(__('Next section navigation is not allowed.'), 403);
+
+                return;
+            }
+
             try {
                 $session->moveNextAssessmentSection();
 

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -332,6 +332,86 @@ class taoQtiTest_helpers_TestRunnerUtils
     }
 
     /**
+     * Whether the candidate is allowed to navigate to the next assessment section.
+     * Requires the next-section feature flag and a matching QTI category on the current item.
+     *
+     * @param AssessmentTestSession $session
+     * @param RunnerServiceContext|null $context
+     * @return boolean
+     */
+    public static function isNextSectionAllowed(AssessmentTestSession $session, RunnerServiceContext $context = null)
+    {
+        return self::getNextSectionDenialReason($session, $context) === null;
+    }
+
+    /**
+     * @return string|null denial reason, or null when next section navigation is allowed
+     */
+    public static function getNextSectionDenialReason(
+        AssessmentTestSession $session,
+        RunnerServiceContext $context = null
+    ) {
+        $nextSectionEnabled = false;
+
+        if ($context !== null && $context->getTestConfig() !== null) {
+            $nextSectionEnabled = !empty($context->getTestConfig()->getConfigValue('nextSection'));
+        } else {
+            $config = common_ext_ExtensionsManager::singleton()
+                ->getExtensionById('taoQtiTest')
+                ->getConfig('testRunner');
+            $nextSectionEnabled = !empty($config['next-section']);
+        }
+
+        if (!$nextSectionEnabled) {
+            return 'feature-disabled';
+        }
+
+        $categories = self::getCategories($session, $context);
+
+        if (
+            in_array('x-tao-option-nextSection', $categories, true)
+            || in_array('x-tao-option-nextSectionWarning', $categories, true)
+        ) {
+            return null;
+        }
+
+        return 'missing-category';
+    }
+
+    /**
+     * Log rejected next-section navigation attempts for monitoring and investigation.
+     */
+    public static function logNextSectionDeniedAttempt(
+        AssessmentTestSession $session,
+        RunnerServiceContext $context = null,
+        $source = 'unknown'
+    ) {
+        $reason = self::getNextSectionDenialReason($session, $context);
+
+        if ($reason === null) {
+            return;
+        }
+
+        $executionUri = $context !== null ? $context->getTestExecutionUri() : null;
+        $categories = self::getCategories($session, $context);
+        $itemRef = $session->getCurrentAssessmentItemRef();
+        $section = $session->getCurrentAssessmentSection();
+
+        common_Logger::w(
+            sprintf(
+                'Next section navigation rejected (%s): reason=%s item=%s section=%s execution=%s categories=[%s]',
+                $source,
+                $reason,
+                $itemRef !== null ? $itemRef->getIdentifier() : 'n/a',
+                $section !== null ? $section->getIdentifier() : 'n/a',
+                $executionUri ?? 'n/a',
+                implode(',', $categories)
+            ),
+            ['nextSection', 'navigation-rejected']
+        );
+    }
+
+    /**
      * Whether or not the candidate's response is validated
      *
      * @param AssessmentTestSession $session A given AssessmentTestSession object.

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -38,6 +38,7 @@ use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
 use qtism\common\datatypes\QtiString;
 use oat\oatbox\service\ServiceManager;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
+use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 
 /**
 * Utility methods for the QtiTest Test Runner.
@@ -390,9 +391,11 @@ class taoQtiTest_helpers_TestRunnerUtils
             return;
         }
 
-        $executionUri = $deliveryExecutionUri
-            ?? ($context !== null ? $context->getTestExecutionUri() : null)
-            ?? 'n/a';
+        $executionUri = $deliveryExecutionUri;
+        if ($executionUri === null && $context instanceof QtiRunnerServiceContext) {
+            $executionUri = $context->getTestExecutionUri();
+        }
+        $executionUri = $executionUri ?? 'n/a';
 
         common_Logger::w(
             sprintf('Next section navigation is not allowed for delivery execution %s', $executionUri),

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -379,36 +379,27 @@ class taoQtiTest_helpers_TestRunnerUtils
     }
 
     /**
-     * Log rejected next-section navigation attempts for monitoring and investigation.
+     * @throws common_exception_Unauthorized
      */
-    public static function logNextSectionDeniedAttempt(
+    public static function assertNextSectionAllowed(
         AssessmentTestSession $session,
         RunnerServiceContext $context = null,
-        $source = 'unknown'
-    ) {
-        $reason = self::getNextSectionDenialReason($session, $context);
-
-        if ($reason === null) {
+        ?string $deliveryExecutionUri = null
+    ): void {
+        if (self::isNextSectionAllowed($session, $context)) {
             return;
         }
 
-        $executionUri = $context !== null ? $context->getTestExecutionUri() : null;
-        $categories = self::getCategories($session, $context);
-        $itemRef = $session->getCurrentAssessmentItemRef();
-        $section = $session->getCurrentAssessmentSection();
+        $executionUri = $deliveryExecutionUri
+            ?? ($context !== null ? $context->getTestExecutionUri() : null)
+            ?? 'n/a';
 
         common_Logger::w(
-            sprintf(
-                'Next section navigation rejected (%s): reason=%s item=%s section=%s execution=%s categories=[%s]',
-                $source,
-                $reason,
-                $itemRef !== null ? $itemRef->getIdentifier() : 'n/a',
-                $section !== null ? $section->getIdentifier() : 'n/a',
-                $executionUri ?? 'n/a',
-                implode(',', $categories)
-            ),
-            ['nextSection', 'navigation-rejected']
+            sprintf('Next section navigation is not allowed for delivery execution %s', $executionUri),
+            ['nextSection']
         );
+
+        throw new common_exception_Unauthorized(__('Next section navigation is not allowed.'));
     }
 
     /**

--- a/models/classes/runner/navigation/QtiRunnerNavigation.php
+++ b/models/classes/runner/navigation/QtiRunnerNavigation.php
@@ -26,6 +26,7 @@ use common_Exception;
 use common_exception_InconsistentData;
 use common_exception_InvalidArgumentType;
 use common_exception_NotImplemented;
+use common_exception_Unauthorized;
 use common_Logger;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
@@ -104,6 +105,17 @@ class QtiRunnerNavigation
         /* @var ?AssessmentTestSession $session */
         $session = $context->getTestSession();
         $navigator = self::getNavigator($direction, $scope);
+
+        if ($direction === 'next' && $scope === 'section') {
+            if (!\taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session, $context)) {
+                \taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
+                    $session,
+                    $context,
+                    self::class . '::move'
+                );
+                throw new common_exception_Unauthorized(__('Next section navigation is not allowed.'));
+            }
+        }
 
         if (self::isSessionSuspended($context) || self::isExecutionPaused($context)) {
             self::getLogger()->logDebug(

--- a/models/classes/runner/navigation/QtiRunnerNavigation.php
+++ b/models/classes/runner/navigation/QtiRunnerNavigation.php
@@ -26,7 +26,6 @@ use common_Exception;
 use common_exception_InconsistentData;
 use common_exception_InvalidArgumentType;
 use common_exception_NotImplemented;
-use common_exception_Unauthorized;
 use common_Logger;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
@@ -107,14 +106,7 @@ class QtiRunnerNavigation
         $navigator = self::getNavigator($direction, $scope);
 
         if ($direction === 'next' && $scope === 'section') {
-            if (!\taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session, $context)) {
-                \taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
-                    $session,
-                    $context,
-                    self::class . '::move'
-                );
-                throw new common_exception_Unauthorized(__('Next section navigation is not allowed.'));
-            }
+            \taoQtiTest_helpers_TestRunnerUtils::assertNextSectionAllowed($session, $context);
         }
 
         if (self::isSessionSuspended($context) || self::isExecutionPaused($context)) {

--- a/test/unit/helpers/IsNextSectionAllowedTest.php
+++ b/test/unit/helpers/IsNextSectionAllowedTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\helpers;
+
+use oat\generis\test\TestCase;
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
+use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
+use oat\taoQtiTest\models\runner\session\TestSession;
+use qtism\common\collections\StringCollection;
+use qtism\data\AssessmentItemRef;
+use taoQtiTest_helpers_TestRunnerUtils as TestRunnerUtils;
+
+class IsNextSectionAllowedTest extends TestCase
+{
+    public function testReturnsFalseWhenFeatureDisabled(): void
+    {
+        $session = $this->createSessionMock([]);
+        $context = $this->createContextMock(false, ['x-tao-option-nextSection']);
+
+        $this->assertFalse(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertSame('feature-disabled', TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    public function testReturnsFalseWhenFeatureEnabledButNoCategory(): void
+    {
+        $session = $this->createSessionMock([]);
+        $context = $this->createContextMock(true, []);
+
+        $this->assertFalse(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertSame('missing-category', TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    public function testReturnsTrueWhenFeatureEnabledWithNextSectionCategory(): void
+    {
+        $session = $this->createSessionMock(['x-tao-option-nextSection']);
+        $context = $this->createContextMock(true, ['x-tao-option-nextSection']);
+
+        $this->assertTrue(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertNull(TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    public function testReturnsTrueWhenFeatureEnabledWithNextSectionWarningCategory(): void
+    {
+        $session = $this->createSessionMock(['x-tao-option-nextSectionWarning']);
+        $context = $this->createContextMock(true, ['x-tao-option-nextSectionWarning']);
+
+        $this->assertTrue(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertNull(TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    private function createSessionMock(array $categories): TestSession
+    {
+        $itemRef = $this->createMock(AssessmentItemRef::class);
+        $itemRef
+            ->method('getCategories')
+            ->willReturn(new StringCollection($categories));
+
+        $session = $this->createMock(TestSession::class);
+        $session
+            ->method('getCurrentAssessmentItemRef')
+            ->willReturn($itemRef);
+
+        return $session;
+    }
+
+    private function createContextMock(bool $nextSectionEnabled, array $categories): QtiRunnerServiceContext
+    {
+        $testConfig = $this->createMock(RunnerConfig::class);
+        $testConfig
+            ->method('getConfigValue')
+            ->with('nextSection')
+            ->willReturn($nextSectionEnabled);
+
+        $itemRef = $this->createMock(AssessmentItemRef::class);
+        $itemRef
+            ->method('getCategories')
+            ->willReturn(new StringCollection($categories));
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context
+            ->method('getTestConfig')
+            ->willReturn($testConfig);
+        $context
+            ->method('getCurrentAssessmentItemRef')
+            ->willReturn($itemRef);
+
+        return $context;
+    }
+}

--- a/test/unit/models/classes/runner/navigation/QtiRunnerNavigationNextSectionTest.php
+++ b/test/unit/models/classes/runner/navigation/QtiRunnerNavigationNextSectionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\models\classes\runner\navigation;
+
+use oat\generis\test\TestCase;
+use oat\taoQtiTest\models\runner\navigation\QtiRunnerNavigationNextSection;
+use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
+use oat\taoQtiTest\models\runner\session\TestSession;
+
+class QtiRunnerNavigationNextSectionTest extends TestCase
+{
+    public function testMoveAdvancesToNextSection(): void
+    {
+        $testSession = $this->createMock(TestSession::class);
+        $testSession
+            ->expects($this->once())
+            ->method('moveNextAssessmentSection');
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context
+            ->method('getTestSession')
+            ->willReturn($testSession);
+
+        $navigator = new QtiRunnerNavigationNextSection();
+
+        $this->assertTrue($navigator->move($context, null));
+    }
+}

--- a/test/unit/models/classes/runner/navigation/QtiRunnerNavigationTest.php
+++ b/test/unit/models/classes/runner/navigation/QtiRunnerNavigationTest.php
@@ -24,12 +24,16 @@ use oat\generis\test\TestCase;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use oat\taoQtiTest\models\runner\navigation\QtiRunnerNavigation;
 use oat\taoQtiTest\models\runner\QtiRunnerPausedException;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use qtism\runtime\tests\AssessmentTestSessionState;
+use qtism\common\collections\StringCollection;
+use qtism\data\AssessmentItemRef;
 use common_Logger;
+use common_exception_Unauthorized;
 use core_kernel_classes_Resource;
 
 class QtiRunnerNavigationTest extends TestCase
@@ -111,5 +115,51 @@ class QtiRunnerNavigationTest extends TestCase
         $this->expectException(QtiRunnerPausedException::class);
 
         QtiRunnerNavigation::move('next', 'item', $context, 'ref');
+    }
+
+    public function testMoveNextSectionRejectedWhenNotAllowed(): void
+    {
+        $testSession = $this->createMock(TestSession::class);
+        $testSession
+            ->expects($this->never())
+            ->method('moveNextAssessmentSection');
+        $testSession
+            ->method('getState')
+            ->willReturn(AssessmentTestSessionState::INTERACTING);
+
+        $context = $this->createNextSectionContext(false, ['x-tao-option-nextSection']);
+        $context
+            ->method('getTestSession')
+            ->willReturn($testSession);
+
+        QtiRunnerNavigation::setLogger($this->createMock(common_Logger::class));
+
+        $this->expectException(common_exception_Unauthorized::class);
+
+        QtiRunnerNavigation::move('next', 'section', $context, null);
+    }
+
+    private function createNextSectionContext(bool $nextSectionEnabled, array $categories): QtiRunnerServiceContext
+    {
+        $testConfig = $this->createMock(RunnerConfig::class);
+        $testConfig
+            ->method('getConfigValue')
+            ->with('nextSection')
+            ->willReturn($nextSectionEnabled);
+
+        $itemRef = $this->createMock(AssessmentItemRef::class);
+        $itemRef
+            ->method('getCategories')
+            ->willReturn(new StringCollection($categories));
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context
+            ->method('getTestConfig')
+            ->willReturn($testConfig);
+        $context
+            ->method('getCurrentAssessmentItemRef')
+            ->willReturn($itemRef);
+
+        return $context;
     }
 }


### PR DESCRIPTION
Summary
Adds server-side validation for next-section navigation (INF-461). The frontend hides the button via CSS/categories, but the backend previously executed moveNextAssessmentSection without checking whether the feature was enabled.

Validation mirrors the frontend plugin: next-section config must be on and the current item must have x-tao-option-nextSection or x-tao-option-nextSectionWarning. Rejected requests return 403 and do not advance the session.
Video: https://oat-sa.atlassian.net/browse/INF-461?focusedCommentId=376485



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added next-section navigation eligibility checks, gated by a feature flag and supported item categories.
* **Bug Fixes**
  * Prevented advancing to the next assessment section when navigation is not allowed, returning an error response instead.
* **Monitoring**
  * Added warning logging when next-section navigation is denied, including execution context when available.
* **Tests**
  * Added unit tests for allow/deny decision logic and for rejecting next-section navigation when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->