### PR TITLE
[INF-566] Fix: bump @oat-sa/tao-test-runner-qti to 4.5.1

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@oat-sa/tao-test-runner": "^1.0.0",
-                "@oat-sa/tao-test-runner-qti": "^4.5.0"
+                "@oat-sa/tao-test-runner-qti": "^4.5.1"
             }
         },
         "node_modules/@oat-sa/tao-test-runner": {
@@ -22,10 +22,9 @@
             }
         },
         "node_modules/@oat-sa/tao-test-runner-qti": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-4.5.0.tgz",
-            "integrity": "sha512-hAfGL+s2uWoIvJRzDjnpCNtSiRR41VdsEUFRTjXWZDnwLbySD4ha6nLqqTddpmPUFtZyjH15tWQu6LmLVxa+CQ==",
-            "license": "GPL-2.0",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner-qti/-/tao-test-runner-qti-4.5.1.tgz",
+            "integrity": "sha512-NGEgXuWzRcRFD8K/utIW8NjXOpN8h3m/OqiFjHQ1+kaSvxREwm+W/3+8bkw0m6CFjLu+j06Y4ynQddDc23OO+A==",
             "engines": {
                 "node": ">=14.0.0"
             }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     "license": "GPL-2.0",
     "dependencies": {
         "@oat-sa/tao-test-runner": "^1.0.0",
-        "@oat-sa/tao-test-runner-qti": "^4.5.0"
+        "@oat-sa/tao-test-runner-qti": "^4.5.1"
     }
 }


### PR DESCRIPTION
## Summary
- Bump `@oat-sa/tao-test-runner-qti` from `4.5.0` to `4.5.1` to pick up the dialog header ruby fix for [INF-566](https://oat-sa.atlassian.net/browse/INF-566).
- Version update only; no extension code changes.

## Test plan
- [ ] Install/update extension dependencies so `@oat-sa/tao-test-runner-qti@4.5.1` is resolved
- [ ] Reproduce Next Section / exit dialog with ruby in header translation
- [ ] Confirm ruby renders in the bold header (not as literal tags)

[INF-566]: https://oat-sa.atlassian.net/browse/INF-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test runner component to version 4.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->