### PR TITLE
fix: INF-458 use microtime format in AGS continueInteraction test (v49.0.14)

### DIFF
--- a/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
+++ b/test/unit/models/classes/runner/QtiRunnerServiceContinueInteractionTest.php
@@ -458,7 +458,7 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         $deliveryExecution = $this->createMock(DeliveryExecution::class);
         $deliveryExecution->method('getUserIdentifier')->willReturn($userUri);
         $deliveryExecution->method('getIdentifier')->willReturn($executionId);
-        $deliveryExecution->method('getFinishTime')->willReturn(1234567890.1234);
+        $deliveryExecution->method('getFinishTime')->willReturn('0.12340000 1234567890');
         $deliveryExecution->expects($this->once())->method('setState')->willReturn(true);
 
         $this->injectDeliveryExecutionServiceProxy($deliveryExecution);
@@ -551,7 +551,7 @@ class QtiRunnerServiceContinueInteractionTest extends TestCase
         return (new OutcomeVariableModel())
             ->setIdentifier($identifier)
             ->setValue((string)$value)
-            ->setEpoch('1234567890.1234');
+            ->setEpoch('0.12340000 1234567890');
     }
 
     private function injectDeliveryExecutionServiceProxy(DeliveryExecution $deliveryExecution): void


### PR DESCRIPTION
## Summary
- Backport of develop fix for AGS continueInteraction test microtime fixtures
- Targets `release-49.0.14` from `v49.0.13` for tao-community Feb (`release-2026.02.28` / #770)

## Test plan
- [ ] Unit test passes
- [ ] After merge: tag `v49.0.14` and bump on tao-community #770