### PR TITLE
fix: INF-461 + INF-458 backport for v49.0.13

### DIFF
--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -675,18 +675,13 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule
         if ($this->beforeAction()) {
             $session = $this->getTestSession();
 
-            if (!taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session)) {
-                taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
+            try {
+                taoQtiTest_helpers_TestRunnerUtils::assertNextSectionAllowed(
                     $session,
                     null,
-                    __CLASS__ . '::nextSection'
+                    $this->getRequestParameter('serviceCallId')
                 );
-                $this->notifyError(__('Next section navigation is not allowed.'), 403);
 
-                return;
-            }
-
-            try {
                 $session->moveNextAssessmentSection();
 
                 if (
@@ -697,6 +692,10 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule
                 }
             } catch (AssessmentTestSessionException $e) {
                 $this->handleAssessmentTestSessionException($e);
+            } catch (common_exception_Unauthorized $e) {
+                $this->notifyError($e->getMessage(), 403);
+
+                return;
             }
 
             $this->afterAction();

--- a/actions/class.TestRunner.php
+++ b/actions/class.TestRunner.php
@@ -675,6 +675,17 @@ class taoQtiTest_actions_TestRunner extends tao_actions_ServiceModule
         if ($this->beforeAction()) {
             $session = $this->getTestSession();
 
+            if (!taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session)) {
+                taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
+                    $session,
+                    null,
+                    __CLASS__ . '::nextSection'
+                );
+                $this->notifyError(__('Next section navigation is not allowed.'), 403);
+
+                return;
+            }
+
             try {
                 $session->moveNextAssessmentSection();
 

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -332,6 +332,86 @@ class taoQtiTest_helpers_TestRunnerUtils
     }
 
     /**
+     * Whether the candidate is allowed to navigate to the next assessment section.
+     * Requires the next-section feature flag and a matching QTI category on the current item.
+     *
+     * @param AssessmentTestSession $session
+     * @param RunnerServiceContext|null $context
+     * @return boolean
+     */
+    public static function isNextSectionAllowed(AssessmentTestSession $session, RunnerServiceContext $context = null)
+    {
+        return self::getNextSectionDenialReason($session, $context) === null;
+    }
+
+    /**
+     * @return string|null denial reason, or null when next section navigation is allowed
+     */
+    public static function getNextSectionDenialReason(
+        AssessmentTestSession $session,
+        RunnerServiceContext $context = null
+    ) {
+        $nextSectionEnabled = false;
+
+        if ($context !== null && $context->getTestConfig() !== null) {
+            $nextSectionEnabled = !empty($context->getTestConfig()->getConfigValue('nextSection'));
+        } else {
+            $config = common_ext_ExtensionsManager::singleton()
+                ->getExtensionById('taoQtiTest')
+                ->getConfig('testRunner');
+            $nextSectionEnabled = !empty($config['next-section']);
+        }
+
+        if (!$nextSectionEnabled) {
+            return 'feature-disabled';
+        }
+
+        $categories = self::getCategories($session, $context);
+
+        if (
+            in_array('x-tao-option-nextSection', $categories, true)
+            || in_array('x-tao-option-nextSectionWarning', $categories, true)
+        ) {
+            return null;
+        }
+
+        return 'missing-category';
+    }
+
+    /**
+     * Log rejected next-section navigation attempts for monitoring and investigation.
+     */
+    public static function logNextSectionDeniedAttempt(
+        AssessmentTestSession $session,
+        RunnerServiceContext $context = null,
+        $source = 'unknown'
+    ) {
+        $reason = self::getNextSectionDenialReason($session, $context);
+
+        if ($reason === null) {
+            return;
+        }
+
+        $executionUri = $context !== null ? $context->getTestExecutionUri() : null;
+        $categories = self::getCategories($session, $context);
+        $itemRef = $session->getCurrentAssessmentItemRef();
+        $section = $session->getCurrentAssessmentSection();
+
+        common_Logger::w(
+            sprintf(
+                'Next section navigation rejected (%s): reason=%s item=%s section=%s execution=%s categories=[%s]',
+                $source,
+                $reason,
+                $itemRef !== null ? $itemRef->getIdentifier() : 'n/a',
+                $section !== null ? $section->getIdentifier() : 'n/a',
+                $executionUri ?? 'n/a',
+                implode(',', $categories)
+            ),
+            ['nextSection', 'navigation-rejected']
+        );
+    }
+
+    /**
      * Whether or not the candidate's response is validated
      *
      * @param AssessmentTestSession $session A given AssessmentTestSession object.

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -38,6 +38,7 @@ use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
 use qtism\common\datatypes\QtiString;
 use oat\oatbox\service\ServiceManager;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
+use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 
 /**
 * Utility methods for the QtiTest Test Runner.
@@ -390,9 +391,11 @@ class taoQtiTest_helpers_TestRunnerUtils
             return;
         }
 
-        $executionUri = $deliveryExecutionUri
-            ?? ($context !== null ? $context->getTestExecutionUri() : null)
-            ?? 'n/a';
+        $executionUri = $deliveryExecutionUri;
+        if ($executionUri === null && $context instanceof QtiRunnerServiceContext) {
+            $executionUri = $context->getTestExecutionUri();
+        }
+        $executionUri = $executionUri ?? 'n/a';
 
         common_Logger::w(
             sprintf('Next section navigation is not allowed for delivery execution %s', $executionUri),

--- a/helpers/class.TestRunnerUtils.php
+++ b/helpers/class.TestRunnerUtils.php
@@ -379,36 +379,27 @@ class taoQtiTest_helpers_TestRunnerUtils
     }
 
     /**
-     * Log rejected next-section navigation attempts for monitoring and investigation.
+     * @throws common_exception_Unauthorized
      */
