### PR TITLE
fix: INF-458 use microtime format in AGS continueInteraction test

### DIFF
--- a/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
+++ b/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
@@ -458,7 +458,7 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $deliveryExecution = $this->createMock(DeliveryExecution::class);
         $deliveryExecution->method('getUserIdentifier')->willReturn($userUri);
         $deliveryExecution->method('getIdentifier')->willReturn($executionId);
-        $deliveryExecution->method('getFinishTime')->willReturn(1234567890.1234);
+        $deliveryExecution->method('getFinishTime')->willReturn('0.12340000 1234567890');
         $deliveryExecution->expects($this->once())->method('setState')->willReturn(true);
 
         $this->injectDeliveryExecutionServiceProxy($deliveryExecution);
@@ -551,7 +551,7 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         return (new OutcomeVariableModel())
             ->setIdentifier($identifier)
             ->setValue((string)$value)
-            ->setEpoch('1234567890.1234');
+            ->setEpoch('0.12340000 1234567890');
     }
 
     private function injectDeliveryExecutionServiceProxy(DeliveryExecution $deliveryExecution): void


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-458
## Summary
- Fix unit test fixtures to use PHP `microtime()` format (`"usec seconds"`) expected by `DateHelper::formatMicrotime`
- Prevents `Undefined array key 1` when `LtiAgsListener` runs (e.g. tao-community CI with `ltiDeliveryProvider`)

## Context
`testContinueInteractionTimeoutFinishEmitsAgsPayloadWithOutcomeScores` used timestamp-like values (`1234567890.1234`). Package CI often skips the AGS assertion when the listener is absent; community CI has LTI and hits the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timeout completion handling to use the expected finish-time format.
  * Ensured outcome scores are emitted consistently when an interaction finishes due to a timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->