-    public static function logNextSectionDeniedAttempt(
+    public static function assertNextSectionAllowed(
         AssessmentTestSession $session,
         RunnerServiceContext $context = null,
-        $source = 'unknown'
-    ) {
-        $reason = self::getNextSectionDenialReason($session, $context);
-
-        if ($reason === null) {
+        ?string $deliveryExecutionUri = null
+    ): void {
+        if (self::isNextSectionAllowed($session, $context)) {
             return;
         }
 
-        $executionUri = $context !== null ? $context->getTestExecutionUri() : null;
-        $categories = self::getCategories($session, $context);
-        $itemRef = $session->getCurrentAssessmentItemRef();
-        $section = $session->getCurrentAssessmentSection();
+        $executionUri = $deliveryExecutionUri
+            ?? ($context !== null ? $context->getTestExecutionUri() : null)
+            ?? 'n/a';
 
         common_Logger::w(
-            sprintf(
-                'Next section navigation rejected (%s): reason=%s item=%s section=%s execution=%s categories=[%s]',
-                $source,
-                $reason,
-                $itemRef !== null ? $itemRef->getIdentifier() : 'n/a',
-                $section !== null ? $section->getIdentifier() : 'n/a',
-                $executionUri ?? 'n/a',
-                implode(',', $categories)
-            ),
-            ['nextSection', 'navigation-rejected']
+            sprintf('Next section navigation is not allowed for delivery execution %s', $executionUri),
+            ['nextSection']
         );
+
+        throw new common_exception_Unauthorized(__('Next section navigation is not allowed.'));
     }
 
     /**

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1432,6 +1432,12 @@ class QtiRunnerService extends ConfigurableService implements PersistableRunnerS
 
             TestRunnerUtils::beginCandidateInteraction($session);
             $continue = true;
+        } elseif ($session->isRunning() === true && $session->isTimeout() === true) {
+            try {
+                $session->checkTimeLimits(false, true, false);
+            } catch (AssessmentTestSessionException $e) {
+                $this->onTimeout($context, $e);
+            }
         } else {
             $this->finish($context);
         }

--- a/models/classes/runner/QtiRunnerService.php
+++ b/models/classes/runner/QtiRunnerService.php
@@ -1435,6 +1435,11 @@ class QtiRunnerService extends ConfigurableService implements PersistableRunnerS
         } elseif ($session->isRunning() === true && $session->isTimeout() === true) {
             try {
                 $session->checkTimeLimits(false, true, false);
+                $event = new QtiContinueInteractionEvent($context, $this);
+                $this->getServiceManager()->get(EventManager::SERVICE_ID)->trigger($event);
+
+                TestRunnerUtils::beginCandidateInteraction($session);
+                $continue = true;
             } catch (AssessmentTestSessionException $e) {
                 $this->onTimeout($context, $e);
             }

--- a/models/classes/runner/navigation/QtiRunnerNavigation.php
+++ b/models/classes/runner/navigation/QtiRunnerNavigation.php
@@ -24,7 +24,6 @@ use common_Exception;
 use common_exception_InconsistentData;
 use common_exception_InvalidArgumentType;
 use common_exception_NotImplemented;
-use common_exception_Unauthorized;
 use common_Logger;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
@@ -105,14 +104,7 @@ class QtiRunnerNavigation
         $navigator = self::getNavigator($direction, $scope);
 
         if ($direction === 'next' && $scope === 'section') {
-            if (!\taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session, $context)) {
-                \taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
-                    $session,
-                    $context,
-                    self::class . '::move'
-                );
-                throw new common_exception_Unauthorized(__('Next section navigation is not allowed.'));
-            }
+            \taoQtiTest_helpers_TestRunnerUtils::assertNextSectionAllowed($session, $context);
         }
 
         if (self::isSessionSuspended($context) || self::isExecutionPaused($context)) {

--- a/models/classes/runner/navigation/QtiRunnerNavigation.php
+++ b/models/classes/runner/navigation/QtiRunnerNavigation.php
@@ -24,6 +24,7 @@ use common_Exception;
 use common_exception_InconsistentData;
 use common_exception_InvalidArgumentType;
 use common_exception_NotImplemented;
+use common_exception_Unauthorized;
 use common_Logger;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
@@ -102,6 +103,17 @@ class QtiRunnerNavigation
         /* @var ?AssessmentTestSession $session */
         $session = $context->getTestSession();
         $navigator = self::getNavigator($direction, $scope);
+
+        if ($direction === 'next' && $scope === 'section') {
+            if (!\taoQtiTest_helpers_TestRunnerUtils::isNextSectionAllowed($session, $context)) {
+                \taoQtiTest_helpers_TestRunnerUtils::logNextSectionDeniedAttempt(
+                    $session,
+                    $context,
+                    self::class . '::move'
+                );
+                throw new common_exception_Unauthorized(__('Next section navigation is not allowed.'));
+            }
+        }
 
         if (self::isSessionSuspended($context) || self::isExecutionPaused($context)) {
             self::getLogger()->logDebug(

--- a/test/unit/helpers/IsNextSectionAllowedTest.php
+++ b/test/unit/helpers/IsNextSectionAllowedTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\helpers;
+
+use oat\generis\test\TestCase;
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
+use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
+use oat\taoQtiTest\models\runner\session\TestSession;
+use qtism\common\collections\StringCollection;
+use qtism\data\AssessmentItemRef;
+use taoQtiTest_helpers_TestRunnerUtils as TestRunnerUtils;
+
+class IsNextSectionAllowedTest extends TestCase
+{
+    public function testReturnsFalseWhenFeatureDisabled(): void
+    {
+        $session = $this->createSessionMock([]);
+        $context = $this->createContextMock(false, ['x-tao-option-nextSection']);
+
+        $this->assertFalse(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertSame('feature-disabled', TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    public function testReturnsFalseWhenFeatureEnabledButNoCategory(): void
+    {
+        $session = $this->createSessionMock([]);
+        $context = $this->createContextMock(true, []);
+
+        $this->assertFalse(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertSame('missing-category', TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    public function testReturnsTrueWhenFeatureEnabledWithNextSectionCategory(): void
+    {
+        $session = $this->createSessionMock(['x-tao-option-nextSection']);
+        $context = $this->createContextMock(true, ['x-tao-option-nextSection']);
+
+        $this->assertTrue(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertNull(TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    public function testReturnsTrueWhenFeatureEnabledWithNextSectionWarningCategory(): void
+    {
+        $session = $this->createSessionMock(['x-tao-option-nextSectionWarning']);
+        $context = $this->createContextMock(true, ['x-tao-option-nextSectionWarning']);
+
+        $this->assertTrue(TestRunnerUtils::isNextSectionAllowed($session, $context));
+        $this->assertNull(TestRunnerUtils::getNextSectionDenialReason($session, $context));
+    }
+
+    private function createSessionMock(array $categories): TestSession
+    {
+        $itemRef = $this->createMock(AssessmentItemRef::class);
+        $itemRef
+            ->method('getCategories')
+            ->willReturn(new StringCollection($categories));
+
+        $session = $this->createMock(TestSession::class);
+        $session
+            ->method('getCurrentAssessmentItemRef')
+            ->willReturn($itemRef);
+
+        return $session;
+    }
+
+    private function createContextMock(bool $nextSectionEnabled, array $categories): QtiRunnerServiceContext
+    {
+        $testConfig = $this->createMock(RunnerConfig::class);
+        $testConfig
+            ->method('getConfigValue')
+            ->with('nextSection')
+            ->willReturn($nextSectionEnabled);
+
+        $itemRef = $this->createMock(AssessmentItemRef::class);
+        $itemRef
+            ->method('getCategories')
+            ->willReturn(new StringCollection($categories));
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context
+            ->method('getTestConfig')
+            ->willReturn($testConfig);
+        $context
+            ->method('getCurrentAssessmentItemRef')
+            ->willReturn($itemRef);
+
+        return $context;
+    }
+}

--- a/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
+++ b/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\models\classes\runner;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\event\EventManager;
+use oat\taoQtiTest\models\runner\QtiRunnerService;
+use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
+use oat\taoQtiTest\models\runner\session\TestSession;
+use Psr\Log\LoggerInterface;
+use qtism\runtime\tests\AssessmentItemSession;
+use qtism\runtime\tests\AssessmentItemSessionState;
+use qtism\runtime\tests\AssessmentTestSessionException;
+
+class QtiRunnerServiceContinueInteractionTest extends TestCase
+{
+    private function invokeContinueInteraction(QtiRunnerService $service, QtiRunnerServiceContext $context): bool
+    {
+        $method = new \ReflectionMethod(QtiRunnerService::class, 'continueInteraction');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $context);
+    }
+
+    private function createService(array $onlyMethods = ['onTimeout', 'finish']): QtiRunnerService
+    {
+        $service = $this->getMockBuilder(QtiRunnerService::class)
+            ->onlyMethods($onlyMethods)
+            ->getMock();
+
+        $service->setLogger($this->createMock(LoggerInterface::class));
+
+        return $service;
+    }
+
+    public function testContinueInteractionBeginsInteractionWhenRunningAndNotTimedOut(): void
+    {
+        $itemSession = $this->createMock(AssessmentItemSession::class);
+        $itemSession->method('getState')->willReturn(AssessmentItemSessionState::INTERACTING);
+        $itemSession->method('getRemainingAttempts')->willReturn(0);
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(true);
+        $session->method('isTimeout')->willReturn(false);
+        $session->method('getCurrentAssessmentItemSession')->willReturn($itemSession);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->expects($this->once())->method('trigger');
+
+        $service = $this->createService(['finish', 'onTimeout']);
+        $service->setServiceLocator($this->getServiceLocatorMock([
+            EventManager::SERVICE_ID => $eventManager,
+        ]));
+        $service->expects($this->never())->method('finish');
+        $service->expects($this->never())->method('onTimeout');
+
+        $this->assertTrue($this->invokeContinueInteraction($service, $context));
+    }
+
+    public function testContinueInteractionInvokesOnTimeoutWhenRunningAndTimedOut(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of testPart timedPart not respected.',
+            AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW
+        );
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(true);
+        $session->method('isTimeout')->willReturn(true);
+        $session->expects($this->once())
+            ->method('checkTimeLimits')
+            ->with(false, true, false)
+            ->willThrowException($timeoutException);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $service = $this->createService();
+        $service->expects($this->once())
+            ->method('onTimeout')
+            ->with($context, $timeoutException);
+        $service->expects($this->never())->method('finish');
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+    }
+
+    public function testContinueInteractionFinishesWhenSessionIsNotRunning(): void
+    {
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(false);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $service = $this->createService();
+        $service->expects($this->once())->method('finish')->with($context);
+        $service->expects($this->never())->method('onTimeout');
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+    }
+
+    public function testContinueInteractionDoesNotFinishOnTimeoutBoundaryNavigation(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of assessmentSection timedSection not respected.',
+            AssessmentTestSessionException::ASSESSMENT_SECTION_DURATION_OVERFLOW
+        );
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(true);
+        $session->method('isTimeout')->willReturn(true);
+        $session->method('checkTimeLimits')
+            ->with(false, true, false)
+            ->willThrowException($timeoutException);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $service = $this->createService();
+        $service->expects($this->once())->method('onTimeout');
+        $service->expects($this->never())->method('finish');
+
+        $this->invokeContinueInteraction($service, $context);
+    }
+
+    public function testContinueInteractionRepeatedTimeoutHandlingIsIdempotentAtBranchLevel(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of testPart timedPart not respected.',
+            AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW
+        );
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(true);
+        $session->method('isTimeout')->willReturn(true);
+        $session->method('checkTimeLimits')
+            ->with(false, true, false)
+            ->willThrowException($timeoutException);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $service = $this->createService();
+        $service->expects($this->exactly(2))
+            ->method('onTimeout')
+            ->with($context, $timeoutException);
+        $service->expects($this->never())->method('finish');
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+    }
+
+    public function testContinueInteractionHandlesTestLevelTimeout(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of assessmentTest timedTest not respected.',
+            AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW
+        );
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(true);
+        $session->method('isTimeout')->willReturn(true);
+        $session->method('checkTimeLimits')
+            ->with(false, true, false)
+            ->willThrowException($timeoutException);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $service = $this->createService();
+        $service->expects($this->once())
+            ->method('onTimeout')
+            ->with($context, $timeoutException);
+        $service->expects($this->never())->method('finish');
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+    }
+
+    public function testOnTimeoutMovesToNextTestPartForLinearTestPartOverflow(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of testPart timedPart not respected.',
+            AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW
+        );
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('getCurrentNavigationMode')->willReturn(\qtism\data\NavigationMode::LINEAR);
+        $session->expects($this->once())->method('moveNextTestPart');
+        $session->expects($this->never())->method('moveThroughAndEndTestSession');
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->expects($this->exactly(2))->method('trigger');
+
+        $service = $this->getMockBuilder(QtiRunnerService::class)
+            ->onlyMethods(['continueInteraction'])
+            ->getMock();
+        $service->setLogger($this->createMock(LoggerInterface::class));
+        $service->setServiceLocator($this->getServiceLocatorMock([
+            EventManager::SERVICE_ID => $eventManager,
+        ]));
+        $service->expects($this->once())->method('continueInteraction')->with($context);
+
+        $method = new \ReflectionMethod(QtiRunnerService::class, 'onTimeout');
+        $method->setAccessible(true);
+        $method->invoke($service, $context, $timeoutException);
+    }
+
+    public function testOnTimeoutEndsSessionForTestLevelOverflow(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of assessmentTest timedTest not respected.',
+            AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW
+        );
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('getCurrentNavigationMode')->willReturn(\qtism\data\NavigationMode::LINEAR);
+        $session->expects($this->once())->method('moveThroughAndEndTestSession');
+        $session->expects($this->never())->method('moveNextTestPart');
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->expects($this->exactly(2))->method('trigger');
+
+        $service = $this->getMockBuilder(QtiRunnerService::class)
+            ->onlyMethods(['continueInteraction'])
+            ->getMock();
+        $service->setLogger($this->createMock(LoggerInterface::class));
+        $service->setServiceLocator($this->getServiceLocatorMock([
+            EventManager::SERVICE_ID => $eventManager,
+        ]));
+        $service->expects($this->once())->method('continueInteraction')->with($context);
+
+        $method = new \ReflectionMethod(QtiRunnerService::class, 'onTimeout');
+        $method->setAccessible(true);
+        $method->invoke($service, $context, $timeoutException);
+    }
+
+    public function testContinueInteractionFinishesOnlyAfterSessionEnds(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of assessmentTest timedTest not respected.',
+            AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW
+        );
+
+        $runningSession = $this->createMock(TestSession::class);
+        $runningSession->method('isRunning')->willReturn(true);
+        $runningSession->method('isTimeout')->willReturn(true);
+        $runningSession->method('getCurrentNavigationMode')->willReturn(\qtism\data\NavigationMode::LINEAR);
+        $runningSession->method('checkTimeLimits')
+            ->with(false, true, false)
+            ->willThrowException($timeoutException);
+
+        $closedSession = $this->createMock(TestSession::class);
+        $closedSession->method('isRunning')->willReturn(false);
+
+        $callCount = 0;
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')
+            ->willReturnCallback(static function () use ($runningSession, $closedSession, &$callCount) {
+                return (++$callCount <= 2) ? $runningSession : $closedSession;
+            });
+
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->method('trigger');
+
+        $service = $this->getMockBuilder(QtiRunnerService::class)
+            ->onlyMethods(['finish'])
+            ->getMock();
+        $service->setLogger($this->createMock(LoggerInterface::class));
+        $service->setServiceLocator($this->getServiceLocatorMock([
+            EventManager::SERVICE_ID => $eventManager,
+        ]));
+        $runningSession->expects($this->once())->method('moveThroughAndEndTestSession');
+        $service->expects($this->once())->method('finish')->with($context);
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+    }
+}

--- a/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
+++ b/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
@@ -5,17 +5,48 @@ declare(strict_types=1);
 namespace oat\taoQtiTest\test\unit\models\classes\runner;
 
 use oat\generis\test\TestCase;
+use oat\ltiDeliveryProvider\model\events\LtiAgsListener;
+use oat\ltiDeliveryProvider\model\execution\LtiContextRepositoryInterface;
 use oat\oatbox\event\EventManager;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
+use oat\taoLti\models\classes\LtiLaunchData;
+use oat\taoOutcomeRds\model\RdsResultStorage;
+use oat\taoQtiTest\models\event\DeliveryExecutionFinish;
+use oat\taoQtiTest\models\ExtendedStateService;
 use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
+use oat\taoResultServer\models\classes\implementation\ResultServerService;
+use OAT\Library\Lti1p3Core\Message\Payload\Claim\AgsClaim;
 use Psr\Log\LoggerInterface;
+use qtism\data\NavigationMode;
 use qtism\runtime\tests\AssessmentItemSession;
 use qtism\runtime\tests\AssessmentItemSessionState;
 use qtism\runtime\tests\AssessmentTestSessionException;
+use tao_models_classes_Service;
 
 class QtiRunnerServiceContinueInteractionTest extends TestCase
 {
+    private ?array $serviceSingletonBackup = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->serviceSingletonBackup !== null) {
+            $property = new \ReflectionProperty(tao_models_classes_Service::class, 'instances');
+            $property->setAccessible(true);
+            $property->setValue(null, $this->serviceSingletonBackup);
+            $this->serviceSingletonBackup = null;
+        }
+
+        $sessionProperty = new \ReflectionProperty(\common_session_SessionManager::class, 'session');
+        $sessionProperty->setAccessible(true);
+        $sessionProperty->setValue(null, null);
+
+        parent::tearDown();
+    }
     private function invokeContinueInteraction(QtiRunnerService $service, QtiRunnerServiceContext $context): bool
     {
         $method = new \ReflectionMethod(QtiRunnerService::class, 'continueInteraction');
@@ -33,6 +64,43 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $service->setLogger($this->createMock(LoggerInterface::class));
 
         return $service;
+    }
+
+    private function createServiceWithRealOnTimeout(EventManager $eventManager): QtiRunnerService
+    {
+        $service = $this->getMockBuilder(QtiRunnerService::class)
+            ->onlyMethods(['finish'])
+            ->getMock();
+
+        $service->setLogger($this->createMock(LoggerInterface::class));
+        $service->setServiceLocator($this->getServiceLocatorMock([
+            EventManager::SERVICE_ID => $eventManager,
+        ]));
+        $service->expects($this->never())->method('finish');
+
+        return $service;
+    }
+
+    private function createSessionContinuingAfterTimeoutTransition(
+        AssessmentTestSessionException $timeoutException,
+        string $transitionMethod
+    ): TestSession {
+        $itemSession = $this->createMock(AssessmentItemSession::class);
+        $itemSession->method('getState')->willReturn(AssessmentItemSessionState::INTERACTING);
+        $itemSession->method('getRemainingAttempts')->willReturn(0);
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(true);
+        // isTimeout() is evaluated in both the if and elseif guards on each entry.
+        $session->method('isTimeout')->willReturnOnConsecutiveCalls(true, true, false);
+        $session->method('checkTimeLimits')
+            ->with(false, true, false)
+            ->willThrowException($timeoutException);
+        $session->method('getCurrentNavigationMode')->willReturn(NavigationMode::LINEAR);
+        $session->method('getCurrentAssessmentItemSession')->willReturn($itemSession);
+        $session->expects($this->once())->method($transitionMethod);
+
+        return $session;
     }
 
     public function testContinueInteractionBeginsInteractionWhenRunningAndNotTimedOut(): void
@@ -69,22 +137,18 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
             AssessmentTestSessionException::TEST_PART_DURATION_OVERFLOW
         );
 
-        $session = $this->createMock(TestSession::class);
-        $session->method('isRunning')->willReturn(true);
-        $session->method('isTimeout')->willReturn(true);
-        $session->expects($this->once())
-            ->method('checkTimeLimits')
-            ->with(false, true, false)
-            ->willThrowException($timeoutException);
+        $session = $this->createSessionContinuingAfterTimeoutTransition(
+            $timeoutException,
+            'moveNextTestPart'
+        );
 
         $context = $this->createMock(QtiRunnerServiceContext::class);
         $context->method('getTestSession')->willReturn($session);
 
-        $service = $this->createService();
-        $service->expects($this->once())
-            ->method('onTimeout')
-            ->with($context, $timeoutException);
-        $service->expects($this->never())->method('finish');
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->expects($this->exactly(3))->method('trigger');
+
+        $service = $this->createServiceWithRealOnTimeout($eventManager);
 
         $this->assertFalse($this->invokeContinueInteraction($service, $context));
     }
@@ -111,21 +175,43 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
             AssessmentTestSessionException::ASSESSMENT_SECTION_DURATION_OVERFLOW
         );
 
-        $session = $this->createMock(TestSession::class);
-        $session->method('isRunning')->willReturn(true);
-        $session->method('isTimeout')->willReturn(true);
-        $session->method('checkTimeLimits')
-            ->with(false, true, false)
-            ->willThrowException($timeoutException);
+        $session = $this->createSessionContinuingAfterTimeoutTransition(
+            $timeoutException,
+            'moveNextAssessmentSection'
+        );
 
         $context = $this->createMock(QtiRunnerServiceContext::class);
         $context->method('getTestSession')->willReturn($session);
 
-        $service = $this->createService();
-        $service->expects($this->once())->method('onTimeout');
-        $service->expects($this->never())->method('finish');
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->expects($this->exactly(3))->method('trigger');
 
-        $this->invokeContinueInteraction($service, $context);
+        $service = $this->createServiceWithRealOnTimeout($eventManager);
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+    }
+
+    public function testContinueInteractionMovesToNextItemOnItemTimeoutWithoutFinish(): void
+    {
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of assessmentItem timedItem not respected.',
+            AssessmentTestSessionException::ASSESSMENT_ITEM_DURATION_OVERFLOW
+        );
+
+        $session = $this->createSessionContinuingAfterTimeoutTransition(
+            $timeoutException,
+            'moveNextAssessmentItem'
+        );
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->expects($this->exactly(3))->method('trigger');
+
+        $service = $this->createServiceWithRealOnTimeout($eventManager);
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
     }
 
     public function testContinueInteractionRepeatedTimeoutHandlingIsIdempotentAtBranchLevel(): void
@@ -314,5 +400,181 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $service->expects($this->once())->method('finish')->with($context);
 
         $this->assertFalse($this->invokeContinueInteraction($service, $context));
+    }
+
+    public function testContinueInteractionTimeoutFinishEmitsAgsPayloadWithOutcomeScores(): void
+    {
+        if (!class_exists(LtiAgsListener::class)) {
+            $this->markTestSkipped('This test needs ' . LtiAgsListener::class);
+        }
+
+        $timeoutException = new AssessmentTestSessionException(
+            'Maximum duration of assessmentTest timedTest not respected.',
+            AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW
+        );
+
+        $scoreTotal = 7.0;
+        $scoreTotalMax = 10.0;
+        $executionId = 'http://execution/id';
+        $userUri = 'http://user/id';
+
+        $runningSession = $this->createMock(TestSession::class);
+        $runningSession->method('isRunning')->willReturn(true);
+        $runningSession->method('isTimeout')->willReturnOnConsecutiveCalls(true, true);
+        $runningSession->method('getCurrentNavigationMode')->willReturn(NavigationMode::LINEAR);
+        $runningSession->method('checkTimeLimits')
+            ->with(false, true, false)
+            ->willThrowException($timeoutException);
+        $runningSession->expects($this->once())->method('moveThroughAndEndTestSession');
+
+        $closedSession = $this->createMock(TestSession::class);
+        $closedSession->method('isRunning')->willReturn(false);
+        $closedSession->method('isManualScored')->willReturn(false);
+
+        $callCount = 0;
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestExecutionUri')->willReturn($executionId);
+        $context->method('getTestSession')
+            ->willReturnCallback(static function () use ($runningSession, $closedSession, &$callCount) {
+                return (++$callCount <= 2) ? $runningSession : $closedSession;
+            });
+
+        $deliveryExecution = $this->createMock(DeliveryExecution::class);
+        $deliveryExecution->method('getUserIdentifier')->willReturn($userUri);
+        $deliveryExecution->method('getIdentifier')->willReturn($executionId);
+        $deliveryExecution->method('getFinishTime')->willReturn(1234567890.1234);
+        $deliveryExecution->expects($this->once())->method('setState')->willReturn(true);
+
+        $this->injectDeliveryExecutionServiceProxy($deliveryExecution);
+        $this->injectSessionUserUri($userUri);
+
+        $agsPayload = null;
+        $queueDispatcher = $this->createMock(QueueDispatcherInterface::class);
+        $queueDispatcher->expects($this->once())
+            ->method('createTask')
+            ->willReturnCallback(static function ($task, array $body) use (&$agsPayload) {
+                $agsPayload = $body;
+
+                return null;
+            });
+
+        $agsClaim = $this->createMock(AgsClaim::class);
+        $agsClaim->method('normalize')->willReturn(['lineItem' => 'test-line-item']);
+
+        $launchData = $this->createMock(LtiLaunchData::class);
+        $launchData->method('hasVariable')->with(LtiLaunchData::AGS_CLAIMS)->willReturn(true);
+        $launchData->method('getVariable')->willReturnCallback(
+            static function (string $key) use ($agsClaim, $userUri) {
+                return match ($key) {
+                    LtiLaunchData::AGS_CLAIMS => $agsClaim,
+                    LtiLaunchData::TOOL_CONSUMER_INSTANCE_ID => 'registration-id',
+                    default => $userUri,
+                };
+            }
+        );
+        $launchData->method('getUserID')->willReturn($userUri);
+
+        $ltiContextRepository = $this->createLtiContextRepositoryStub($launchData, $executionId);
+
+        $resultStorage = $this->createMock(RdsResultStorage::class);
+        $resultStorage->method('getDeliveryVariables')
+            ->with($executionId)
+            ->willReturn($this->createDeliveryOutcomeVariables($scoreTotal, $scoreTotalMax));
+
+        $resultServerService = $this->createMock(ResultServerService::class);
+        $resultServerService->method('getResultStorage')->willReturn($resultStorage);
+
+        $extendedStateService = $this->createMock(ExtendedStateService::class);
+        $extendedStateService->expects($this->once())->method('clearEvents')->with($executionId);
+
+        $eventManager = new EventManager();
+        $agsListener = new LtiAgsListener();
+        $eventManager->attach(DeliveryExecutionFinish::class, [$agsListener, 'onDeliveryExecutionFinish']);
+
+        $serviceManager = $this->getServiceLocatorMock([
+            EventManager::SERVICE_ID => $eventManager,
+            ResultServerService::SERVICE_ID => $resultServerService,
+            ExtendedStateService::SERVICE_ID => $extendedStateService,
+            QueueDispatcherInterface::SERVICE_ID => $queueDispatcher,
+            LtiContextRepositoryInterface::class => $ltiContextRepository,
+        ]);
+        $eventManager->setServiceLocator($serviceManager);
+        $agsListener->setServiceLocator($serviceManager);
+
+        $service = new QtiRunnerService();
+        $service->setLogger($this->createMock(LoggerInterface::class));
+        $service->setServiceLocator($serviceManager);
+
+        $this->assertFalse($this->invokeContinueInteraction($service, $context));
+        $this->assertNotNull($agsPayload);
+        $this->assertSame($scoreTotal, $agsPayload['data']['scoreGiven']);
+        $this->assertSame($scoreTotalMax, $agsPayload['data']['scoreMaximum']);
+        $this->assertSame($executionId, $agsPayload['deliveryExecutionId']);
+    }
+
+    private function createDeliveryOutcomeVariables(float $scoreTotal, float $scoreTotalMax): array
+    {
+        return [
+            1 => [(object)['variable' => $this->createOutcomeVariable('SCORE_TOTAL', $scoreTotal)]],
+            2 => [(object)['variable' => $this->createOutcomeVariable('SCORE_TOTAL_MAX', $scoreTotalMax)]],
+        ];
+    }
+
+    private function createOutcomeVariable(string $identifier, float $value): \taoResultServer_models_classes_OutcomeVariable
+    {
+        return (new \taoResultServer_models_classes_OutcomeVariable())
+            ->setIdentifier($identifier)
+            ->setValue((string)$value)
+            ->setEpoch('1234567890.1234');
+    }
+
+    private function injectDeliveryExecutionServiceProxy(DeliveryExecution $deliveryExecution): void
+    {
+        $proxy = $this->createMock(TaoDeliveryServiceProxy::class);
+        $proxy->method('getDeliveryExecution')->willReturn($deliveryExecution);
+
+        $property = new \ReflectionProperty(tao_models_classes_Service::class, 'instances');
+        $property->setAccessible(true);
+        $this->serviceSingletonBackup = $property->getValue();
+        $instances = $this->serviceSingletonBackup ?? [];
+        $instances[TaoDeliveryServiceProxy::class] = $proxy;
+        $property->setValue(null, $instances);
+    }
+
+    private function injectSessionUserUri(string $userUri): void
+    {
+        $session = $this->createMock(\common_session_Session::class);
+        $session->method('getUserUri')->willReturn($userUri);
+
+        $property = new \ReflectionProperty(\common_session_SessionManager::class, 'session');
+        $property->setAccessible(true);
+        $property->setValue(null, $session);
+    }
+
+    private function createLtiContextRepositoryStub(
+        LtiLaunchData $launchData,
+        string $executionId
+    ): LtiContextRepositoryInterface {
+        return new class($launchData, $executionId) implements LtiContextRepositoryInterface {
+            public function __construct(
+                private LtiLaunchData $launchData,
+                private string $executionId
+            ) {
+            }
+
+            public function findByDeliveryExecutionId(string $deliveryExecutionId): ?LtiLaunchData
+            {
+                return $deliveryExecutionId === $this->executionId ? $this->launchData : null;
+            }
+
+            public function findByDeliveryExecution(DeliveryExecutionInterface $deliveryExecution): ?LtiLaunchData
+            {
+                return $this->findByDeliveryExecutionId($deliveryExecution->getIdentifier());
+            }
+
+            public function save(LtiLaunchData $ltiLaunchData, DeliveryExecutionInterface $deliveryExecution): void
+            {
+            }
+        };
     }
 }

--- a/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
+++ b/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
@@ -181,6 +181,36 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $this->assertFalse($this->invokeContinueInteraction($service, $context));
     }
 
+    public function testContinueInteractionContinuesWhenTimeoutRevalidationPasses(): void
+    {
+        $itemSession = $this->createMock(AssessmentItemSession::class);
+        $itemSession->method('getState')->willReturn(AssessmentItemSessionState::INTERACTING);
+        $itemSession->method('getRemainingAttempts')->willReturn(0);
+
+        $session = $this->createMock(TestSession::class);
+        $session->method('isRunning')->willReturn(true);
+        $session->method('isTimeout')->willReturn(true);
+        $session->expects($this->once())
+            ->method('checkTimeLimits')
+            ->with(false, true, false);
+        $session->method('getCurrentAssessmentItemSession')->willReturn($itemSession);
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context->method('getTestSession')->willReturn($session);
+
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager->expects($this->once())->method('trigger');
+
+        $service = $this->createService();
+        $service->setServiceLocator($this->getServiceLocatorMock([
+            EventManager::SERVICE_ID => $eventManager,
+        ]));
+        $service->expects($this->never())->method('onTimeout');
+        $service->expects($this->never())->method('finish');
+
+        $this->assertTrue($this->invokeContinueInteraction($service, $context));
+    }
+
     public function testOnTimeoutMovesToNextTestPartForLinearTestPartOverflow(): void
     {
         $timeoutException = new AssessmentTestSessionException(

--- a/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
+++ b/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
@@ -27,6 +27,7 @@ use qtism\runtime\tests\AssessmentItemSession;
 use qtism\runtime\tests\AssessmentItemSessionState;
 use qtism\runtime\tests\AssessmentTestSessionException;
 use tao_models_classes_Service;
+use taoResultServer_models_classes_OutcomeVariable as OutcomeVariableModel;
 
 class QtiRunnerServiceContinueInteractionTest extends TestCase
 {
@@ -520,9 +521,9 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         ];
     }
 
-    private function createOutcomeVariable(string $identifier, float $value): \taoResultServer_models_classes_OutcomeVariable
+    private function createOutcomeVariable(string $identifier, float $value): OutcomeVariableModel
     {
-        return (new \taoResultServer_models_classes_OutcomeVariable())
+        return (new OutcomeVariableModel())
             ->setIdentifier($identifier)
             ->setValue((string)$value)
             ->setEpoch('1234567890.1234');
@@ -555,7 +556,7 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         LtiLaunchData $launchData,
         string $executionId
     ): LtiContextRepositoryInterface {
-        return new class($launchData, $executionId) implements LtiContextRepositoryInterface {
+        return new class ($launchData, $executionId) implements LtiContextRepositoryInterface {
             public function __construct(
                 private LtiLaunchData $launchData,
                 private string $executionId

--- a/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
+++ b/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
@@ -31,14 +31,17 @@ use taoResultServer_models_classes_OutcomeVariable as OutcomeVariableModel;
 
 class QtiRunnerServiceContinueInteractionTest extends TestCase
 {
+    private bool $serviceSingletonBackupTaken = false;
+
     private ?array $serviceSingletonBackup = null;
 
     protected function tearDown(): void
     {
-        if ($this->serviceSingletonBackup !== null) {
+        if ($this->serviceSingletonBackupTaken) {
             $property = new \ReflectionProperty(tao_models_classes_Service::class, 'instances');
             $property->setAccessible(true);
             $property->setValue(null, $this->serviceSingletonBackup);
+            $this->serviceSingletonBackupTaken = false;
             $this->serviceSingletonBackup = null;
         }
 
@@ -418,6 +421,8 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $scoreTotalMax = 10.0;
         $executionId = 'http://execution/id';
         $userUri = 'http://user/id';
+        $persistedVariables = [];
+        $operationOrder = [];
 
         $runningSession = $this->createMock(TestSession::class);
         $runningSession->method('isRunning')->willReturn(true);
@@ -426,7 +431,17 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $runningSession->method('checkTimeLimits')
             ->with(false, true, false)
             ->willThrowException($timeoutException);
-        $runningSession->expects($this->once())->method('moveThroughAndEndTestSession');
+        $runningSession->expects($this->once())
+            ->method('moveThroughAndEndTestSession')
+            ->willReturnCallback(function () use (
+                &$persistedVariables,
+                &$operationOrder,
+                $scoreTotal,
+                $scoreTotalMax
+            ): void {
+                $operationOrder[] = 'persistOutcomes';
+                $persistedVariables = $this->createDeliveryOutcomeVariables($scoreTotal, $scoreTotalMax);
+            });
 
         $closedSession = $this->createMock(TestSession::class);
         $closedSession->method('isRunning')->willReturn(false);
@@ -478,9 +493,18 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $ltiContextRepository = $this->createLtiContextRepositoryStub($launchData, $executionId);
 
         $resultStorage = $this->createMock(RdsResultStorage::class);
-        $resultStorage->method('getDeliveryVariables')
+        $resultStorage->expects($this->once())
+            ->method('getDeliveryVariables')
             ->with($executionId)
-            ->willReturn($this->createDeliveryOutcomeVariables($scoreTotal, $scoreTotalMax));
+            ->willReturnCallback(function () use (&$persistedVariables, &$operationOrder) {
+                $operationOrder[] = 'readOutcomes';
+                $this->assertNotEmpty(
+                    $persistedVariables,
+                    'SCORE_TOTAL outcomes must be persisted before finish reads delivery variables'
+                );
+
+                return $persistedVariables;
+            });
 
         $resultServerService = $this->createMock(ResultServerService::class);
         $resultServerService->method('getResultStorage')->willReturn($resultStorage);
@@ -507,6 +531,7 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $service->setServiceLocator($serviceManager);
 
         $this->assertFalse($this->invokeContinueInteraction($service, $context));
+        $this->assertSame(['persistOutcomes', 'readOutcomes'], $operationOrder);
         $this->assertNotNull($agsPayload);
         $this->assertSame($scoreTotal, $agsPayload['data']['scoreGiven']);
         $this->assertSame($scoreTotalMax, $agsPayload['data']['scoreMaximum']);
@@ -537,6 +562,7 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $property = new \ReflectionProperty(tao_models_classes_Service::class, 'instances');
         $property->setAccessible(true);
         $this->serviceSingletonBackup = $property->getValue();
+        $this->serviceSingletonBackupTaken = true;
         $instances = $this->serviceSingletonBackup ?? [];
         $instances[TaoDeliveryServiceProxy::class] = $proxy;
         $property->setValue(null, $instances);

--- a/test/unit/models/classes/runner/navigation/QtiRunnerNavigationNextSectionTest.php
+++ b/test/unit/models/classes/runner/navigation/QtiRunnerNavigationNextSectionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTest\test\unit\models\classes\runner\navigation;
+
+use oat\generis\test\TestCase;
+use oat\taoQtiTest\models\runner\navigation\QtiRunnerNavigationNextSection;
+use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
+use oat\taoQtiTest\models\runner\session\TestSession;
+
+class QtiRunnerNavigationNextSectionTest extends TestCase
+{
+    public function testMoveAdvancesToNextSection(): void
+    {
+        $testSession = $this->createMock(TestSession::class);
+        $testSession
+            ->expects($this->once())
+            ->method('moveNextAssessmentSection');
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context
+            ->method('getTestSession')
+            ->willReturn($testSession);
+
+        $navigator = new QtiRunnerNavigationNextSection();
+
+        $this->assertTrue($navigator->move($context, null));
+    }
+}

--- a/test/unit/models/classes/runner/navigation/QtiRunnerNavigationTest.php
+++ b/test/unit/models/classes/runner/navigation/QtiRunnerNavigationTest.php
@@ -24,12 +24,16 @@ use oat\generis\test\TestCase;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy as TaoDeliveryServiceProxy;
+use oat\taoQtiTest\models\runner\config\RunnerConfig;
 use oat\taoQtiTest\models\runner\navigation\QtiRunnerNavigation;
 use oat\taoQtiTest\models\runner\QtiRunnerPausedException;
 use oat\taoQtiTest\models\runner\QtiRunnerServiceContext;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use qtism\runtime\tests\AssessmentTestSessionState;
+use qtism\common\collections\StringCollection;
+use qtism\data\AssessmentItemRef;
 use common_Logger;
+use common_exception_Unauthorized;
 use core_kernel_classes_Resource;
 
 class QtiRunnerNavigationTest extends TestCase
@@ -111,5 +115,51 @@ class QtiRunnerNavigationTest extends TestCase
         $this->expectException(QtiRunnerPausedException::class);
 
         QtiRunnerNavigation::move('next', 'item', $context, 'ref');
+    }
+
+    public function testMoveNextSectionRejectedWhenNotAllowed(): void
+    {
+        $testSession = $this->createMock(TestSession::class);
+        $testSession
+            ->expects($this->never())
+            ->method('moveNextAssessmentSection');
+        $testSession
+            ->method('getState')
+            ->willReturn(AssessmentTestSessionState::INTERACTING);
+
+        $context = $this->createNextSectionContext(false, ['x-tao-option-nextSection']);
+        $context
+            ->method('getTestSession')
+            ->willReturn($testSession);
+
+        QtiRunnerNavigation::setLogger($this->createMock(common_Logger::class));
+
+        $this->expectException(common_exception_Unauthorized::class);
+
+        QtiRunnerNavigation::move('next', 'section', $context, null);
+    }
+
+    private function createNextSectionContext(bool $nextSectionEnabled, array $categories): QtiRunnerServiceContext
+    {
+        $testConfig = $this->createMock(RunnerConfig::class);
+        $testConfig
+            ->method('getConfigValue')
+            ->with('nextSection')
+            ->willReturn($nextSectionEnabled);
+
+        $itemRef = $this->createMock(AssessmentItemRef::class);
+        $itemRef
+            ->method('getCategories')
+            ->willReturn(new StringCollection($categories));
+
+        $context = $this->createMock(QtiRunnerServiceContext::class);
+        $context
+            ->method('getTestConfig')
+            ->willReturn($testConfig);
+        $context
+            ->method('getCurrentAssessmentItemRef')
+            ->willReturn($itemRef);
+
+        return $context;
     }
 }


### PR DESCRIPTION
**Backport:**
- [fix] [INF-461](https://oat-sa.atlassian.net/browse/INF-461) Server-side next-section validation [#2802](https://github.com/oat-sa/extension-tao-testqti/pull/2802)
- [fix] [INF-458](https://oat-sa.atlassian.net/browse/INF-458) Timeout flows via onTimeout for outcome/AGS scores [#2775](https://github.com/oat-sa/extension-tao-testqti/pull/2775)

Target release branch: `release-49.0.13`
Target release tag: `v49.0.13`

[INF-461]: https://oat-sa.atlassian.net/browse/INF-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INF-458]: https://oat-sa.atlassian.net/browse/INF-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